### PR TITLE
👍  Add `mapping` module to manage mappings

### DIFF
--- a/denops_std/mapping/README.md
+++ b/denops_std/mapping/README.md
@@ -1,0 +1,87 @@
+# mapping
+
+`mapping` is a module to provide helper functions to manage mappings.
+
+- [API documentation](https://doc.deno.land/https/deno.land/x/denops_std/mapping/mod.ts)
+
+## Usage
+
+### map
+
+Use `map()` to register a mapping like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std/mapping/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await mapping.map(denops, "<Plug>(test-denops-std)", "Hello");
+  await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+    mode: "i",
+  });
+}
+```
+
+### unmap
+
+Use `unmap()` to unregister a mapping like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std/mapping/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await mapping.map(denops, "<Plug>(test-denops-std)", "Hello");
+  await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+    mode: "i",
+  });
+
+  await mapping.unmap(denops, "<Plug>(test-denops-std)");
+  await mapping.unmap(denops, "<Plug>(test-denops-std)", {
+    mode: "i",
+  });
+}
+```
+
+### read
+
+Use `read()` to read a mapping like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std/mapping/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await denops.cmd(`map <Plug>(test-denops-std) Hello`);
+
+  console.log(await mapping.read(denops, "<Plug>(test-denops-std)"));
+  // {
+  //   mode: "",
+  //   lhs: "<Plug>(test-denops-std)",
+  //   rhs: "Hello",
+  //   // ...
+  // }
+}
+```
+
+### list
+
+Use `list()` to list mappings like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import * as mapping from "https://deno.land/x/denops_std/mapping/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  const result = await mapping.list(denops, "<Plug>");
+  console.log(result);
+  // [
+  //   {
+  //     mode: "",
+  //     lhs: "<Plug>(...)",
+  //     // ...
+  //   },
+  //   // ...
+  // ]
+}
+```

