### PR TITLE
:boom: Drop support vim before 8.2.0662

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,32 @@ jobs:
           - "1.11.0"
           - "1.x"
         host_version:
-          - vim: "v8.1.2424"
+          - vim: "v8.2.0662"
             nvim: "v0.4.4"
           - vim: "v8.2.3081"
             nvim: "v0.5.0"
+        include:
+          - runner: windows-latest
+            version: 1.11.0
+            host_version:
+              vim: v8.2.0671 # Instead of v8.2.0662
+              nvim: v0.4.4
+          - runner: windows-latest
+            version: 1.x
+            host_version:
+              vim: v8.2.0671 # Instead of v8.2.0662
+              nvim: v0.4.4
+        exclude:
+          - runner: windows-latest
+            version: 1.11.0
+            host_version:
+              vim: v8.2.0662 # Not found on vim-win32-installer
+              nvim: v0.4.4
+          - runner: windows-latest
+            version: 1.x
+            host_version:
+              vim: v8.2.0662 # Not found on vim-win32-installer
+              nvim: v0.4.4
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false

--- a/denops_std/deps.ts
+++ b/denops_std/deps.ts
@@ -3,6 +3,6 @@ export * as hash from "https://deno.land/std@0.104.0/hash/mod.ts#^";
 export * as path from "https://deno.land/std@0.104.0/path/mod.ts#^";
 export { deferred } from "https://deno.land/std@0.104.0/async/mod.ts#^";
 
-export * from "https://deno.land/x/denops_core@v1.3.0/mod.ts#^";
+export * from "https://deno.land/x/denops_core@v1.4.0/mod.ts#^";
 
 export * from "https://deno.land/x/unknownutil@v1.1.0/mod.ts";

--- a/denops_std/deps_test.ts
+++ b/denops_std/deps_test.ts
@@ -1,3 +1,3 @@
 export * from "https://deno.land/std@0.104.0/testing/asserts.ts#^";
 
-export * from "https://deno.land/x/denops_core@v1.3.0/test/mod.ts#^";
+export * from "https://deno.land/x/denops_core@v1.4.0/test/mod.ts#^";

