### PR TITLE
:+1: Define behaviors of BatchHelper/GatherHelper instances outside of the block

### DIFF
--- a/denops_std/batch/README.md
+++ b/denops_std/batch/README.md
@@ -88,8 +88,8 @@ export async function main(denops: Denops): Promise<void> {
 
 Not like `batch`, the function can NOT be nested.
 
-Note that `denops.call()`, `denops.batch()`, or `denops.eval()` always return
-falsy value in `gather()`, indicating that you **cannot** write code like below:
+Note that `denops.call()` or `denops.eval()` always return falsy value in
+`gather()`, indicating that you **cannot** write code like below:
 
 ```typescript
 import { Denops } from "https://deno.land/x/denops_std/mod.ts";
@@ -106,3 +106,7 @@ export async function main(denops: Denops): Promise<void> {
   });
 }
 ```
+
+The `denops` instance passed to the `gather` block is NOT available outside of
+the block. An error is thrown when `denops.call()`, `denops.cmd()`, or
+`denops.eval()` is called.

--- a/denops_std/batch/README.md
+++ b/denops_std/batch/README.md
@@ -67,6 +67,33 @@ export async function main(denops: Denops): Promise<void> {
 }
 ```
 
+The `denops` instance passed to the `batch` block is available even outside of
+the block. It works like a real `denops` instance, mean that you can write code
+like:
+
+```typescript
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { batch } from "https://deno.land/x/denops_std/batch/mod.ts";
+import * as anonymous from "https://deno.land/x/denops_std/anonymous/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  await batch(denops, async (denops) => {
+    const [id] = anonymous.add(denops, () => {
+      // This code is called outside of 'batch' block
+      // thus the 'denops' instance works like a real one.
+      // That's why you can write code like below
+      if (await denops.eval("&verbose")) {
+        await denops.cmd("echomsg 'VERBOSE'");
+      }
+      await denops.cmd("echomsg 'Hello world'");
+    });
+    await denops.cmd(
+      `command! Test call denops#request('${denops.name}', '${id}', [])`,
+    );
+  });
+}
+```
+
 ### gather
 
 Use `gather()` to call multiple denops functions sequentially without overhead

--- a/denops_std/batch/batch.ts
+++ b/denops_std/batch/batch.ts
@@ -3,14 +3,20 @@ import { Context, Denops, Dispatcher, Meta } from "../deps.ts";
 class BatchHelper implements Denops {
   #denops: Denops;
   #calls: [string, ...unknown[]][];
+  #closed: boolean;
 
   constructor(denops: Denops) {
     this.#denops = denops;
     this.#calls = [];
+    this.#closed = false;
   }
 
   static getCalls(helper: BatchHelper): [string, ...unknown[]][] {
     return helper.#calls;
+  }
+
+  static close(helper: BatchHelper): void {
+    helper.#closed = true;
   }
 
   get name(): string {
@@ -30,21 +36,33 @@ class BatchHelper implements Denops {
   }
 
   call(fn: string, ...args: unknown[]): Promise<unknown> {
+    if (this.#closed) {
+      return this.#denops.call(fn, ...args);
+    }
     this.#calls.push([fn, ...args]);
     return Promise.resolve();
   }
 
   batch(...calls: [string, ...unknown[]][]): Promise<unknown[]> {
+    if (this.#closed) {
+      return this.#denops.batch(...calls);
+    }
     this.#calls.push(...calls);
     return Promise.resolve([]);
   }
 
   cmd(cmd: string, ctx: Context = {}): Promise<void> {
+    if (this.#closed) {
+      return this.#denops.cmd(cmd, ctx);
+    }
     this.call("denops#api#cmd", cmd, ctx);
     return Promise.resolve();
   }
 
   eval(expr: string, ctx: Context = {}): Promise<unknown> {
+    if (this.#closed) {
+      return this.#denops.eval(expr, ctx);
+    }
     this.call("denops#api#eval", expr, ctx);
     return Promise.resolve();
   }
@@ -62,7 +80,11 @@ export async function batch(
   main: (helper: BatchHelper) => Promise<void>,
 ): Promise<void> {
   const helper = new BatchHelper(denops);
-  await main(helper);
+  try {
+    await main(helper);
+  } finally {
+    BatchHelper.close(helper);
+  }
   const calls = BatchHelper.getCalls(helper);
   await denops.batch(...calls);
 }

--- a/denops_std/batch/batch_test.ts
+++ b/denops_std/batch/batch_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, test } from "../deps_test.ts";
-import { batch } from "./batch.ts";
+import { batch, BatchHelper } from "./batch.ts";
 
 test({
   mode: "any",
@@ -127,6 +127,36 @@ test({
       "7",
       "8",
       "9",
+    ]);
+  },
+});
+test({
+  mode: "any",
+  name:
+    "The 'helper' instance passed in batch block is available outside of the block",
+  fn: async (denops) => {
+    await denops.cmd("let g:denops_batch_test = []");
+    await denops.cmd(
+      "command! -nargs=1 DenopsBatchTest let g:denops_batch_test += [<f-args>]",
+    );
+
+    let helper: BatchHelper;
+    await batch(denops, (denops) => {
+      helper = denops;
+      return Promise.resolve();
+    });
+    await helper!.call("execute", "DenopsBatchTest 1");
+    await helper!.batch(["execute", "DenopsBatchTest 1"]);
+    await helper!.cmd("DenopsBatchTest 1");
+    assertEquals(
+      await helper!.eval("add(g:denops_batch_test, string(1))"),
+      ["1", "1", "1", "1"],
+    );
+    assertEquals(await denops.eval("g:denops_batch_test") as string[], [
+      "1",
+      "1",
+      "1",
+      "1",
     ]);
   },
 });


### PR DESCRIPTION
1. `BatchHelper` instance is available outside of the `batch` block and works like a real `denops` instance
2. `GatherHelper` instance is NOT available outside of the `gather` block and errors are thrown