### PR TITLE
:+1: Add `bufname` module

### DIFF
--- a/denops_std/README.md
+++ b/denops_std/README.md
@@ -59,6 +59,7 @@ for more details.
 | [`anonymous`](./anonymous) | A module to provide anonymous function                           |
 | [`autocmd`](./autocmd)     | A module to provide helper functions to manage `autocmd`         |
 | [`batch`](./batch)         | A module to provide wrapper functions of `denops.batch()`        |
+| [`bufname`](./bufname)     | A module to provide helper functions to manage Vim's buffer name |
 | [`function`](./function)   | A module to provide functions of Vim and Neovim native functions |
 | [`helper`](./helper)       | A module to provide helper functions                             |
 | [`mapping`](./mapping)     | A module to provide helper functions to manage mappings          |

--- a/denops_std/bufname/README.md
+++ b/denops_std/bufname/README.md
@@ -1,0 +1,100 @@
+# bufname
+
+`bufname` is a module to provide manage Vim's buffer name.
+
+- [API documentation](https://doc.deno.land/https/deno.land/x/denops_std/bufname/mod.ts)
+
+## Usage
+
+### format
+
+Use `format()` to format a Vim's buffer name in a safe way from `Bufname`
+instance like:
+
+```typescript
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { format } from "https://deno.land/x/denops_std/bufname/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  assertEquals(
+    format({ scheme: "denops", path: "/Users/johntitor/.vimrc" }),
+    "denops:///Users/johntitor/.vimrc",
+  );
+
+  assertEquals(
+    format({
+      scheme: "denops",
+      path: "/Users/johntitor/.vimrc",
+      params: {
+        foo: "foo",
+        bar: ["bar", "bar"],
+        hoge: undefined,
+      },
+    }),
+    "denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar",
+  );
+
+  assertEquals(
+    format({
+      scheme: "denops",
+      path: "/Users/johntitor/.vimrc",
+      params: {
+        foo: "foo",
+        bar: ["bar", "bar"],
+        hoge: undefined,
+      },
+      fragment: "README.md",
+    }),
+    "denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md",
+  );
+}
+```
+
+Note that unusable characters (`"`, `<`, `>`, `|`, `?`, `*`) are replaced with
+percent-encoded characters.
+
+### parse
+
+Use `parse()` to parse Vim's buffer name and get a `Bufname` instance like
+
+```typescript
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { Denops } from "https://deno.land/x/denops_std/mod.ts";
+import { parse } from "https://deno.land/x/denops_std/bufname/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  assertEquals(parse("denops:///Users/johntitor/.vimrc"), {
+    scheme: "denops",
+    path: "/Users/johntitor/.vimrc",
+  });
+
+  assertEquals(
+    parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar"),
+    {
+      scheme: "denops",
+      path: "/Users/johntitor/.vimrc",
+      params: {
+        foo: "foo",
+        bar: ["bar", "bar"],
+      },
+    },
+  );
+
+  assertEquals(
+    parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md"),
+    {
+      scheme: "denops",
+      path: "/Users/johntitor/.vimrc",
+      params: {
+        foo: "foo",
+        bar: ["bar", "bar"],
+      },
+      fragment: "README.md",
+    },
+  );
+}
+```
+
+Note that percent-encoded characters of unusable characters (`"`, `<`, `>`, `|`,
+`?`, `*`) are restored.

--- a/denops_std/bufname/bufname.ts
+++ b/denops_std/bufname/bufname.ts
@@ -1,0 +1,119 @@
+import { bufnameUnusablePattern, decode, encode } from "./utils.ts";
+
+export type BufnameParams = Record<string, string | string[] | undefined>;
+
+export type Bufname = {
+  // Scheme part of a buffer name. Note that Vim supports only alphabets in scheme part.
+  scheme: string;
+  // Path part of a buffer name. Note that '<>|?*' are not supported in Vim on Windows.
+  path: string;
+  // Params part of a buffer name. While '?' is not supported, the params part are splitted by ';' instead.
+  params?: BufnameParams;
+  // Fragment part of a buffer name. This is mainly used to regulate the suffix of the buffer name.
+  fragment?: string;
+};
+
+// Vim only supports alphabet characters in the scheme part of a buffer name.
+// That behavior has slightly improved from Vim 8.2.3153 but we suppor Vim 8.2.0662
+// thus we need to stack old behavior
+// https://github.com/vim/vim/pull/8299
+const schemeUnusablePattern = /[^a-zA-Z]/;
+
+// Vim assumes a bufname is URL when it starts with "name://"
+// https://github.com/vim/vim/blob/36698e34aacee4186e6f5f87f431626752fcb337/src/misc1.c#L2567-L2580
+const schemePattern = /^(\S+):\/\//;
+
+// The path part might contains query and/or fragment
+const pathPattern = /^(.*?)(?:;(.*?))?(?:#(.*))?$/;
+
+/**
+ * Format Bufname instance to construct Vim's buffer name.
+ */
+export function format({ scheme, path, params, fragment }: Bufname): string {
+  if (schemeUnusablePattern.test(scheme)) {
+    throw new Error(
+      `Scheme '${scheme}' contains unusable characters. Only alphabets are allowed.`,
+    );
+  }
+  const encodedPath = encode(path).replaceAll(";", "%3b").replaceAll(
+    "#",
+    "%23",
+  );
+  const suffix1 = params
+    ? `;${encode(toURLSearchParams(params).toString())}`
+    : "";
+  const suffix2 = fragment ? `#${encode(fragment)}` : "";
+  return `${scheme}://${encodedPath}${suffix1}${suffix2}`;
+}
+
+/**
+ * Parse Vim's buffer name to construct Bufname instance.
+ */
+export function parse(expr: string): Bufname {
+  if (bufnameUnusablePattern.test(expr)) {
+    throw new Error(
+      `Expression '${expr}' contains unusable characters. Vim (on Windows) does not support '<>|?*' in a buffer name.`,
+    );
+  }
+  // Check if the bufname is remote
+  const m1 = expr.match(schemePattern);
+  if (!m1) {
+    throw new Error(`Expression '${expr}' does not start from '{scheme}://'.`);
+  }
+  const scheme = m1[1];
+  // Vim (less than 8.2.3153) only supports alphabets in scheme part
+  if (schemeUnusablePattern.test(scheme)) {
+    throw new Error(
+      `Scheme '${scheme}' contains unusable characters. Only alphabets are allowed.`,
+    );
+  }
+  const remain = decode(expr.substring(`${scheme}://`.length), [
+    "%3b", // ;
+    "%23", // #
+  ]);
+  const m2 = remain.match(pathPattern)!;
+  const path = decode(m2[1]);
+  const params = m2[2]
+    ? fromURLSearchParams(new URLSearchParams(decode(m2[2])))
+    : undefined;
+  const fragment = m2[3] ? decode(m2[3]) : undefined;
+  return {
+    scheme,
+    path,
+    ...(params ? { params } : {}),
+    ...(fragment ? { fragment } : {}),
+  };
+}
+
+function toURLSearchParams(params: BufnameParams): URLSearchParams {
+  const cs = Object.entries(params).flatMap(
+    ([key, value]): [string, string][] => {
+      if (value == undefined) {
+        return [];
+      } else if (Array.isArray(value)) {
+        return value.map((v) => [key, v]);
+      } else {
+        return [[key, value]];
+      }
+    },
+  );
+  return new URLSearchParams(cs);
+}
+
+function fromURLSearchParams(search: URLSearchParams): BufnameParams {
+  const params: BufnameParams = {};
+  search.forEach((value, key) => {
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      const previous = params[key];
+      if (Array.isArray(previous)) {
+        previous.push(value);
+        return;
+      } else if (previous != undefined) {
+        params[key] = [previous, value];
+        return;
+      }
+    }
+    params[key] = value;
+  });
+  return params;
+}

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -1,0 +1,264 @@
+import { assertEquals, assertThrows } from "../deps_test.ts";
+import { format, parse } from "./bufname.ts";
+
+Deno.test("format throws exception when 'scheme' contains unusable characters", () => {
+  assertThrows(
+    () =>
+      format({
+        scheme: "denops0number",
+        path: "/absolute/path/to/worktree",
+      }),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () =>
+      format({
+        scheme: "denops+plus",
+        path: "/absolute/path/to/worktree",
+      }),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () =>
+      format({
+        scheme: "denops-minus",
+        path: "/absolute/path/to/worktree",
+      }),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () =>
+      format({
+        scheme: "denops.dot",
+        path: "/absolute/path/to/worktree",
+      }),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () =>
+      format({
+        scheme: "denops_underscore",
+        path: "/absolute/path/to/worktree",
+      }),
+    undefined,
+    "contains unusable characters",
+  );
+});
+Deno.test("format returns buffer name string from Bufname instance", () => {
+  const src = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+  };
+  const dst = format(src);
+  const exp = "denops:///absolute/path/to/worktree";
+  assertEquals(dst, exp);
+});
+Deno.test("format encodes unusable characters in 'path'", () => {
+  const src = {
+    scheme: "denops",
+    path: "<>|?*",
+  };
+  const dst = format(src);
+  const exp = "denops://%3c%3e%7c%3f%2a";
+  assertEquals(dst, exp);
+});
+Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams)", () => {
+  const src = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    params: {
+      foo: "foo",
+      bar: ["bar", "bar"],
+      hoge: undefined,
+    },
+  };
+  const dst = format(src);
+  const exp = "denops:///absolute/path/to/worktree;foo=foo&bar=bar&bar=bar";
+  assertEquals(dst, exp);
+});
+Deno.test("format encodes unusable characters in 'params'", () => {
+  const src = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    params: {
+      foo: "<>|?*",
+    },
+  };
+  const dst = format(src);
+  const exp = "denops:///absolute/path/to/worktree;foo=%3C%3E%7C%3F%2a";
+  assertEquals(dst, exp);
+});
+Deno.test("format returns buffer name string from Bufname instance (with fragment)", () => {
+  const src = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    fragment: "Hello World.md",
+  };
+  const dst = format(src);
+  const exp = "denops:///absolute/path/to/worktree#Hello World.md";
+  assertEquals(dst, exp);
+});
+Deno.test("format encodes unusable characters in 'fragment'", () => {
+  const src = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    fragment: "<>|?*",
+  };
+  const dst = format(src);
+  const exp = "denops:///absolute/path/to/worktree#%3c%3e%7c%3f%2a";
+  assertEquals(dst, exp);
+});
+Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams and fragment)", () => {
+  const src = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    params: {
+      foo: "foo",
+      bar: ["bar", "bar"],
+      hoge: undefined,
+    },
+    fragment: "Hello World.md",
+  };
+  const dst = format(src);
+  const exp =
+    "denops:///absolute/path/to/worktree;foo=foo&bar=bar&bar=bar#Hello World.md";
+  assertEquals(dst, exp);
+});
+Deno.test("format encodes ';' and '#' in 'path'", () => {
+  const src = {
+    scheme: "denops",
+    path: "hello;world#hello",
+  };
+  const dst = format(src);
+  const exp = "denops://hello%3bworld%23hello";
+  assertEquals(dst, exp);
+});
+
+Deno.test("parse throws exception when 'expr' contains unusable characters", () => {
+  const src = "denops://<>|?*";
+  assertThrows(
+    () => {
+      parse(src);
+    },
+    undefined,
+    "contains unusable characters",
+  );
+});
+Deno.test("parse throws exception when scheme part of 'expr' contains unusable characters", () => {
+  assertThrows(
+    () => parse("denops0number://absolute/path/to/worktree"),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () => parse("denops+plus://absolute/path/to/worktree"),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () => parse("denops+minus://absolute/path/to/worktree"),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () => parse("denops.dot://absolute/path/to/worktree"),
+    undefined,
+    "contains unusable characters",
+  );
+  assertThrows(
+    () => parse("denops_underscore://absolute/path/to/worktree"),
+    undefined,
+    "contains unusable characters",
+  );
+});
+Deno.test("parse returns Bufname instance from buffer name", () => {
+  const src = "denops:///absolute/path/to/worktree";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse decodes percent-encoded characters in 'path'", () => {
+  const src = "denops://%3c%3e%7c%3f%2a";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "<>|?*",
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse returns Bufname instance from buffer name (with params)", () => {
+  const src = "denops:///absolute/path/to/worktree;foo=foo&bar=bar&bar=bar";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    params: {
+      foo: "foo",
+      bar: ["bar", "bar"],
+    },
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse decodes percent-encoded characters in 'params'", () => {
+  const src = "denops:///absolute/path/to/worktree;foo=%3C%3E%7C%3F%2a";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    params: {
+      foo: "<>|?*",
+    },
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse returns Bufname instance from buffer name (with fragment)", () => {
+  const src = "denops:///absolute/path/to/worktree#Hello World.md";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    fragment: "Hello World.md",
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse decodes percent-encoded characters in 'fragment'", () => {
+  const src = "denops:///absolute/path/to/worktree#%3c%3e%7c%3f%2a";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    fragment: "<>|?*",
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse returns Bufname instance from buffer name (with params and fragment)", () => {
+  const src =
+    "denops:///absolute/path/to/worktree;foo=foo&bar=bar&bar=bar#Hello World.md";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "/absolute/path/to/worktree",
+    params: {
+      foo: "foo",
+      bar: ["bar", "bar"],
+    },
+    fragment: "Hello World.md",
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse decode percent-encoded characters (';' and '#') in 'path'", () => {
+  const src = "denops://hello%3bworld%23hello";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    path: "hello;world#hello",
+  };
+  assertEquals(dst, exp);
+});