--- a/denops_std/function/_generated.ts
+++ b/denops_std/function/_generated.ts
@@ -920,19 +920,6 @@ export function diff_hlID(
 }
 
 /**
- * Return all of environment variables as dictionary. You can
- * check if an environment variable exists like this:
- * 	:echo has_key(environ(), 'HOME')
- * Note that the variable name may be CamelCase; to ignore case
- * use this:
- * 	:echo index(keys(environ()), 'HOME', 0, 1) != -1
- */
-export function environ(denops: Denops): Promise<unknown>;
-export function environ(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("environ", ...args);
-}
-
-/**
  * Return the Number 1 if {expr} is empty, zero otherwise.
  * - A |List| or |Dictionary| is empty when it does not have any
  *   items.
@@ -950,6 +937,19 @@ export function environ(denops: Denops, ...args: unknown[]): Promise<unknown> {
 export function empty(denops: Denops, expr: unknown): Promise<unknown>;
 export function empty(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("empty", ...args);
+}
+
+/**
+ * Return all of environment variables as dictionary. You can
+ * check if an environment variable exists like this:
+ * 	:echo has_key(environ(), 'HOME')
+ * Note that the variable name may be CamelCase; to ignore case
+ * use this:
+ * 	:echo index(keys(environ()), 'HOME', 0, 1) != -1
+ */
+export function environ(denops: Denops): Promise<unknown>;
+export function environ(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("environ", ...args);
 }
 
 /**
@@ -1005,16 +1005,15 @@ export function eventhandler(
  * arguments.
  * executable() uses the value of $PATH and/or the normal
  * searchpath for programs.
- * On MS-DOS and MS-Windows the ".exe", ".bat", etc. can
- * optionally be included.  Then the extensions in $PATHEXT are
- * tried.  Thus if "foo.exe" does not exist, "foo.exe.bat" can be
- * found.  If $PATHEXT is not set then ".exe;.com;.bat;.cmd" is
- * used.  A dot by itself can be used in $PATHEXT to try using
- * the name without an extension.  When 'shell' looks like a
- * Unix shell, then the name is also tried without adding an
- * extension.
- * On MS-DOS and MS-Windows it only checks if the file exists and
- * is not a directory, not if it's really executable.
+ * On MS-Windows the ".exe", ".bat", etc. can optionally be
+ * included.  Then the extensions in $PATHEXT are tried.  Thus if
+ * "foo.exe" does not exist, "foo.exe.bat" can be found.  If
+ * $PATHEXT is not set then ".exe;.com;.bat;.cmd" is used.  A dot
+ * by itself can be used in $PATHEXT to try using the name
+ * without an extension.  When 'shell' looks like a Unix shell,
+ * then the name is also tried without adding an extension.
+ * On MS-Windows it only checks if the file exists and is not a
+ * directory, not if it's really executable.
  * On MS-Windows an executable in the same directory as Vim is
  * always found.  Since this directory is added to $PATH it
  * should also work to execute it |win32-PATH|.
@@ -1260,6 +1259,8 @@ export function extend(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * 'L'	Lowlevel input.  Only works for Unix or when using the
  * 	GUI. Keys are used as if they were coming from the
  * 	terminal.  Other flags are not used.
+ * 	When a CTRL-C interrupts and 't' is included it sets
+ * 	the internal "got_int" flag.
  * 'i'	Insert the string instead of appending (see above).
  * 'x'	Execute commands until typeahead is empty.  This is
  * 	similar to using ":normal!".  You can call feedkeys()
@@ -1835,6 +1836,8 @@ export function get(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * 			{only with the |+viminfo| feature}
  * 	listed		TRUE if the buffer is listed.
  * 	lnum		current line number in buffer.
+ * 	linecount	number of lines in the buffer (only
+ * 			valid when loaded)
  * 	loaded		TRUE if the buffer is loaded.
  * 	name		full path to the file in the buffer.
  * 	signs		list of signs placed in the buffer.
@@ -2133,6 +2136,7 @@ export function getcmdwintype(
  * command		Ex command (and arguments)
  * compiler	compilers
  * cscope		|:cscope| suboptions
+ * diff_buffer     |:diffget| and |:diffput| completion
  * dir		directory names
  * environment	environment variable names
  * event		autocommand events
@@ -2435,7 +2439,7 @@ export function getmatches(
 /**
  * Return a Number which is the process ID of the Vim process.
  * On Unix and MS-Windows this is a unique number, until Vim
- * exits.  On MS-DOS it's always zero.
+ * exits.
  */
 export function getpid(denops: Denops): Promise<unknown>;
 export function getpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -2754,7 +2758,7 @@ export function getwininfo(
 }
 
 /**
- * The result is a list with two numbers, the result of
+ * The result is a List with two numbers, the result of
  * |getwinposx()| and |getwinposy()| combined:
  * 	[x-pos, y-pos]
  * {timeout} can be used to specify how long to wait in msec for
@@ -3879,6 +3883,7 @@ export function map(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *   "rhs"	     The {rhs} of the mapping as typed.
  *   "silent"   1 for a |:map-silent| mapping, else 0.
  *   "noremap"  1 if the {rhs} of the mapping is not remappable.
+ *   "script"   1 if mapping was defined with <script>.
  *   "expr"     1 for an expression mapping (|:map-<expr>|).
  *   "buffer"   1 for a buffer local mapping (|:map-local|).
  *   "mode"     Modes for which the mapping is defined. In
@@ -4003,6 +4008,10 @@ export function mapcheck(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The 'ignorecase' option is used to set the ignore-caseness of
  * the pattern.  'smartcase' is NOT used.  The matching is always
  * done like 'magic' is set and 'cpoptions' is empty.
+ * Note that a match at the start is preferred, thus when the
+ * pattern is using "*" (any number of matches) it tends to find
+ * zero matches at the start instead of a number of matches
+ * further down in the text.
  * Can also be used as a |method|:
  * 	GetList()->match('word')
  */
