### PR TITLE
Add `batch` module to perform batch process

### DIFF
--- a/denops_std/helper/batch.ts
+++ b/denops_std/helper/batch.ts
@@ -1,0 +1,78 @@
+import {
+  Context,
+  Denops,
+  Dispatcher,
+  Meta,
+} from "../vendor/https/deno.land/x/denops_core/mod.ts";
+
+class BatchHelper implements Denops {
+  #denops: Denops;
+  #calls: [string, ...unknown[]][];
+
+  constructor(denops: Denops) {
+    this.#denops = denops;
+    this.#calls = [];
+  }
+
+  static getCalls(helper: BatchHelper): [string, ...unknown[]][] {
+    return helper.#calls;
+  }
+
+  get name(): string {
+    return this.#denops.name;
+  }
+
+  get meta(): Meta {
+    return this.#denops.meta;
+  }
+
+  get dispatcher(): Dispatcher {
+    return this.#denops.dispatcher;
+  }
+
+  set dispatcher(dispatcher: Dispatcher) {
+    this.#denops.dispatcher = dispatcher;
+  }
+
+  call(fn: string, ...args: unknown[]): Promise<unknown> {
+    this.#calls.push([fn, ...args]);
+    return Promise.resolve();
+  }
+
+  batch(..._calls: [string, ...unknown[]][]): Promise<unknown[]> {
+    throw new Error(
+      "The 'batch' method is not available on BatchDenops instance.",
+    );
+  }
+
+  cmd(cmd: string, ctx: Context = {}): Promise<void> {
+    this.call("denops#api#cmd", cmd, ctx);
+    return Promise.resolve();
+  }
+
+  eval(expr: string, ctx: Context = {}): Promise<unknown> {
+    this.call("denops#api#eval", expr, ctx);
+    return Promise.resolve();
+  }
+
+  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown> {
+    return this.#denops.dispatch(name, fn, ...args);
+  }
+}
+
+/**
+ * Call denops functions sequentially without redraw and return the results.
+ *
+ * It is a wrapper function of `denops.batch()` to allow users to use `function`
+ * modules, `denops.cmd()`, `denops.eval()`, or whatever things which assume a
+ * `denops` instance.
+ */
+export async function batch(
+  denops: Denops,
+  main: (helper: BatchHelper) => Promise<void> | void,
+): Promise<unknown[]> {
+  const helper = new BatchHelper(denops);
+  await main(helper);
+  const calls = BatchHelper.getCalls(helper);
+  return await denops.batch(...calls);
+}

