### PR TITLE
Add `anonymous.ts` to help registering anonymous functions

### DIFF
--- a/denops_std/anonymous/mod.ts
+++ b/denops_std/anonymous/mod.ts
@@ -1,0 +1,84 @@
+import { Denops } from "../vendor/https/deno.land/x/denops_core/mod.ts";
+
+// https://github.com/microsoft/TypeScript/issues/26223#issuecomment-674500430
+export type TupleOf<T, N extends number> = N extends N
+  ? number extends N ? T[] : _TupleOf<T, N, []>
+  : never;
+export type _TupleOf<T, N extends number, R extends unknown[]> =
+  R["length"] extends N ? R
+    : _TupleOf<T, N, [T, ...R]>;
+
+/**
+ * Anonymous function identifier
+ */
+export type Identifier = string;
+
+/**
+ * Anonymous function callback
+ */
+export type Callback = (...args: unknown[]) => Promise<unknown>;
+
+/**
+ * Add anonymous functions as a denops API and return the identifiers
+ */
+export function add<N extends number>(
+  denops: Denops,
+  ...callbacks: Callback[] & { length: N }
+): TupleOf<Identifier, N> {
+  return callbacks.map((callback) => {
+    const id = makeid();
+    denops.dispatcher[id] = callback;
+    return id;
+    // deno-lint-ignore no-explicit-any
+  }) as any;
+}
+
+/**
+ * Add oneshot anonymous functions as a denops API and return the identifiers
+ */
+export function once<N extends number>(
+  denops: Denops,
+  ...callbacks: Callback[] & { length: N }
+): TupleOf<Identifier, N> {
+  return callbacks.map((callback) => {
+    const id = makeid();
+    denops.dispatcher[id] = async (...args: unknown[]): Promise<unknown> => {
+      try {
+        return await callback(...args);
+      } finally {
+        remove(denops, id);
+      }
+    };
+    return id;
+    // deno-lint-ignore no-explicit-any
+  }) as any;
+}
+
+/**
+ * Remove anonymous functions identified by names from a denops API
+ */
+export function remove<N extends number>(
+  denops: Denops,
+  ...ids: Identifier[] & { length: N }
+): TupleOf<boolean, N> {
+  return ids.map((id) => {
+    if (id in denops.dispatcher) {
+      delete denops.dispatcher[id];
+      return true;
+    }
+    return false;
+    // deno-lint-ignore no-explicit-any
+  }) as any;
+}
+
+// https://stackoverflow.com/a/1349426
+function makeid(): string {
+  const s = 32;
+  const cs = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const cn = cs.length;
+  let r = "";
+  for (let i = 0; i < s; i++) {
+    r += cs.charAt(Math.floor(Math.random() * cn));
+  }
+  return `anonymous:${r}`;
+}

--- a/denops_std/anonymous/mod.ts
+++ b/denops_std/anonymous/mod.ts
@@ -16,7 +16,7 @@ export type Identifier = string;
 /**
  * Anonymous function callback
  */