@@ -4052,6 +4061,10 @@ export function match(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The 'ignorecase' option is used to set the ignore-caseness of
  * the pattern.  'smartcase' is NOT used.  The matching is always
  * done like 'magic' is set and 'cpoptions' is empty.
+ * Note that a match at the start is preferred, thus when the
+ * pattern is using "*" (any number of matches) it tends to find
+ * zero matches at the start instead of a number of matches
+ * further down in the text.
  * Can also be used as a |method|:
  * 	GetList()->match('word')
  */
@@ -4094,6 +4107,10 @@ export function strpbrk(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The 'ignorecase' option is used to set the ignore-caseness of
  * the pattern.  'smartcase' is NOT used.  The matching is always
  * done like 'magic' is set and 'cpoptions' is empty.
+ * Note that a match at the start is preferred, thus when the
+ * pattern is using "*" (any number of matches) it tends to find
+ * zero matches at the start instead of a number of matches
+ * further down in the text.
  * Can also be used as a |method|:
  * 	GetList()->match('word')
  */
@@ -4409,9 +4426,9 @@ export function matchstrpos(
 
 /**
  * Return the maximum value of all items in {expr}.
- * {expr} can be a list or a dictionary.  For a dictionary,
- * it returns the maximum of all values in the dictionary.
- * If {expr} is neither a list nor a dictionary, or one of the
+ * {expr} can be a List or a Dictionary.  For a Dictionary,
+ * it returns the maximum of all values in the Dictionary.
+ * If {expr} is neither a List nor a Dictionary, or one of the
  * items in {expr} cannot be used as a Number this results in
  * an error.  An empty |List| or |Dictionary| results in zero.
  * Can also be used as a |method|:
@@ -4423,9 +4440,9 @@ export function max(denops: Denops, ...args: unknown[]): Promise<unknown> {
 }
 
 /**
- * {expr} can be a list or a dictionary.  For a dictionary,
- * it returns the minimum of all values in the dictionary.
- * If {expr} is neither a list nor a dictionary, or one of the
+ * {expr} can be a List or a Dictionary.  For a Dictionary,
+ * it returns the minimum of all values in the Dictionary.
+ * If {expr} is neither a List nor a Dictionary, or one of the
  * items in {expr} cannot be used as a Number this results in
  * an error.  An empty |List| or |Dictionary| results in zero.
  * Can also be used as a |method|:
@@ -5912,8 +5929,8 @@ export function setloclist(
 }
 
 /**
- * Restores a list of matches saved by |getmatches() for the
- * current window|.  Returns 0 if successful, otherwise -1.  All
+ * Restores a list of matches saved by |getmatches()| for the
+ * current window.  Returns 0 if successful, otherwise -1.  All
  * current matches are cleared before the list is restored.  See
  * example for |getmatches()|.
  * If {win} is specified, use the window with this number or
@@ -5935,7 +5952,11 @@ export function setmatches(
 
 /**
  * Create or replace or add to the quickfix list.
- * When {what} is not present, use the items in {list}.  Each
+ * If the optional {what} dictionary argument is supplied, then
+ * only the items listed in {what} are set. The first {list}
+ * argument is ignored.  See below for the supported items in
+ * {what}.
+ * When {what} is not present, the items in {list} or used.  Each
  * item must be a dictionary.  Non-dictionary items in {list} are
  * ignored.  Each dictionary item can contain the following
  * entries:
@@ -5983,10 +6004,7 @@ export function setmatches(
  * quickfix list in the stack and all the following lists are
  * freed. To add a new quickfix list at the end of the stack,
  * set "nr" in {what} to "$".
- * If the optional {what} dictionary argument is supplied, then
- * only the items listed in {what} are set. The first {list}
- * argument is ignored.  The following items can be specified in
- * {what}:
+ * The following items can be specified in dictionary {what}:
  *     context	quickfix list context. See |quickfix-context|
  *     efm		errorformat to use when parsing text from
  * 		"lines". If this is not present, then the
@@ -6041,6 +6059,7 @@ export function setqflist(
 
 /**
  * Set the register {regname} to {value}.
+ * If {regname} is "" or "@", the unnamed register '"' is used.
  * {value} may be any value returned by |getreg()|, including
  * a |List|.
  * If {options} contains "a" or {regname} is upper case,
@@ -6156,20 +6175,23 @@ export function settabwinvar(
  * Modify the tag stack of the window {nr} using {dict}.
  * {nr} can be the window number or the |window-ID|.
  * For a list of supported items in {dict}, refer to
- * |gettagstack()|
- * If {action} is not present or is set to 'r', then the tag
- * stack is replaced. If {action} is set to 'a', then new entries
- * from {dict} are pushed onto the tag stack.
+ * |gettagstack()|. "curidx" takes effect before changing the tag
+ * stack.
+ * How the tag stack is modified depends on the {action}
+ * argument:
+ * - If {action} is not present or is set to 'r', then the tag
+ *   stack is replaced.
+ * - If {action} is set to 'a', then new entries from {dict} are
+ *   pushed (added) onto the tag stack.
+ * - If {action} is set to 't', then all the entries from the
+ *   current entry in the tag stack or "curidx" in {dict} are
+ *   removed and then new entries are pushed to the stack.
+ * The current index is set to one after the length of the tag
+ * stack after the modification.
  * Returns zero for success, -1 for failure.
- * Examples:
- *     Set current index of the tag stack to 4:
- * 	call settagstack(1005, {'curidx' : 4})
+ * Examples (for more examples see |tagstack-examples||):
  *     Empty the tag stack of window 3:
  * 	call settagstack(3, {'items' : []})
- *     Push a new item onto the tag stack:
- * 	let pos = [bufnr('myfile.txt'), 10, 1, 0]
- * 	let newtag = [{'tagname' : 'mytag', 'from' : pos}]
- * 	call settagstack(2, {'items' : newtag}, 'a')
  *     Save and restore the tag stack:
  * 	let stack = gettagstack(1003)
  * 	" do something else
@@ -6301,6 +6323,8 @@ export function shiftwidth(
  * removed when "dir" is a symbolic link within the same
  * directory.  In order to resolve all the involved symbolic
  * links before simplifying the path name, use |resolve()|.
+ * Can also be used as a |method|:
+ * 	GetName()->simplify()
  */
 export function simplify(denops: Denops, filename: unknown): Promise<unknown>;
 export function simplify(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -7235,7 +7259,7 @@ export function synstack(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The command executed is constructed using several options:
  * 	'shell' 'shellcmdflag' 'shellxquote' {expr} 'shellredir' {tmp} 'shellxquote'
  * ({tmp} is an automatically generated file name).
- * For Unix and OS/2 braces are put around {expr} to allow for
+ * For Unix, braces are put around {expr} to allow for
  * concatenated commands.
  * The command will be executed in "cooked" mode, so that a
  * CTRL-C will interrupt the command (on Unix at least).
@@ -8009,11 +8033,12 @@ export function winheight(
  * 	" Two horizontally split windows
  * 	:echo winlayout()
  * 	['col', [['leaf', 1000], ['leaf', 1001]]]
- * 	" Three horizontally split windows, with two
- * 	" vertically split windows in the middle window
+ * 	" The second tab page, with three horizontally split
+ * 	" windows, with two vertically split windows in the
+ * 	" middle window
  * 	:echo winlayout(2)
- * 	['col', [['leaf', 1002], ['row', ['leaf', 1003],
- * 			     ['leaf', 1001]]], ['leaf', 1000]]
+ * 	['col', [['leaf', 1002], ['row', [['leaf', 1003],
+ * 			    ['leaf', 1001]]], ['leaf', 1000]]]
  * Can also be used as a |method|:
  * 	GetTabnr()->winlayout()
  */
@@ -8028,6 +8053,7 @@ export function winlayout(
 /**
  * The result is a Number, which is the number of the current
  * window.  The top window has number 1.
+ * Returns zero for a popup window.
  * The optional argument {arg} supports the following values:
  * 	$	the number of the last window (the window
  * 		count).

--- a/denops_std/function/vim/_generated.ts
+++ b/denops_std/function/vim/_generated.ts
@@ -121,6 +121,7 @@ export function last_buffer_nr(
  * 	  directory (|:tcd|) then changes the tabpage local
  * 	  directory.
  * 	- Otherwise, changes the global directory.
+ * {dir} must be a String.
  * If successful, returns the previous working directory.  Pass
  * this to another chdir() to restore the directory.
  * On failure, returns an empty string.
@@ -152,6 +153,20 @@ export function debugbreak(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("debugbreak", ...args);
+}
+
+/**
+ * Output {expr} as-is, including unprintable characters.  This
+ * can be used to output a terminal code. For example, to disable
+ * modifyOtherKeys:
+ * 	call echoraw(&t_TE)
+ * and to enable it again:
+ * 	call echoraw(&t_TI)
+ * Use with care, you can mess up the terminal this way.
+ */
+export function echoraw(denops: Denops, expr: unknown): Promise<unknown>;
+export function echoraw(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("echoraw", ...args);
 }
 
 /**
@@ -499,6 +514,71 @@ export function luaeval(
 ): Promise<unknown>;
 export function luaeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("luaeval", ...args);
+}
+
+/**
+ * Return information about the specified menu {name} in
+ * mode {mode}. The menu name should be specified without the
+ * shortcut character ('&').
+ * {mode} can be one of these strings:
+ * 	"n"	Normal
+ * 	"v"	Visual (including Select)
+ * 	"o"	Operator-pending
+ * 	"i"	Insert
+ * 	"c"	Cmd-line
+ * 	"s"	Select
+ * 	"x"	Visual
+ * 	"t"	Terminal-Job
+ * 	""	Normal, Visual and Operator-pending
+ * 	"!"	Insert and Cmd-line
+ * When {mode} is omitted, the modes for "" are used.
+ * Returns a |Dictionary| containing the following items:
+ *   accel		menu item accelerator text |menu-text|
+ *   display	display name (name without '&')
+ *   enabled	v:true if this menu item is enabled
+ * 		Refer to |:menu-enable|
+ *   icon		name of the icon file (for toolbar)
+ * 		|toolbar-icon|
+ *   iconidx	index of a built-in icon
+ *   modes		modes for which the menu is defined. In
+ * 		addition to the modes mentioned above, these
+ * 		characters will be used:
+ * 		" "	Normal, Visual and Operator-pending
+ *   name		menu item name.
+ *   noremenu	v:true if the {rhs} of the menu item is not
+ * 		remappable else v:false.
+ *   priority	menu order priority |menu-priority|
+ *   rhs		right-hand-side of the menu item. The returned
+ * 		string has special characters translated like
+ * 		in the output of the ":menu" command listing.
+ * 		When the {rhs} of a menu item is empty, then
+ * 		"<Nop>" is returned.
+ *   script	v:true if script-local remapping of {rhs} is
+ * 		allowed else v:false.  See |:menu-script|.
+ *   shortcut	shortcut key (character after '&' in
+ * 		the menu name) |menu-shortcut|
+ *   silent	v:true if the menu item is created
+ * 		with <silent> argument |:menu-silent|
+ *   submenus	|List| containing the names of
+ * 		all the submenus.  Present only if the menu
+ * 		item has submenus.
+ * Returns an empty dictionary if the menu item is not found.
+ * Examples:
+ * 	:echo menu_info('Edit.Cut')
+ * 	:echo menu_info('File.Save', 'n')
+ * Can also be used as a |method|:
+ * 	GetMenuName()->menu_info('v')
+ */
+export function menu_info(
+  denops: Denops,
+  name: unknown,
+  mode?: unknown,
+): Promise<unknown>;
+export function menu_info(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("menu_info", ...args);
 }
 
 /**
@@ -958,11 +1038,33 @@ export function win_execute(
 }
 
 /**
+ * Return the type of the window:
+ * 	"popup"		popup window |popup|
+ * 	"command"	command-line window |cmdwin|
+ * 	(empty)		normal window
+ * 	"unknown"	window {nr} not found
+ * When {nr} is omitted return the type of the current window.
+ * When {nr} is given return the type of this window by number or
+ * |window-ID|.
+ * Also see the 'buftype' option.  When running a terminal in a
+ * popup window then 'buftype' is "terminal" and win_gettype()
+ * returns "popup".
+ */
+export function win_gettype(denops: Denops, nr?: unknown): Promise<unknown>;
+export function win_gettype(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("win_gettype", ...args);
+}
+
+/**
  * 	        Move the window {nr} to a new split of the window {target}.
  * This is similar to moving to {target}, creating a new window
  * using |:split| but having the same contents as window {nr}, and
  * then closing {nr}.
  * Both {nr} and {target} can be window numbers or |window-ID|s.
+ * Both must be in the current tab page.
  * Returns zero for success, non-zero for failure.
  * {options} is a Dictionary with the following optional entries:
  *   "vertical"	When TRUE, the split is created vertically,
@@ -986,4 +1088,18 @@ export function win_splitmove(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("win_splitmove", ...args);
+}
+
+/**
+ * The result is a String.  For MS-Windows it indicates the OS
+ * version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
+ * Windows XP is "5.1".  For non-MS-Windows systems the result is
+ * an empty string.
+ */
+export function windowsversion(denops: Denops): Promise<unknown>;
+export function windowsversion(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("windowsversion", ...args);
 }

--- a/denops_std/option/_generated.ts
+++ b/denops_std/option/_generated.ts
@@ -378,6 +378,8 @@ export const background = {
  * eol	allow backspacing over line breaks (join lines)
  * start	allow backspacing over the start of insert; CTRL-W and CTRL-U
  * 	stop once at the start of insert.
+ * nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
+ * 	insert.
  */
 export const backspace = {
   async get(denops: Denops): Promise<string> {
@@ -480,9 +482,9 @@ export const backupcopy = {
  *   impossible!).  Writing may fail because of this.
  * - A directory "." means to put the backup file in the same directory
  *   as the edited file.
- * - A directory starting with "./" (or ".\" for MS-DOS et al.) means to
- *   put the backup file relative to where the edited file is.  The
- *   leading "." is replaced with the path name of the edited file.
+ * - A directory starting with "./" (or ".\" for MS-Windows) means to put
+ *   the backup file relative to where the edited file is.  The leading
+ *   "." is replaced with the path name of the edited file.
  *   ("." inside a directory name has no special meaning).
  * - Spaces after the comma are ignored, other spaces are considered part
  *   of the directory name.  To have a space at the start of a directory
@@ -2206,9 +2208,9 @@ export const digraph = {
  *   the edited file.  On Unix, a dot is prepended to the file name, so
  *   it doesn't show in a directory listing.  On MS-Windows the "hidden"
  *   attribute is set and a dot prepended if possible.
- * - A directory starting with "./" (or ".\" for MS-DOS et al.) means to
- *   put the swap file relative to where the edited file is.  The leading
- *   "." is replaced with the path name of the edited file.
+ * - A directory starting with "./" (or ".\" for MS-Windows) means to put
+ *   the swap file relative to where the edited file is.  The leading "."
+ *   is replaced with the path name of the edited file.
  * - For Unix and Win32, if a directory ends in two path separators "//",
  *   the swap file name will be built from the complete path to the file
  *   with all path separators substituted to percent '%' signs. This will
@@ -3662,12 +3664,11 @@ export const grepprg = {
 /**
  *
  * 		{only available when compiled with GUI enabled, and
- * 		for MS-DOS and Win32 console}
+ * 		for Win32 console}
  * This option tells Vim what the cursor should look like in different
- * modes.  It fully works in the GUI.  In an MSDOS or Win32 console, only
- * the height of the cursor can be changed.  This can be done by
- * specifying a block cursor, or a percentage for a vertical or
- * horizontal cursor.
+ * modes.  It fully works in the GUI.  In a Win32 console, only the
+ * height of the cursor can be changed.  This can be done by specifying a
+ * block cursor, or a percentage for a vertical or horizontal cursor.
  * For a console the 't_SI', 't_SR', and 't_EI' escape sequences are
  * used.
  */
@@ -4874,8 +4875,8 @@ export const keywordprg = {
  * be able to execute Normal mode commands.
  * This is the opposite of the 'keymap' option, where characters are
  * mapped in Insert mode.
- * Also consider resetting 'langremap' to avoid 'langmap' applies to
- * characters resulting from a mapping.
+ * Also consider setting 'langremap' to off, to prevent 'langmap' from
+ * applying to characters resulting from a mapping.
  * This option cannot be set from a |modeline| or in the |sandbox|, for
  * security reasons.
  */
@@ -5734,7 +5735,7 @@ export const modified = {
  * default because it makes using the pull down menus a little goofy, as
  * a pointer transit may activate a window unintentionally.
  * MS-Windows: Also see 'scrollfocus' for what window is scrolled when
- * using the mouse scroll whel.
+ * using the mouse scroll wheel.
  */
 export const mousefocus = {
   async get(denops: Denops): Promise<boolean> {
@@ -5872,7 +5873,7 @@ export const mouseshape = {
 
 /**
  *
- * Only for GUI, MS-DOS, Win32 and Unix with xterm.  Defines the maximum
+ * Only for GUI, Win32 and Unix with xterm.  Defines the maximum
  * time in msec between two mouse clicks for the second click to be
  * recognized as a multi click.
  */
@@ -6048,7 +6049,7 @@ export const omnifunc = {
 
 /**
  *
- * 		{only for MS-DOS, MS-Windows and OS/2}
+ * 		{only for MS-Windows}
  * Enable reading and writing from devices.  This may get Vim stuck on a
  * device that can be opened but doesn't actually do the I/O.  Therefore
  * it is off by default.
@@ -7078,6 +7079,7 @@ export const rulerformat = {
  *   compiler/	compiler files |:compiler|
  *   doc/		documentation |write-local-help|
  *   ftplugin/	filetype plugins |write-filetype-plugin|
+ *   import/	files that are found by `:import`
  *   indent/	indent scripts |indent-expression|
  *   keymap/	key mapping files |mbyte-keymap|
  *   lang/		menu translations |:menutrans|
@@ -7490,13 +7492,13 @@ export const shell = {
 /**
  *
  * Flag passed to the shell to execute "!" and ":!" commands; e.g.,
- * "bash.exe -c ls" or "command.com /c dir".  For the MS-DOS-like
- * systems, the default is set according to the value of 'shell', to
- * reduce the need to set this option by the user.
+ * "bash.exe -c ls" or "cmd.exe /c dir".  For MS-Windows, the default is
+ * set according to the value of 'shell', to reduce the need to set this
+ * option by the user.
  * On Unix it can have more than one flag.  Each white space separated
  * part is passed as an argument to the shell command.
  * See |option-backslash| about including spaces and backslashes.
- * Also see |dos-shell| for MS-DOS and MS-Windows.
+ * Also see |dos-shell| for MS-Windows.
  * This option cannot be set from a |modeline| or in the |sandbox|, for
  * security reasons.
  */
@@ -7531,8 +7533,9 @@ export const shellcmdflag = {
  * The name of the temporary file can be represented by "%s" if necessary
  * (the file name is appended automatically if no %s appears in the value
  * of this option).
- * For the Amiga and MS-DOS the default is ">".  The output is directly
- * saved in a file and not echoed to the screen.
+ * For the Amiga the default is ">".  For MS-Windows the default is
+ * ">%s 2>&1".  The output is directly saved in a file and not echoed to
+ * the screen.
  * For Unix the default it "| tee".  The stdout of the compiler is saved
  * in a file and echoed to the screen.  If the 'shell' option is "csh" or
  * "tcsh" after initializations, the default becomes "|& tee".  If the
@@ -7582,10 +7585,10 @@ export const shellpipe = {
  * quoting.  See 'shellxquote' to include the redirection.  It's
  * probably not useful to set both options.
  * This is an empty string by default.  Only known to be useful for
- * third-party shells on MS-DOS-like systems, such as the MKS Korn Shell
- * or bash, where it should be "\"".  The default is adjusted according
- * the value of 'shell', to reduce the need to set this option by the
- * user.  See |dos-shell|.
+ * third-party shells on MS-Windows-like systems, such as the MKS Korn
+ * Shell or bash, where it should be "\"".  The default is adjusted
+ * according the value of 'shell', to reduce the need to set this option
+ * by the user.  See |dos-shell|.
  * This option cannot be set from a |modeline| or in the |sandbox|, for
  * security reasons.
  */
@@ -7657,11 +7660,11 @@ export const shellredir = {
 
 /**
  *
- * 		{only for MSDOS, MS-Windows and OS/2}
+ * 		{only for MS-Windows}
  * When set, a forward slash is used when expanding file names.  This is
- * useful when a Unix-like shell is used instead of command.com or
- * cmd.exe.  Backward slashes can still be typed, but they are changed to
- * forward slashes by Vim.
+ * useful when a Unix-like shell is used instead of cmd.exe.  Backward
+ * slashes can still be typed, but they are changed to forward slashes by
+ * Vim.
  * Note that setting or resetting this option has no effect for some
  * existing file names, thus this option needs to be set before opening
  * any file for best results.  This might change in the future.
@@ -9778,7 +9781,7 @@ export const viewdir = {
  *    slash	backslashes in file names replaced with forward
  * 		slashes
  *    unix		with Unix end-of-line format (single <NL>), even when
- * 		on Windows or DOS
+ * 		on MS-Windows
  *    curdir	the window-local directory, if set with `:lcd`
  */
 export const viewoptions = {
@@ -10564,7 +10567,7 @@ export const writebackup = {
  *
  * The number of milliseconds to wait for each character sent to the
  * screen.  When non-zero, characters are sent to the terminal one by
- * one.  For MS-DOS pcterm this does not work.  For debugging purposes.
+ * one.  For debugging purposes.
  */
 export const writedelay = {
   async get(denops: Denops): Promise<number> {

--- a/denops_std/option/vim/_generated.ts
+++ b/denops_std/option/vim/_generated.ts
@@ -147,9 +147,9 @@ export const compatible = {
  * When this option is set it overrules 'shellslash' for completion:
  * - When this option is set to "slash", a forward slash is used for path
  *   completion in insert mode. This is useful when editing HTML tag, or
- *   Makefile with 'noshellslash' on Windows.
+ *   Makefile with 'noshellslash' on MS-Windows.
  * - When this option is set to "backslash", backslash is used. This is
- *   useful when editing a batch file with 'shellslash' set on Windows.
+ *   useful when editing a batch file with 'shellslash' set on MS-Windows.
  * - When this option is empty, same character is used as for
  *   'shellslash'.
  * For Insert mode completion the buffer-local value is used.  For
@@ -921,7 +921,7 @@ export const renderoptions = {
 
 /**
  *
- * 		{only in Windows 95/NT console version}
+ * 		{only in MS-Windows console version}
  * When set, the screen contents is restored when exiting Vim.  This also
  * happens when executing external commands.
  */
@@ -1011,11 +1011,9 @@ export const shelltype = {
  * Filenames are assumed to be 8 characters plus one extension of 3
  * characters.  Multiple dots in file names are not allowed.  When this
  * option is on, dots in file names are replaced with underscores when
- * adding an extension (".~" or ".swp").  This option is not available
- * for MS-DOS, because then it would always be on.  This option is useful
+ * adding an extension (".~" or ".swp").  This option is useful
  * when editing files on an MS-DOS compatible filesystem, e.g., messydos
- * or crossdos.  When running the Win32 GUI version under Win32s, this
- * option is always on by default.
+ * or crossdos.
  */
 export const shortname = {
   async get(denops: Denops): Promise<boolean> {
@@ -1679,7 +1677,7 @@ export const vartabstop = {
  * r	Removable media.  The argument is a string (up to the next
  * 	',').  This parameter can be given several times.  Each
  * 	specifies the start of a path for which no marks will be
- * 	stored.  This is to avoid removable media.  For MS-DOS you
+ * 	stored.  This is to avoid removable media.  For MS-Windows you
  * 	could use "ra:,rb:", for Amiga "rdf0:,rdf1:,rdf2:".  You can
  * 	also use it for temp files, e.g., for Unix: "r/tmp".  Case is
  * 	ignored.  Maximum length of each 'r' argument is 50

--- a/scripts/gen-function/gen-function.ts
+++ b/scripts/gen-function/gen-function.ts
@@ -10,7 +10,7 @@ import { parse } from "./parse.ts";
 import { format } from "./format.ts";
 import { downloadString } from "./utils.ts";
 
-const VIM_VERSION = "8.1.2424";
+const VIM_VERSION = "8.2.0662";
 const NVIM_VERSION = "0.4.4";
 
 const manualFnSet = new Set([

--- a/scripts/gen-option/gen-option.ts
+++ b/scripts/gen-option/gen-option.ts
@@ -10,7 +10,7 @@ import { parse } from "./parse.ts";
 import { format } from "./format.ts";
 import { downloadString } from "./utils.ts";
 
-const VIM_VERSION = "8.1.2424";
+const VIM_VERSION = "8.2.0662";
 const NVIM_VERSION = "0.4.4";
 
 const manualOptionSet = new Set([


### PR DESCRIPTION
While denops.vim itself drop support Vim before 8.2.0662 (https://github.com/vim-denops/denops.vim/pull/97)