--- a/denops_std/helper/batch_test.ts
+++ b/denops_std/helper/batch_test.ts
@@ -1,0 +1,113 @@
+import { test } from "../vendor/https/deno.land/x/denops_core/test/mod.ts";
+import { assertEquals } from "../vendor/https/deno.land/std/testing/asserts.ts";
+import * as fn from "../function/mod.ts";
+import { batch } from "./batch.ts";
+
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'helper.call()' as batch process.",
+  fn: async (denops) => {
+    const results = await batch(denops, (helper) => {
+      helper.call("range", 0);
+      helper.call("range", 1);
+      helper.call("range", 2);
+    });
+    assertEquals(results, [[], [0], [0, 1]]);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'helper.cmd()' as batch process.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = 0");
+    await denops.cmd("command! DenopsBatchTest let g:denops_batch_test += 1");
+    const results = await batch(denops, (helper) => {
+      helper.cmd("DenopsBatchTest");
+      helper.cmd("DenopsBatchTest");
+      helper.cmd("DenopsBatchTest");
+    });
+    assertEquals(results, [0, 0, 0]);
+    assertEquals(await denops.eval("g:denops_batch_test") as number, 3);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'helper.eval()' as batch process.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = 10");
+    const results = await batch(denops, (helper) => {
+      helper.eval("g:denops_batch_test + 1");
+      helper.eval("g:denops_batch_test - 1");
+      helper.eval("g:denops_batch_test * 10");
+    });
+    assertEquals(results, [11, 9, 100]);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'fn.XXX(helper, ...)' as batch process.",
+  fn: async (denops) => {
+    const results = await batch(denops, (helper) => {
+      fn.range(helper, 0);
+      fn.range(helper, 1);
+      fn.range(helper, 2);
+    });
+    assertEquals(results, [[], [0], [0, 1]]);
+  },
+});
+
+test({
+  mode: "any",
+  name:
+    "batch() sequentially execute 'helper.call()' as batch process (async).",
+  fn: async (denops) => {
+    const results = await batch(denops, async (helper) => {
+      assertEquals(await helper.call("range", 0), undefined);
+      assertEquals(await helper.call("range", 1), undefined);
+      assertEquals(await helper.call("range", 2), undefined);
+    });
+    assertEquals(results, [[], [0], [0, 1]]);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'helper.cmd()' as batch process (async).",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = 0");
+    await denops.cmd("command! DenopsBatchTest let g:denops_batch_test += 1");
+    const results = await batch(denops, async (helper) => {
+      assertEquals(await helper.cmd("DenopsBatchTest"), undefined);
+      assertEquals(await helper.cmd("DenopsBatchTest"), undefined);
+      assertEquals(await helper.cmd("DenopsBatchTest"), undefined);
+    });
+    assertEquals(results, [0, 0, 0]);
+    assertEquals(await denops.eval("g:denops_batch_test") as number, 3);
+  },
+});
+test({
+  mode: "any",
+  name:
+    "batch() sequentially execute 'helper.eval()' as batch process (async).",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = 10");
+    const results = await batch(denops, async (helper) => {
+      assertEquals(await helper.eval("g:denops_batch_test + 1"), undefined);
+      assertEquals(await helper.eval("g:denops_batch_test - 1"), undefined);
+      assertEquals(await helper.eval("g:denops_batch_test * 10"), undefined);
+    });
+    assertEquals(results, [11, 9, 100]);
+  },
+});
+test({
+  mode: "any",
+  name:
+    "batch() sequentially execute 'fn.XXX(helper, ...)' as batch process (async).",
+  fn: async (denops) => {
+    const results = await batch(denops, async (helper) => {
+      assertEquals(await fn.range(helper, 0), undefined);
+      assertEquals(await fn.range(helper, 1), undefined);
+      assertEquals(await fn.range(helper, 2), undefined);
+    });
+    assertEquals(results, [[], [0], [0, 1]]);
+  },
+});

--- a/denops_std/helper/mod.ts
+++ b/denops_std/helper/mod.ts
@@ -1,2 +1,3 @@
+export * from "./batch.ts";
 export * from "./execute.ts";
 export * from "./load.ts";

--- a/denops_std/modules-lock.json
+++ b/denops_std/modules-lock.json
@@ -9,7 +9,7 @@
     ]
   },
   "https://deno.land/x/denops_core": {
-    "version": "@v1.0.0-alpha.11",
+    "version": "@v1.0.0-alpha.12",
     "modules": [
       "/mod.ts",
       "/test/mod.ts"

--- a/denops_std/modules.json
+++ b/denops_std/modules.json
@@ -9,7 +9,7 @@
     ]
   },
   "https://deno.land/x/denops_core": {
-    "version": "@v1.0.0-alpha.11",
+    "version": "@v1.0.0-alpha.12",
     "modules": ["/mod.ts", "/test/mod.ts"]
   },
   "https://deno.land/x/unknownutil": {

--- a/denops_std/vendor/https/deno.land/x/denops_core/mod.ts
+++ b/denops_std/vendor/https/deno.land/x/denops_core/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/denops_core@v1.0.0-alpha.11/mod.ts";
+export * from "https://deno.land/x/denops_core@v1.0.0-alpha.12/mod.ts";

--- a/denops_std/vendor/https/deno.land/x/denops_core/test/mod.ts
+++ b/denops_std/vendor/https/deno.land/x/denops_core/test/mod.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/x/denops_core@v1.0.0-alpha.11/test/mod.ts";
+export * from "https://deno.land/x/denops_core@v1.0.0-alpha.12/test/mod.ts";


### PR DESCRIPTION
With this PR, users can use `denops.cmd()`, `denops.eval()`, `function` module, or whatever which require `denops` instance to perform batch process like:

```typescript
const results = await batch(denops, (helper) => {
  helper.cmd("DoSomething");
  helper.eval("1 + 1");
  fn.range(helper, 2);
});
assertEquals(results, [0, 2, [0, 1]);
```

It's a wrapper function of `denops.batch()`.