--- a/denops_std/mapping/mod.ts
+++ b/denops_std/mapping/mod.ts
@@ -58,6 +58,10 @@ export type ReadOptions = {
 
 /**
  * Read a mapping and return a `Mapping` instance.
+ *
+ * Note that prior to Vim 8.2.0491 or Neovim 0.5.0, `script` is
+ * not detectable by `maparg` function internally used in this
+ * function.
  */
 export async function read(
   denops: Denops,

--- a/denops_std/mapping/mod.ts
+++ b/denops_std/mapping/mod.ts
@@ -1,0 +1,107 @@
+import { Denops } from "../deps.ts";
+import * as fn from "../function/mod.ts";
+import { Mapping, Mode } from "./types.ts";
+import { parse } from "./parser.ts";
+
+export type MapOptions = {
+  mode?: Mode;
+  noremap?: boolean;
+  script?: boolean;
+  buffer?: boolean;
+  expr?: boolean;
+  nowait?: boolean;
+  silent?: boolean;
+  unique?: boolean;
+};
+
+/**
+ * Register a mapping for `lhs` to `rhs` with given options.
+ */
+export async function map(
+  denops: Denops,
+  lhs: string,
+  rhs: string,
+  options: MapOptions = {},
+): Promise<void> {
+  const mode = options.mode ?? "";
+  const prefix = options.noremap ? "nore" : "";
+  const arg = [
+    options.buffer ? "<buffer>" : "",
+    options.nowait ? "<nowait>" : "",
+    options.silent ? "<silent>" : "",
+    options.script ? "<script>" : "",
+    options.expr ? "<expr>" : "",
+    options.unique ? "<unique>" : "",
+  ].filter((v) => v).join("");
+  await denops.cmd(`${mode}${prefix}map ${arg} ${lhs} ${rhs}`);
+}
+
+export type UnmapOptions = {
+  mode?: Mode;
+};
+
+/**
+ * Remove a mapping for `lhs`.
+ */
+export async function unmap(
+  denops: Denops,
+  lhs: string,
+  options: UnmapOptions = {},
+): Promise<void> {
+  const mode = options.mode ?? "";
+  await denops.cmd(`${mode}unmap ${lhs}`);
+}
+
+export type ReadOptions = {
+  mode?: Mode;
+};
+
+/**
+ * Read a mapping and return a `Mapping` instance.
+ */
+export async function read(
+  denops: Denops,
+  lhs: string,
+  options: ReadOptions = {},
+): Promise<Mapping> {
+  const info = await fn.maparg(
+    denops,
+    lhs,
+    options.mode ?? "",
+    false,
+    true,
+  ) as Record<string, unknown>;
+  if (Object.keys(info).length === 0) {
+    throw new Error(`No mapping found for '${lhs}'`);
+  }
+  return {
+    mode: (info.mode as string).trim() as Mode,
+    lhs: info.lhs as string,
+    rhs: info.rhs as string,
+    noremap: !!info.noremap,
+    script: !!info.script,
+    buffer: !!info.buffer,
+    sid: info.sid as number,
+    lnum: info.lnum as number,
+    expr: !!info.expr,
+    nowait: !!info.nowait,
+    silent: !!info.silent,
+  };
+}
+
+export type ListOptions = {
+  mode?: Mode;
+};
+
+/**
+ * List mappings which starts from `lhs`.
+ */
+export async function list(
+  denops: Denops,
+  lhs: string,
+  options: ListOptions = {},
+): Promise<Mapping[]> {
+  const mode = options.mode ?? "";
+  const result = await fn.execute(denops, `${mode}map ${lhs}`) as string;
+  return result.split(/\r?\n/).filter((v) => v).map(parse);
+}

--- a/denops_std/mapping/mod_test.ts
+++ b/denops_std/mapping/mod_test.ts
@@ -1,3 +1,4 @@
+import { Denops } from "../deps.ts";
 import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
 import { Mapping, Mode } from "./types.ts";
 import * as mapping from "./mod.ts";
@@ -69,6 +70,10 @@ test({
   mode: "all",
   name: `map() registers mapping (script)`,
   fn: async (denops) => {
+    if (!await isScriptSupported(denops)) {
+      console.warn("Skip");
+      return;
+    }
     await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
       script: true,
     });
@@ -276,6 +281,10 @@ test({
   mode: "all",
   name: `read() returns mapping (script)`,
   fn: async (denops) => {
+    if (!await isScriptSupported(denops)) {
+      console.warn("Skip");
+      return;
+    }
     await denops.cmd(`map <script> <Plug>(test-denops-std) Hello`);
     assertEquals(
       {
@@ -397,4 +406,12 @@ for (const mode of modes) {
       ]);
     },
   });
+}
+
+async function isScriptSupported(denops: Denops): Promise<boolean> {
+  if (denops.meta.host === "vim") {
+    return !!await denops.call("has", "patch-8.2.0491");
+  } else {
+    return !!await denops.call("has", "nvim-0.5.0");
+  }
 }

--- a/denops_std/mapping/mod_test.ts
+++ b/denops_std/mapping/mod_test.ts
@@ -1,0 +1,400 @@
+import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { Mapping, Mode } from "./types.ts";
+import * as mapping from "./mod.ts";
+
+const skeleton: Mapping = {
+  mode: "",
+  lhs: "",
+  rhs: "",
+  noremap: false,
+  script: false,
+  buffer: false,
+  sid: 0,
+  lnum: 0,
+  expr: false,
+  nowait: false,
+  silent: false,
+};
+const modes: Mode[] = ["", "n", "i", "c", "v", "x", "s", "o", "t", "l"];
+
+for (const mode of modes) {
+  test({
+    mode: "all",
+    name: `map() registers mapping (${mode}map)`,
+    fn: async (denops) => {
+      await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+        mode,
+      });
+      assertEquals(
+        {
+          ...await mapping.read(denops, "<Plug>(test-denops-std)", { mode }),
+          sid: 0,
+          lnum: 0,
+        },
+        {
+          ...skeleton,
+          mode,
+          lhs: "<Plug>(test-denops-std)",
+          rhs: "Hello",
+        },
+      );
+    },
+  });
+  test({
+    mode: "all",
+    name: `map() registers mapping (${mode}noremap)`,
+    fn: async (denops) => {
+      await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+        mode,
+        noremap: true,
+      });
+      assertEquals(
+        {
+          ...await mapping.read(denops, "<Plug>(test-denops-std)", { mode }),
+          sid: 0,
+          lnum: 0,
+        },
+        {
+          ...skeleton,
+          mode,
+          lhs: "<Plug>(test-denops-std)",
+          rhs: "Hello",
+          noremap: true,
+        },
+      );
+    },
+  });
+}
+test({
+  mode: "all",
+  name: `map() registers mapping (script)`,
+  fn: async (denops) => {
+    await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+      script: true,
+    });
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        noremap: true,
+        script: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `map() registers mapping (buffer)`,
+  fn: async (denops) => {
+    await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+      buffer: true,
+    });
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        buffer: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `map() registers mapping (expr)`,
+  fn: async (denops) => {
+    await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+      expr: true,
+    });
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        expr: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `map() registers mapping (nowait)`,
+  fn: async (denops) => {
+    await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+      nowait: true,
+    });
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        nowait: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `map() registers mapping (silent)`,
+  fn: async (denops) => {
+    await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+      silent: true,
+    });
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        silent: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `map() registers mapping (unique)`,
+  fn: async (denops) => {
+    await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+      unique: true,
+    });
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+      },
+    );
+    await assertThrowsAsync(
+      async () => {
+        await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+          unique: true,
+        });
+      },
+      undefined,
+      "E227: mapping already exists",
+    );
+  },
+});
+
+for (const mode of modes) {
+  test({
+    mode: "all",
+    name: `unmap() removes mapping (${mode}unmap)`,
+    fn: async (denops) => {
+      await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+        mode,
+      });
+      await mapping.unmap(denops, "<Plug>(test-denops-std)", {
+        mode,
+      });
+      await assertThrowsAsync(
+        async () => {
+          await mapping.read(denops, "<Plug>(test-denops-std)", { mode });
+        },
+        undefined,
+        "No mapping found for",
+      );
+    },
+  });
+}
+
+for (const mode of modes) {
+  test({
+    mode: "all",
+    name: `read() returns mapping (${mode}map)`,
+    fn: async (denops) => {
+      await denops.cmd(`${mode}map <Plug>(test-denops-std) Hello`);
+      assertEquals(
+        {
+          ...await mapping.read(denops, "<Plug>(test-denops-std)", { mode }),
+          sid: 0,
+          lnum: 0,
+        },
+        {
+          ...skeleton,
+          mode,
+          lhs: "<Plug>(test-denops-std)",
+          rhs: "Hello",
+        },
+      );
+    },
+  });
+  test({
+    mode: "all",
+    name: `read() returns mapping (${mode}noremap)`,
+    fn: async (denops) => {
+      await denops.cmd(`${mode}noremap <Plug>(test-denops-std) Hello`);
+      assertEquals(
+        {
+          ...await mapping.read(denops, "<Plug>(test-denops-std)", { mode }),
+          sid: 0,
+          lnum: 0,
+        },
+        {
+          ...skeleton,
+          mode,
+          lhs: "<Plug>(test-denops-std)",
+          rhs: "Hello",
+          noremap: true,
+        },
+      );
+    },
+  });
+}
+test({
+  mode: "all",
+  name: `read() returns mapping (script)`,
+  fn: async (denops) => {
+    await denops.cmd(`map <script> <Plug>(test-denops-std) Hello`);
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        noremap: true,
+        script: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `read() returns mapping (buffer)`,
+  fn: async (denops) => {
+    await denops.cmd(`map <buffer> <Plug>(test-denops-std) Hello`);
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        buffer: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `read() returns mapping (expr)`,
+  fn: async (denops) => {
+    await denops.cmd(`map <expr> <Plug>(test-denops-std) Hello`);
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        expr: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `read() returns mapping (nowait)`,
+  fn: async (denops) => {
+    await denops.cmd(`map <nowait> <Plug>(test-denops-std) Hello`);
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        nowait: true,
+      },
+    );
+  },
+});
+test({
+  mode: "all",
+  name: `read() returns mapping (silent)`,
+  fn: async (denops) => {
+    await denops.cmd(`map <silent> <Plug>(test-denops-std) Hello`);
+    assertEquals(
+      {
+        ...await mapping.read(denops, "<Plug>(test-denops-std)"),
+        sid: 0,
+        lnum: 0,
+      },
+      {
+        ...skeleton,
+        lhs: "<Plug>(test-denops-std)",
+        rhs: "Hello",
+        silent: true,
+      },
+    );
+  },
+});
+
+for (const mode of modes) {
+  test({
+    mode: "all",
+    name: `list() lists mappings starts from {lhs} (${mode}map)`,
+    fn: async (denops) => {
+      await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
+        mode,
+      });
+      const result = await mapping.list(denops, "<Plug>(test-denops-std)", {
+        mode,
+      });
+      assertEquals(result, [
+        {
+          mode,
+          lhs: "<Plug>(test-denops-std)",
+          rhs: "Hello",
+          noremap: false,
+          script: false,
+          buffer: false,
+        },
+      ]);
+    },
+  });
+}

