### PR TITLE
👍  Add `echo` function to `helper` module

### DIFF
--- a/denops_std/deps.ts
+++ b/denops_std/deps.ts
@@ -1,5 +1,6 @@
 export * as fs from "https://deno.land/std@0.100.0/fs/mod.ts#^";
 export * as hash from "https://deno.land/std@0.100.0/hash/mod.ts#^";
 export * as path from "https://deno.land/std@0.100.0/path/mod.ts#^";
+export { deferred } from "https://deno.land/std@0.100.0/async/mod.ts#^";
 
 export * from "https://deno.land/x/denops_core@v1.0.0-beta.3/mod.ts#^";

--- a/denops_std/helper/README.md
+++ b/denops_std/helper/README.md
@@ -6,6 +6,25 @@
 
 ## Usage
 
+### echo
+
+Use `echo()` to show messages on the cmdline area. It is required while Vim
+won't show messages reported from channel commands and it won't pause multi-line
+messages reported from asynchronous context (e.g. timer or job). It's same for
+`denops.cmd('echo "Hello\nWorld!"')` in Neovim.
+
+Note that there is no similar function for `echomsg` while there is no way to
+properly show multi-line messages with `echomsg` from asynchronous context.
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { echo } from "https://deno.land/x/denops_std/helper/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await echo(denops, "Hello\nWorld!");
+}
+```
+
 ### batch
 
 Use `batch()` to call multiple denops functions sequentially without overhead

--- a/denops_std/helper/echo.ts
+++ b/denops_std/helper/echo.ts
@@ -1,0 +1,79 @@
+import { deferred, Denops } from "../deps.ts";
+import * as anonymous from "../anonymous/mod.ts";
+import { execute } from "./execute.ts";
+
+let defined = false;
+
+/**
+ * Echo message as like `echo` on Vim script.
+ *
+ * Vim (not Neovim) won't show message posted from a channel command
+ * and Vim won't pause multiline message posted from timer.
+ * This function applied some workaround to show message posted from
+ * a channel command, and pause if the message is multiline.
+ *
+ * Note that it does nothing and return immediately when denops is
+ * running as 'test' mode to avoid unwilling test failures.
+ */
+export function echo(denops: Denops, message: string): Promise<void> {
+  if (denops.meta.mode === "test") {
+    return Promise.resolve();
+  } else if (denops.meta.host === "vim") {
+    return echoVim(denops, message);
+  } else {
+    return denops.cmd("redraw | echo message", { message });
+  }
+}
+
+async function echoVim(denops: Denops, message: string): Promise<void> {
+  const waiter = deferred<void>();
+  const id = anonymous.once(denops, () => waiter.resolve())[0];
+  await define(denops);
+  await denops.cmd(
+    `call timer_start(0, { -> s:denops_std_helper_echo(l:message, l:name, l:id) })`,
+    {
+      message,
+      name: denops.name,
+      id,
+    },
+  );
+  await waiter;
+}
+
+async function define(denops: Denops): Promise<void> {
+  if (defined) {
+    return;
+  }
+  await execute(
+    denops,
+    `
+    if exists('s:loaded_denops_std_helper_echo')
+      return
+    endif
+    let s:loaded_denops_std_helper_echo = 1
+    function! s:denops_std_helper_echo(message, name, id) abort
+      let info = {}
+      let info.t = timer_start(0, { -> feedkeys('jk', 'n') })
+      let info.name = a:name
+      let info.id = a:id
+      let info.message = a:message
+      let info.updatetime = &updatetime
+      let &updatetime = 1
+      let s:denops_std_helper_echo_info = info
+      augroup denops_std_helper_echo
+        autocmd!
+        autocmd CursorHold * ++once call s:denops_std_helper_echo_post()
+      augroup END
+    endfunction
+    function! s:denops_std_helper_echo_post() abort
+      let info = s:denops_std_helper_echo_info
+      silent! unlet! s:denops_std_helper_echo_info
+      let &updatetime = info.updatetime
+      call timer_stop(info.t)
+      redraw | echo info.message
+      call denops#request(info.name, info.id, [])
+    endfunction
+    `,
+  );
+  defined = true;
+}

--- a/denops_std/helper/echo_test.ts
+++ b/denops_std/helper/echo_test.ts
@@ -1,0 +1,21 @@
+import { test } from "../deps_test.ts";
+import { echo } from "./echo.ts";
+
+test({
+  mode: "all",
+  name: "echo() shows short message",
+  fn: async (denops) => {
+    await echo(denops, "Hello");
+    // No way to test if `echo` success
+  },
+});
+
+test({
+  mode: "all",
+  name: "echo() shows multiline message",
+  fn: async (denops) => {
+    await denops.cmd("set cmdheight=5");
+    await echo(denops, "A\nB\nC\nD\nE");
+    // No way to test if `echo` success
+  },
+});


### PR DESCRIPTION
### echo

Use `echo()` to show messages on the cmdline area. It is required while Vim won't show messages reported from channel commands and it won't pause multi-line messages reported from asynchronous context (e.g. timer or job). It's same for `denops.cmd('echo "Hello\nWorld!"')` in Neovim.

Note that there is no similar function for `echomsg` while there is no way to properly show multi-line messages with `echomsg` from asynchronous context.

```typescript
import { Denops } from "https://deno.land/x/denops_std/mod.ts";
import { echo } from "https://deno.land/x/denops_std/helper/mod.ts";
export async function main(denops: Denops): Promise<void> {
  await echo(denops, "Hello\nWorld!");
}
```