-export type Callback = (...args: unknown[]) => Promise<unknown>;
+export type Callback = (...args: unknown[]) => Promise<unknown> | unknown;
 
 /**
  * Add anonymous functions as a denops API and return the identifiers
@@ -27,7 +27,9 @@ export function add<N extends number>(
 ): TupleOf<Identifier, N> {
   return callbacks.map((callback) => {
     const id = makeid();
-    denops.dispatcher[id] = callback;
+    denops.dispatcher[id] = async (...args: unknown[]) => {
+      return await callback(...args);
+    };
     return id;
     // deno-lint-ignore no-explicit-any
   }) as any;

--- a/denops_std/anonymous/mod_test.ts
+++ b/denops_std/anonymous/mod_test.ts
@@ -1,0 +1,101 @@
+import {
+  assertEquals,
+  assertThrowsAsync,
+} from "../vendor/https/deno.land/std/testing/asserts.ts";
+import { test } from "../vendor/https/deno.land/x/denops_core/test/mod.ts";
+import * as anonymous from "./mod.ts";
+
+test({
+  mode: "all",
+  name: "add() registers anonymous functions",
+  fn: async (denops) => {
+    const ids = anonymous.add(
+      denops,
+      () => Promise.resolve("0"),
+      () => Promise.resolve("1"),
+      () => Promise.resolve("2"),
+    );
+    assertEquals(await denops.dispatch(denops.name, ids[0]), "0");
+    assertEquals(await denops.dispatch(denops.name, ids[1]), "1");
+    assertEquals(await denops.dispatch(denops.name, ids[2]), "2");
+    assertEquals(await denops.dispatch(denops.name, ids[0]), "0");
+    assertEquals(await denops.dispatch(denops.name, ids[1]), "1");
+    assertEquals(await denops.dispatch(denops.name, ids[2]), "2");
+  },
+});
+
+test({
+  mode: "all",
+  name: "once() registers oneshot anonymous functions",
+  fn: async (denops) => {
+    const ids = anonymous.once(
+      denops,
+      () => Promise.resolve("0"),
+      () => Promise.resolve("1"),
+      () => Promise.resolve("2"),
+    );
+    assertEquals(await denops.dispatch(denops.name, ids[0]), "0");
+    assertEquals(await denops.dispatch(denops.name, ids[1]), "1");
+    assertEquals(await denops.dispatch(denops.name, ids[2]), "2");
+
+    // The method will be removed
+    await assertThrowsAsync(
+      async () => {
+        await denops.dispatch(denops.name, ids[0]);
+      },
+      undefined,
+      `No method '${ids[0]}' exists`,
+    );
+    await assertThrowsAsync(
+      async () => {
+        await denops.dispatch(denops.name, ids[1]);
+      },
+      undefined,
+      `No method '${ids[1]}' exists`,
+    );
+    await assertThrowsAsync(
+      async () => {
+        await denops.dispatch(denops.name, ids[2]);
+      },
+      undefined,
+      `No method '${ids[2]}' exists`,
+    );
+  },
+});
+
+test({
+  mode: "all",
+  name: "remove() unregisters anonymous functions identified by ids",
+  fn: async (denops) => {
+    const ids = anonymous.add(
+      denops,
+      () => Promise.resolve("0"),
+      () => Promise.resolve("1"),
+      () => Promise.resolve("2"),
+    );
+    assertEquals(anonymous.remove(denops, ...ids), [true, true, true]);
+
+    // The method is removed
+    await assertThrowsAsync(
+      async () => {
+        await denops.dispatch(denops.name, ids[0]);
+      },
+      undefined,
+      `No method '${ids[0]}' exists`,
+    );
+    await assertThrowsAsync(
+      async () => {
+        await denops.dispatch(denops.name, ids[1]);
+      },
+      undefined,
+      `No method '${ids[1]}' exists`,
+    );
+    await assertThrowsAsync(
+      async () => {
+        await denops.dispatch(denops.name, ids[2]);
+      },
+      undefined,
+      `No method '${ids[2]}' exists`,
+    );
+  },
+});


### PR DESCRIPTION
Close https://github.com/vim-denops/denops.vim/issues/48 by `anonymous` module like:


```typescript
test({
  mode: "all",
  name: "add() registers anonymous functions",
  fn: async (denops) => {
    const ids = anonymous.add(
      denops,
      () => Promise.resolve("0"),
      () => Promise.resolve("1"),
      () => Promise.resolve("2"),
    );
    assertEquals(await denops.dispatch(denops.name, ids[0]), "0");
    assertEquals(await denops.dispatch(denops.name, ids[1]), "1");
    assertEquals(await denops.dispatch(denops.name, ids[2]), "2");
    assertEquals(await denops.dispatch(denops.name, ids[0]), "0");
    assertEquals(await denops.dispatch(denops.name, ids[1]), "1");
    assertEquals(await denops.dispatch(denops.name, ids[2]), "2");
  },
});

test({
  mode: "all",
  name: "once() registers oneshot anonymous functions",
  fn: async (denops) => {
    const ids = anonymous.once(
      denops,
      () => Promise.resolve("0"),
      () => Promise.resolve("1"),
      () => Promise.resolve("2"),
    );
    assertEquals(await denops.dispatch(denops.name, ids[0]), "0");
    assertEquals(await denops.dispatch(denops.name, ids[1]), "1");
    assertEquals(await denops.dispatch(denops.name, ids[2]), "2");

    // The method will be removed
    await assertThrowsAsync(
      async () => {
        await denops.dispatch(denops.name, ids[0]);
      },
      undefined,
      `No method '${ids[0]}' exists`,
    );
    await assertThrowsAsync(
      async () => {
        await denops.dispatch(denops.name, ids[1]);
      },
      undefined,
      `No method '${ids[1]}' exists`,
    );
    await assertThrowsAsync(
      async () => {
        await denops.dispatch(denops.name, ids[2]);
      },
      undefined,
      `No method '${ids[2]}' exists`,
    );
  },
});

test({
  mode: "all",
  name: "remove() unregisters anonymous functions identified by ids",
  fn: async (denops) => {
    const ids = anonymous.add(
      denops,
      () => Promise.resolve("0"),
      () => Promise.resolve("1"),
      () => Promise.resolve("2"),
    );
    assertEquals(anonymous.remove(denops, ...ids), [true, true, true]);

    // The method is removed
    await assertThrowsAsync(
      async () => {
        await denops.dispatch(denops.name, ids[0]);
      },
      undefined,
      `No method '${ids[0]}' exists`,
    );
    await assertThrowsAsync(
      async () => {
        await denops.dispatch(denops.name, ids[1]);
      },
      undefined,
      `No method '${ids[1]}' exists`,
    );
    await assertThrowsAsync(
      async () => {
        await denops.dispatch(denops.name, ids[2]);
      },
      undefined,
      `No method '${ids[2]}' exists`,
    );
  },
});
```