--- a/denops_std/mapping/parser.ts
+++ b/denops_std/mapping/parser.ts
@@ -1,0 +1,24 @@
+import { Mapping, Mode } from "./types.ts";
+
+/**
+ * Parse record displayed by Vim's `map` command and return a `Mapping` instance.
+ */
+export function parse(record: string): Mapping {
+  const m = record.match(/^(.)\s+(\S+)\s+(.*)$/);
+  if (!m) {
+    throw new Error(`Failed to parse a mapping record '${record}'`);
+  }
+  const mode = m[1].trim();
+  const lhs = m[2];
+  const mm = m[3].match(/([\*&@ ]+)(.*)/);
+  const rhs = mm ? mm[2] : m[3];
+  const special = mm ? mm[1].trim() : "";
+  return {
+    mode: mode as Mode,
+    lhs,
+    rhs,
+    noremap: special.indexOf("*") !== -1,
+    script: special.indexOf("&") !== -1,
+    buffer: special.indexOf("@") !== -1,
+  };
+}

--- a/denops_std/mapping/parser_test.ts
+++ b/denops_std/mapping/parser_test.ts
@@ -1,0 +1,89 @@
+import { assertEquals, assertThrows } from "../deps_test.ts";
+import { Mapping } from "./types.ts";
+import { parse } from "./parser.ts";
+
+const testcases: [string, Mapping][] = [
+  ["n  <Space>hp    @<Plug>(test-denops-std)", {
+    mode: "n",
+    lhs: "<Space>hp",
+    rhs: "<Plug>(test-denops-std)",
+    noremap: false,
+    script: false,
+    buffer: true,
+  }],
+  [
+    'v  <C-B>       * test#denops#has_scroll() ? test#denops#nvim_scroll(0, 1) : "\<C-B>"',
+    {
+      mode: "v",
+      lhs: "<C-B>",
+      rhs:
+        'test#denops#has_scroll() ? test#denops#nvim_scroll(0, 1) : "\<C-B>"',
+      noremap: true,
+      script: false,
+      buffer: false,
+    },
+  ],
+  ["o  <C-B>       * <Left>", {
+    mode: "o",
+    lhs: "<C-B>",
+    rhs: "<Left>",
+    noremap: true,
+    script: false,
+    buffer: false,
+  }],
+  ["x  <C-G>Q        <Plug>(test-denops-std)", {
+    mode: "x",
+    lhs: "<C-G>Q",
+    rhs: "<Plug>(test-denops-std)",
+    noremap: false,
+    script: false,
+    buffer: false,
+  }],
+  [
+    'n  <C-L>       * empty(get(b:, \'current_syntax\')) ? "\<C-L>" : "\<C-L>:syntax sync fromstart\<CR>"',
+    {
+      mode: "n",
+      lhs: "<C-L>",
+      rhs:
+        'empty(get(b:, \'current_syntax\')) ? "\<C-L>" : "\<C-L>:syntax sync fromstart\<CR>"',
+      noremap: true,
+      script: false,
+      buffer: false,
+    },
+  ],
+  ["   -             <Plug>(test-denops-std)", {
+    mode: "",
+    lhs: "-",
+    rhs: "<Plug>(test-denops-std)",
+    noremap: false,
+    script: false,
+    buffer: false,
+  }],
+  [
+    "v  <Plug>(test-denops-std) & :<C-U>call test#denops#call('test#denops#do')<CR>gv<SNR>102_(register)g@",
+    {
+      mode: "v",
+      lhs: "<Plug>(test-denops-std)",
+      rhs:
+        ":<C-U>call test#denops#call('test#denops#do')<CR>gv<SNR>102_(register)g@",
+      noremap: false,
+      script: true,
+      buffer: false,
+    },
+  ],
+];
+for (const [record, expected] of testcases) {
+  Deno.test(`parse() parses '${record}' and return a Mapping instance`, () => {
+    const actual = parse(record);
+    assertEquals(actual, expected);
+  });
+}
+Deno.test(`parse() throws an error for invalid record`, () => {
+  assertThrows(
+    () => {
+      parse("This-is-invalid-record");
+    },
+    undefined,
+    "Failed to parse a mapping record",
+  );
+});