--- a/denops_std/bufname/mod.ts
+++ b/denops_std/bufname/mod.ts
@@ -1,0 +1,1 @@
+export * from "./bufname.ts";

--- a/denops_std/bufname/utils.ts
+++ b/denops_std/bufname/utils.ts
@@ -1,0 +1,32 @@
+// Vim on Windows does not support following characters in bufname
+export const bufnameUnusablePattern = /["<>\|\?\*]/g;
+
+// % encoded character
+const encodedCharacterPattern = /(?:%[0-9a-fA-F]{2})+/g;
+
+/**
+ * Encode unusable characters to percent-encoded characters.
+ */
+export function encode(expr: string): string {
+  expr = expr.replaceAll(
+    bufnameUnusablePattern,
+    (c) => `%${c.codePointAt(0)!.toString(16)}`,
+  );
+  return expr;
+}
+
+/**
+ * Decode all percent-encoded characters.
+ */
+export function decode(expr: string, excludes?: string[]): string {
+  expr = expr.replaceAll(
+    encodedCharacterPattern,
+    (m) => {
+      if (excludes?.includes(m.toLowerCase())) {
+        return m;
+      }
+      return decodeURIComponent(m);
+    },
+  );
+  return expr;
+}

--- a/denops_std/bufname/utils_test.ts
+++ b/denops_std/bufname/utils_test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "../deps_test.ts";
+import { decode, encode } from "./utils.ts";
+
+Deno.test("encode does nothing on alphabet characters", () => {
+  const src = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
+  const dst = encode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test("encode does nothing on numeric characters", () => {
+  const src = "1234567890";
+  const dst = encode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test('encode encodes some symbol characters ("<>|?*)', () => {
+  const src = " !\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~";
+  const dst = encode(src);
+  const exp = " !%22#$%&'()%2a+,-./:;%3c=%3e%3f@[\\]^`{%7c}~";
+  assertEquals(dst, exp);
+});
+Deno.test("encode does nothing on 日本語", () => {
+  const src = "いろはにへへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす";
+  const dst = encode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test("encode does nothing on emoji (🥃)", () => {
+  const src = "🥃";
+  const dst = encode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+
+Deno.test("decode does nothing on alphabet characters", () => {
+  const src = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
+  const dst = decode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test("decode does nothing on numeric characters", () => {
+  const src = "1234567890";
+  const dst = decode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test('decode decodes encoded characters ("<>|?*)', () => {
+  const src = " !%22#$%&'()%2a+,-./:;%3c=%3e%3f@[\\]^`{%7c}~";
+  const dst = decode(src);
+  const exp = " !\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~";
+  assertEquals(dst, exp);
+});
+Deno.test("decode does nothing on 日本語", () => {
+  const src = "いろはにへへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす";
+  const dst = decode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test("decode does nothing on emoji (🥃)", () => {
+  const src = "🥃";
+  const dst = decode(src);
+  const exp = src;
+  assertEquals(dst, exp);
+});
+Deno.test("decode decodes encoded 日本語", () => {
+  const src = encodeURIComponent(
+    "いろはにへへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす",
+  );
+  const dst = decode(src);
+  const exp = "いろはにへへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす";
+  assertEquals(dst, exp);
+});
+Deno.test("decode decodes encoded emoji (🥃)", () => {
+  const src = encodeURIComponent("🥃");
+  const dst = decode(src);
+  const exp = "🥃";
+  assertEquals(dst, exp);
+});

--- a/denops_std/deps.ts
+++ b/denops_std/deps.ts
@@ -3,6 +3,6 @@ export * as hash from "https://deno.land/std@0.106.0/hash/mod.ts#^";
 export * as path from "https://deno.land/std@0.106.0/path/mod.ts#^";
 export { deferred } from "https://deno.land/std@0.106.0/async/mod.ts#^";
 
-export * from "https://deno.land/x/denops_core@v1.9.0/mod.ts#^";
+export * from "https://deno.land/x/denops_core@v1.9.1/mod.ts#^";
 
 export * from "https://deno.land/x/unknownutil@v1.1.0/mod.ts";

--- a/denops_std/deps_test.ts
+++ b/denops_std/deps_test.ts
@@ -1,3 +1,3 @@
 export * from "https://deno.land/std@0.106.0/testing/asserts.ts#^";
 
-export * from "https://deno.land/x/denops_core@v1.9.0/test/mod.ts#^";
+export * from "https://deno.land/x/denops_core@v1.9.1/test/mod.ts#^";

--- a/denops_std/helper/load_test.ts
+++ b/denops_std/helper/load_test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
 import { load } from "./load.ts";
 
 const loadScriptUrlBase =
-  "https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.0/denops_std/helper/";
+  "https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/";
 
 test({
   mode: "any",


### PR DESCRIPTION
### format

Use `format()` to format a Vim's buffer name in a safe way from `Bufname` instance like:

```typescript
import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
import { Denops } from "https://deno.land/x/denops_std/mod.ts";
import { format } from "https://deno.land/x/denops_std/bufname/mod.ts";
export async function main(denops: Denops): Promise<void> {
  assertEquals(
    format({ scheme: "denops", path: "/Users/johntitor/.vimrc" }),
    "denops:///Users/johntitor/.vimrc",
  );
  assertEquals(
    format({
      scheme: "denops",
      path: "/Users/johntitor/.vimrc",
      params: {
        foo: "foo",
        bar: ["bar", "bar"],
        hoge: undefined,
      },
    }),
    "denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar",
  );
  assertEquals(
    format({
      scheme: "denops",
      path: "/Users/johntitor/.vimrc",
      params: {
        foo: "foo",
        bar: ["bar", "bar"],
        hoge: undefined,
      },
      fragment: "README.md",
    }),
    "denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md",
  );
}
```

Note that unusable characters (`"`, `<`, `>`, `|`, `?`, `*`) are replaced with percent-encoded characters.

### parse

Use `parse()` to parse Vim's buffer name and get a `Bufname` instance like

```typescript
import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
import { Denops } from "https://deno.land/x/denops_std/mod.ts";
import { parse } from "https://deno.land/x/denops_std/bufname/mod.ts";
export async function main(denops: Denops): Promise<void> {
  assertEquals(parse("denops:///Users/johntitor/.vimrc"), {
    scheme: "denops",
    path: "/Users/johntitor/.vimrc",
  });
  assertEquals(
    parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar"),
    {
      scheme: "denops",
      path: "/Users/johntitor/.vimrc",
      params: {
        foo: "foo",
        bar: ["bar", "bar"],
      },
    },
  );
  assertEquals(
    parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md"),
    {
      scheme: "denops",
      path: "/Users/johntitor/.vimrc",
      params: {
        foo: "foo",
        bar: ["bar", "bar"],
      },
      fragment: "README.md",
    },
  );
}
```

Note that percent-encoded characters of unusable characters (`"`, `<`, `>`, `|`,`?`, `*`) are restored.