### PR TITLE
Add `batch` module to handle `denops.batch` more flexibly

### DIFF
--- a/denops_std/batch/README.md
+++ b/denops_std/batch/README.md
@@ -1,0 +1,108 @@
+# batch
+
+`batch` is a module to provide `denops.batch()` helper functions.
+
+- [API documentation](https://doc.deno.land/https/deno.land/x/denops_std/batch/mod.ts)
+
+## Usage
+
+### batch
+
+Use `batch()` to call multiple denops functions sequentially without overhead
+like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { batch } from "https://deno.land/x/denops_std/batch/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await batch(denops, async (denops) => {
+    await denops.cmd("setlocal modifiable");
+    await denops.cmd("setlocal noswap");
+    await denops.cmd("setlocal nobackup");
+  });
+}
+```
+
+The function can be nested thus users can use functions which may internally use
+`batch()` like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { batch } from "https://deno.land/x/denops_std/batch/mod.ts";
+
+async function replace(denops: Denops, content: string): Promise<void> {
+  await batch(denops, (denops) => {
+    await denops.cmd("setlocal modifiable");
+    await denops.cmd("setlocal foldmethod=manual");
+    await denops.call("setline", 1, content.split(/\r?\n/));
+    await denops.cmd("setlocal nomodifiable");
+    await denops.cmd("setlocal nomodified");
+  });
+}
+
+export async function main(denops: Denops): Promise<void> {
+  await batch(denops, async (denops) => {
+    await denops.cmd("edit Hello");
+    await replace(denops, "Hello Darkness My Old Friend");
+  });
+}
+```
+
+Note that `denops.call()`, `denops.batch()`, or `denops.eval()` always return
+falsy value in `batch()`, indicating that you **cannot** write code like below:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { batch } from "https://deno.land/x/denops_std/batch/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await batch(denops, async (denops) => {
+    // !!! DON'T DO THIS !!!
+    if (await denops.eval("&verbose")) {
+      await denops.cmd("echomsg 'VERBOSE'");
+    }
+    await denops.cmd("echomsg 'Hello world'");
+  });
+}
+```
+
+### gather
+
+Use `gather()` to call multiple denops functions sequentially without overhead
+and return values like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { gather } from "https://deno.land/x/denops_std/batch/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  const results = await gather(denops, async (denops) => {
+    await denops.eval("&modifiable");
+    await denops.eval("&modified");
+    await denops.eval("&filetype");
+  });
+  // results contains the value of modifiable, modified, and filetype
+}
+```
+
+Not like `batch`, the function can NOT be nested.
+
+Note that `denops.call()`, `denops.batch()`, or `denops.eval()` always return
+falsy value in `gather()`, indicating that you **cannot** write code like below:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { batch } from "https://deno.land/x/denops_std/batch/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  const results = await gather(denops, async (denops) => {
+    // !!! DON'T DO THIS !!!
+    if (await denops.call("has", "nvim")) {
+      await denops.call("api_info").version;
+    } else {
+      await denops.eval("v:version");
+    }
+  });
+}
+```

--- a/denops_std/batch/batch.ts
+++ b/denops_std/batch/batch.ts
@@ -1,0 +1,70 @@
+import { Context, Denops, Dispatcher, Meta } from "../deps.ts";
+
+class BatchHelper implements Denops {
+  #denops: Denops;
+  #calls: [string, ...unknown[]][];
+
+  constructor(denops: Denops) {
+    this.#denops = denops;
+    this.#calls = [];
+  }
+
+  static getCalls(helper: BatchHelper): [string, ...unknown[]][] {
+    return helper.#calls;
+  }
+
+  get name(): string {
+    return this.#denops.name;
+  }
+
+  get meta(): Meta {
+    return this.#denops.meta;
+  }
+
+  get dispatcher(): Dispatcher {
+    return this.#denops.dispatcher;
+  }
+
+  set dispatcher(dispatcher: Dispatcher) {
+    this.#denops.dispatcher = dispatcher;
+  }
+
+  call(fn: string, ...args: unknown[]): Promise<unknown> {
+    this.#calls.push([fn, ...args]);
+    return Promise.resolve();
+  }
+
+  batch(...calls: [string, ...unknown[]][]): Promise<unknown[]> {
+    this.#calls.push(...calls);
+    return Promise.resolve([]);
+  }
+
+  cmd(cmd: string, ctx: Context = {}): Promise<void> {
+    this.call("denops#api#cmd", cmd, ctx);
+    return Promise.resolve();
+  }
+
+  eval(expr: string, ctx: Context = {}): Promise<unknown> {
+    this.call("denops#api#eval", expr, ctx);
+    return Promise.resolve();
+  }
+
+  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown> {
+    return this.#denops.dispatch(name, fn, ...args);
+  }
+}
+
+/**
+ * Perform batch call
+ */
+export async function batch(
+  denops: Denops,
+  main: (helper: BatchHelper) => Promise<void>,
+): Promise<void> {
+  const helper = new BatchHelper(denops);
+  await main(helper);
+  const calls = BatchHelper.getCalls(helper);
+  await denops.batch(...calls);
+}
+
+export type { BatchHelper };

--- a/denops_std/batch/batch_test.ts
+++ b/denops_std/batch/batch_test.ts
@@ -1,0 +1,132 @@
+import { assertEquals, test } from "../deps_test.ts";
+import { batch } from "./batch.ts";
+
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'denops.call()' as batch process.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = []");
+    await denops.cmd(
+      "command! -nargs=1 DenopsBatchTest let g:denops_batch_test += [<f-args>]",
+    );
+    await batch(denops, async (denops) => {
+      assertEquals(
+        await denops.call("execute", "DenopsBatchTest 1"),
+        undefined,
+      );
+      assertEquals(
+        await denops.call("execute", "DenopsBatchTest 2"),
+        undefined,
+      );
+      assertEquals(
+        await denops.call("execute", "DenopsBatchTest 3"),
+        undefined,
+      );
+    });
+    assertEquals(await denops.eval("g:denops_batch_test") as string[], [
+      "1",
+      "2",
+      "3",
+    ]);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'denops.cmd()' as batch process.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = []");
+    await denops.cmd(
+      "command! -nargs=1 DenopsBatchTest let g:denops_batch_test += [<f-args>]",
+    );
+    await batch(denops, async (denops) => {
+      assertEquals(await denops.cmd("DenopsBatchTest 1"), undefined);
+      assertEquals(await denops.cmd("DenopsBatchTest 2"), undefined);
+      assertEquals(await denops.cmd("DenopsBatchTest 3"), undefined);
+    });
+    assertEquals(await denops.eval("g:denops_batch_test") as string[], [
+      "1",
+      "2",
+      "3",
+    ]);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute 'denops.eval()' as batch process.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = []");
+    await batch(denops, async (denops) => {
+      assertEquals(
+        await denops.eval("add(g:denops_batch_test, string(1))"),
+        undefined,
+      );
+      assertEquals(
+        await denops.eval("add(g:denops_batch_test, string(2))"),
+        undefined,
+      );
+      assertEquals(
+        await denops.eval("add(g:denops_batch_test, string(3))"),
+        undefined,
+      );
+    });
+    assertEquals(await denops.eval("g:denops_batch_test") as string[], [
+      "1",
+      "2",
+      "3",
+    ]);
+  },
+});
+test({
+  mode: "any",
+  name: "batch() sequentially execute nested 'batch()' as batch process.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = []");
+    await denops.cmd(
+      "command! -nargs=1 DenopsBatchTest let g:denops_batch_test += [<f-args>]",
+    );
+    await batch(denops, async (denops) => {
+      assertEquals(
+        await denops.call("execute", "DenopsBatchTest 1"),
+        undefined,
+      );
+      assertEquals(
+        await denops.call("execute", "DenopsBatchTest 2"),
+        undefined,
+      );
+      await batch(denops, async (denops) => {
+        assertEquals(await denops.cmd("DenopsBatchTest 3"), undefined);
+        assertEquals(await denops.cmd("DenopsBatchTest 4"), undefined);
+        await batch(denops, async (denops) => {
+          assertEquals(
+            await denops.eval("add(g:denops_batch_test, string(5))"),
+            undefined,
+          );
+          assertEquals(
+            await denops.eval("add(g:denops_batch_test, string(6))"),
+            undefined,
+          );
+          assertEquals(
+            await denops.eval("add(g:denops_batch_test, string(7))"),
+            undefined,
+          );
+        });
+        assertEquals(await denops.cmd("DenopsBatchTest 8"), undefined);
+      });
+      assertEquals(
+        await denops.call("execute", "DenopsBatchTest 9"),
+        undefined,
+      );
+    });
+    assertEquals(await denops.eval("g:denops_batch_test") as string[], [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+    ]);
+  },
+});

--- a/denops_std/batch/gather.ts
+++ b/denops_std/batch/gather.ts
@@ -1,0 +1,69 @@
+import { Context, Denops, Dispatcher, Meta } from "../deps.ts";
+
+class GatherHelper implements Denops {
+  #denops: Denops;
+  #calls: [string, ...unknown[]][];
+
+  constructor(denops: Denops) {
+    this.#denops = denops;
+    this.#calls = [];
+  }
+
+  static getCalls(helper: GatherHelper): [string, ...unknown[]][] {
+    return helper.#calls;
+  }
+
+  get name(): string {
+    return this.#denops.name;
+  }
+
+  get meta(): Meta {
+    return this.#denops.meta;
+  }
+
+  get dispatcher(): Dispatcher {
+    return this.#denops.dispatcher;
+  }
+
+  set dispatcher(dispatcher: Dispatcher) {
+    this.#denops.dispatcher = dispatcher;
+  }
+
+  call(fn: string, ...args: unknown[]): Promise<unknown> {
+    this.#calls.push([fn, ...args]);
+    return Promise.resolve();
+  }
+
+  batch(..._calls: [string, ...unknown[]][]): Promise<unknown[]> {
+    throw new Error("The 'batch' method is not available on GatherHelper.");
+  }
+
+  cmd(cmd: string, ctx: Context = {}): Promise<void> {
+    this.call("denops#api#cmd", cmd, ctx);
+    return Promise.resolve();
+  }
+
+  eval(expr: string, ctx: Context = {}): Promise<unknown> {
+    this.call("denops#api#eval", expr, ctx);
+    return Promise.resolve();
+  }
+
+  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown> {
+    return this.#denops.dispatch(name, fn, ...args);
+  }
+}
+
+/**
+ * Perform gather call
+ */
+export async function gather(
+  denops: Denops,
+  main: (helper: GatherHelper) => Promise<void>,
+): Promise<unknown[]> {
+  const helper = new GatherHelper(denops);
+  await main(helper);
+  const calls = GatherHelper.getCalls(helper);
+  return await denops.batch(...calls);
+}
+
+export type { GatherHelper };

--- a/denops_std/batch/gather_test.ts
+++ b/denops_std/batch/gather_test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { gather } from "./gather.ts";
+
+test({
+  mode: "any",
+  name: "gather() sequentially execute 'denops.call()'.",
+  fn: async (denops) => {
+    const results = await gather(denops, async (denops) => {
+      await denops.call("range", 0);
+      await denops.call("range", 1);
+      await denops.call("range", 2);
+    });
+    assertEquals(results, [[], [0], [0, 1]]);
+  },
+});
+test({
+  mode: "any",
+  name: "gather() throws an error when 'denops.cmd()' is called.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_gather_test = 0");
+    await denops.cmd("command! DenopsGatherTest let g:denops_gather_test += 1");
+    const results = await gather(denops, async (denops) => {
+      await denops.cmd("DenopsGatherTest");
+      await denops.cmd("DenopsGatherTest");
+      await denops.cmd("DenopsGatherTest");
+    });
+    assertEquals(results, [0, 0, 0]);
+    assertEquals(await denops.eval("g:denops_gather_test") as number, 3);
+  },
+});
+test({
+  mode: "any",
+  name: "gather() sequentially execute 'denops.eval()'.",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_gather_test = 10");
+    const results = await gather(denops, async (denops) => {
+      await denops.eval("g:denops_gather_test + 1");
+      await denops.eval("g:denops_gather_test - 1");
+      await denops.eval("g:denops_gather_test * 10");
+    });
+    assertEquals(results, [11, 9, 100]);
+  },
+});
+test({
+  mode: "any",
+  name: "gather() throws an error when 'denops.batch()' is called.",
+  fn: async (denops) => {
+    await assertThrowsAsync(
+      async () => {
+        await gather(denops, async (denops) => {
+          await denops.batch();
+        });
+      },
+      undefined,
+      "method is not available",
+    );
+  },
+});

--- a/denops_std/batch/mod.ts
+++ b/denops_std/batch/mod.ts
@@ -1,0 +1,2 @@
+export * from "./batch.ts";
+export * from "./gather.ts";

--- a/denops_std/helper/README.md
+++ b/denops_std/helper/README.md
@@ -27,77 +27,8 @@ export async function main(denops: Denops): Promise<void> {
 
 ### batch
 
-Use `batch()` to call multiple denops functions sequentially without overhead
-and get results like:
-
-```typescript
-import { Denops } from "https://deno.land/x/denops_std/mod.ts";
-import { batch } from "https://deno.land/x/denops_std/helper/mod.ts";
-
-export async function main(denops: Denops): Promise<void> {
-  const results = await batch(denops, (helper) => {
-    helper.call("range", 2);
-    helper.cmd("echomsg 'Hello'");
-    helper.eval("v:version");
-  });
-
-  console.log(results);
-  // [
-  //   [0, 1],
-  //   0,
-  //   '800',
-  // ]
-}
-```
-
-The `helper` instance implement `Denops` interface thus users can use it as
-`denops` like:
-
-```typescript
-import { Denops } from "https://deno.land/x/denops_std/mod.ts";
-import * as fn from "https://deno.land/x/denops_std/function/mod.ts";
-import * as vars from "https://deno.land/x/denops_std/variable/mod.ts";
-import { batch } from "https://deno.land/x/denops_std/helper/mod.ts";
-
-export async function main(denops: Denops): Promise<void> {
-  const results = await batch(denops, (helper) => {
-    fn.range(helper, 2);
-    vars.v.get(helper, "version");
-  });
-
-  console.log(results);
-  // [
-  //   [0, 1],
-  //   '800',
-  // ]
-}
-```
-
-When one of function call fails during batch process, `batch` throws
-`BatchError` which contains succeeded results as `results` like:
-
-```typescript
-import { BatchError, Denops } from "https://deno.land/x/denops_std/mod.ts";
-import { batch } from "https://deno.land/x/denops_std/helper/mod.ts";
-
-export async function main(denops: Denops): Promise<void> {
-  try {
-    await batch(denops, (helper) => {
-      helper.call("range", 0);
-      helper.call("range", 1);
-      helper.call("no-such-function");
-      helper.call("range", 2);
-    });
-  } catch (e) {
-    // e is an instance of BatchErro
-    if (e instanceof BatchError) {
-      // Print succeeded results
-      console.log("Succeeded:", e.results);
-    }
-    throw e;
-  }
-}
-```
+Deprecated in favor of [`batch`](./batch/README.md) module. Use `gather()`
+function on that module instead.
 
 ### execute
 

--- a/denops_std/helper/batch.ts
+++ b/denops_std/helper/batch.ts
@@ -1,75 +1,20 @@
-import { Context, Denops, Dispatcher, Meta } from "../deps.ts";
-
-class BatchHelper implements Denops {
-  #denops: Denops;
-  #calls: [string, ...unknown[]][];
-
-  constructor(denops: Denops) {
-    this.#denops = denops;
-    this.#calls = [];
-  }
-
-  static getCalls(helper: BatchHelper): [string, ...unknown[]][] {
-    return helper.#calls;
-  }
-
-  get name(): string {
-    return this.#denops.name;
-  }
-
-  get meta(): Meta {
-    return this.#denops.meta;
-  }
-
-  get dispatcher(): Dispatcher {
-    return this.#denops.dispatcher;
-  }
-
-  set dispatcher(dispatcher: Dispatcher) {
-    this.#denops.dispatcher = dispatcher;
-  }
-
-  call(fn: string, ...args: unknown[]): Promise<unknown> {
-    this.#calls.push([fn, ...args]);
-    return Promise.resolve();
-  }
-
-  batch(..._calls: [string, ...unknown[]][]): Promise<unknown[]> {
-    throw new Error(
-      "The 'batch' method is not available on BatchDenops instance.",
-    );
-  }
-
-  cmd(cmd: string, ctx: Context = {}): Promise<void> {
-    this.call("denops#api#cmd", cmd, ctx);
-    return Promise.resolve();
-  }
-
-  eval(expr: string, ctx: Context = {}): Promise<unknown> {
-    this.call("denops#api#eval", expr, ctx);
-    return Promise.resolve();
-  }
-
-  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown> {
-    return this.#denops.dispatch(name, fn, ...args);
-  }
-}
+import { Denops } from "../deps.ts";
+import { gather } from "../batch/mod.ts";
+import type { GatherHelper } from "../batch/mod.ts";
 
 /**
- * Call denops functions sequentially without redraw and return the results.
- *
- * It is a wrapper function of `denops.batch()` to allow users to use `function`
- * modules, `denops.cmd()`, `denops.eval()`, or whatever things which assume a
- * `denops` instance.
+ * @deprecated Use `gather()` function in `batch` module instead.
  */
 export async function batch(
   denops: Denops,
-  main: (helper: BatchHelper) => Promise<void> | void,
+  main: (helper: GatherHelper) => Promise<void> | void,
 ): Promise<unknown[]> {
-  const helper = new BatchHelper(denops);
-  await main(helper);
-  const calls = BatchHelper.getCalls(helper);
-  return await denops.batch(...calls);
+  console.warn(
+    "DEPRECATED: Use `gather()` function in `batch` module instead.",
+  );
+  return await gather(denops, async (helper: GatherHelper) => {
+    return await main(helper);
+  });
 }
 
-export type { BatchHelper };
+export type { GatherHelper as BatchHelper };


### PR DESCRIPTION
The previous `batch` could not be nested thus I add a new `batch` module with two functions

- `batch` is used to perform multiple operations sequentially without the overhead. This function can be nested but it does not return results
- `gather` is used to get results of multiple sequential operations without the overhead. This function cannot be nested.