--- a/denops_std/mapping/types.ts
+++ b/denops_std/mapping/types.ts
@@ -1,0 +1,42 @@
+export type Mode =
+  | "" // Normal, Visual, Select and Operator-pending
+  | "n" // Normal
+  | "i" // Insert
+  | "c" // Command-line
+  | "v" // Visual and Select
+  | "x" // Visual
+  | "s" // Select
+  | "o" // Operator-pending
+  | "t" // Terminal-Job
+  | "l"; // ":lmap" mappings for Insert, Command-line and Lang-Arg
+
+export type Mapping = {
+  // Modes for which the mapping is defined
+  mode: Mode;
+  // The {lhs} of the mapping
+  lhs: string;
+  // The {rhs} of the mapping as typed
+  rhs: string;
+  // True if the {rhs} of the mapping is not remappable
+  noremap: boolean;
+  // True if mapping was defined with <script>
+  script: boolean;
+  // True for a buffer local mapping
+  buffer: boolean;
+
+  // The script local ID, used for <sid> mappings
+  // This attribute is missing if the Mapping is returned from `list()`
+  sid?: number;
+  // The line number in "sid", zero if unknown
+  // This attribute is missing if the Mapping is returned from `list()`
+  lnum?: number;
+  // True for an expression mapping
+  // This attribute is missing if the Mapping is returned from `list()`
+  expr?: boolean;
+  // Do not wait for other, longer mappings
+  // This attribute is missing if the Mapping is returned from `list()`
+  nowait?: boolean;
+  // True for a :map-silent mapping, else False
+  // This attribute is missing if the Mapping is returned from `list()`
+  silent?: boolean;
+};


### PR DESCRIPTION
SSIA

```typescript
import { Denops } from "https://deno.land/x/denops_std/mod.ts";
import * as mapping from "https://deno.land/x/denops_std/mapping/mod.ts";
export async function main(denops: Denops): Promise<void> {
  await mapping.map(denops, "<Plug>(test-denops-std)", "Hello");
  await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
    mode: "i",
  });

  console.log(await mapping.read(denops, "<Plug>(test-denops-std)"));
  // {
  //   mode: "",
  //   lhs: "<Plug>(test-denops-std)",
  //   rhs: "Hello",
  //   // ...
  // }

  const result = await mapping.list(denops, "<Plug>");
  console.log(result);
  // [
  //   {
  //     mode: "",
  //     lhs: "<Plug>(...)",
  //     // ...
  //   },
  //   // ...
  // ]

  await mapping.unmap(denops, "<Plug>(test-denops-std)");
  await mapping.unmap(denops, "<Plug>(test-denops-std)", {
    mode: "i",
  });
}
```

Close #57 