### PR TITLE
:boom: Improve `bufname` module (with breaking changes)

### DIFF
--- a/denops_std/bufname/README.md
+++ b/denops_std/bufname/README.md
@@ -1,8 +1,49 @@
 # bufname
 
-`bufname` is a module to provide manage Vim's buffer name.
+`bufname` is a module to provide functions to handle Vim's buffer name.
 
 - [API documentation](https://doc.deno.land/https/deno.land/x/denops_std/bufname/mod.ts)
+
+The format of the buffer name assumed in this module is like
+
+```text
+{scheme}://{expr}[;{params}][#{fragment}]
+```
+
+Where
+
+- `{scheme}` is used to distinguish a buffer kind. It contains only alphabet
+  characters.
+- `{expr}` is used to identify a buffer itself. _Unusable characters_,
+  semicolons (;), and sharps (#) are replaced with percent-encoded characters.
+- `{params}` (Optional) is used to add meta information to the buffer name like
+  query parameters of URL. _Unusable characters_ and sharps (#) are replaced
+  with percent-encoded characters.
+- `{fragment}` (Optional) is used to add a suffix to the buffer name for file
+  type detection or so on. _Unusable characters_ are replaced with
+  percent-encoded characters.
+- _Unusable characters_ are `"`, `<`, `>`, `|`, `?`, or `*`. It is caused by the
+  limitations of Vim on Windows.
+
+For example,
+
+```text
+denops:///Users/John Titor/test.git
+└─┬──┘   └───────────┬────────────┘
+  scheme             expr
+
+denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2
+└─┬──┘   └───────────┬────────────┘ └───────────┬───────────┘
+  scheme             expr                       params
+
+denops:///Users/John Titor/test.git#README.md
+└─┬──┘   └───────────┬────────────┘ └───┬───┘
+  scheme             expr               fragment
+
+denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md
+└─┬──┘   └───────────┬────────────┘ └───────────┬───────────┘ └───┬───┘
+  scheme             expr                       params            fragment
+```
 
 ## Usage
 
@@ -13,46 +54,50 @@ instance like:
 
 ```typescript
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
-import { Denops } from "https://deno.land/x/denops_std/mod.ts";
 import { format } from "https://deno.land/x/denops_std/bufname/mod.ts";
 
-export async function main(denops: Denops): Promise<void> {
-  assertEquals(
-    format({ scheme: "denops", expr: "/Users/johntitor/.vimrc" }),
-    "denops:///Users/johntitor/.vimrc",
-  );
+assertEquals(
+  format({
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+  }),
+  "denops:///Users/John Titor/test.git",
+);
 
-  assertEquals(
-    format({
-      scheme: "denops",
-      expr: "/Users/johntitor/.vimrc",
-      params: {
-        foo: "foo",
-        bar: ["bar", "bar"],
-        hoge: undefined,
-      },
-    }),
-    "denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar",
-  );
+assertEquals(
+  format({
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+    params: {
+      foo: "foo",
+      bar: ["bar1", "bar2"],
+    },
+  }),
+  "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2",
+);
 
-  assertEquals(
-    format({
-      scheme: "denops",
-      expr: "/Users/johntitor/.vimrc",
-      params: {
-        foo: "foo",
-        bar: ["bar", "bar"],
-        hoge: undefined,
-      },
-      fragment: "README.md",
-    }),
-    "denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md",
-  );
-}
+assertEquals(
+  format({
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+    fragment: "README.md",
+  }),
+  "denops:///Users/John Titor/test.git#README.md",
+);
+
+assertEquals(
+  format({
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+    params: {
+      foo: "foo",
+      bar: ["bar1", "bar2"],
+    },
+    fragment: "README.md",
+  }),
+  "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md",
+);
 ```
-
-Note that unusable characters (`"`, `<`, `>`, `|`, `?`, `*`) are replaced with
-percent-encoded characters.
 
 ### parse
 
@@ -60,41 +105,49 @@ Use `parse()` to parse Vim's buffer name and get a `Bufname` instance like
 
 ```typescript
 import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
-import { Denops } from "https://deno.land/x/denops_std/mod.ts";
 import { parse } from "https://deno.land/x/denops_std/bufname/mod.ts";
 
-export async function main(denops: Denops): Promise<void> {
-  assertEquals(parse("denops:///Users/johntitor/.vimrc"), {
+assertEquals(
+  parse("denops:///Users/John Titor/test.git"),
+  {
     scheme: "denops",
-    expr: "/Users/johntitor/.vimrc",
-  });
+    expr: "/Users/John Titor/test.git",
+  },
+);
 
-  assertEquals(
-    parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar"),
-    {
-      scheme: "denops",
-      expr: "/Users/johntitor/.vimrc",
-      params: {
-        foo: "foo",
-        bar: ["bar", "bar"],
-      },
+assertEquals(
+  parse("denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2"),
+  {
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+    params: {
+      foo: "foo",
+      bar: ["bar1", "bar2"],
     },
-  );
+  },
+);
 
-  assertEquals(
-    parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md"),
-    {
-      scheme: "denops",
-      expr: "/Users/johntitor/.vimrc",
-      params: {
-        foo: "foo",
-        bar: ["bar", "bar"],
-      },
-      fragment: "README.md",
+assertEquals(
+  parse("denops:///Users/John Titor/test.git#README.md"),
+  {
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+    fragment: "README.md",
+  },
+);
+
+assertEquals(
+  parse(
+    "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md",
+  ),
+  {
+    scheme: "denops",
+    expr: "/Users/John Titor/test.git",
+    params: {
+      foo: "foo",
+      bar: ["bar1", "bar2"],
     },
-  );
-}
+    fragment: "README.md",
+  },
+);
 ```
-
-Note that percent-encoded characters of unusable characters (`"`, `<`, `>`, `|`,
-`?`, `*`) are restored.

--- a/denops_std/bufname/README.md
+++ b/denops_std/bufname/README.md
@@ -18,14 +18,14 @@ import { format } from "https://deno.land/x/denops_std/bufname/mod.ts";
 
 export async function main(denops: Denops): Promise<void> {
   assertEquals(
-    format({ scheme: "denops", path: "/Users/johntitor/.vimrc" }),
+    format({ scheme: "denops", expr: "/Users/johntitor/.vimrc" }),
     "denops:///Users/johntitor/.vimrc",
   );
 
   assertEquals(
     format({
       scheme: "denops",
-      path: "/Users/johntitor/.vimrc",
+      expr: "/Users/johntitor/.vimrc",
       params: {
         foo: "foo",
         bar: ["bar", "bar"],
@@ -38,7 +38,7 @@ export async function main(denops: Denops): Promise<void> {
   assertEquals(
     format({
       scheme: "denops",
-      path: "/Users/johntitor/.vimrc",
+      expr: "/Users/johntitor/.vimrc",
       params: {
         foo: "foo",
         bar: ["bar", "bar"],
@@ -66,14 +66,14 @@ import { parse } from "https://deno.land/x/denops_std/bufname/mod.ts";
 export async function main(denops: Denops): Promise<void> {
   assertEquals(parse("denops:///Users/johntitor/.vimrc"), {
     scheme: "denops",
-    path: "/Users/johntitor/.vimrc",
+    expr: "/Users/johntitor/.vimrc",
   });
 
   assertEquals(
     parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar"),
     {
       scheme: "denops",
-      path: "/Users/johntitor/.vimrc",
+      expr: "/Users/johntitor/.vimrc",
       params: {
         foo: "foo",
         bar: ["bar", "bar"],
@@ -85,7 +85,7 @@ export async function main(denops: Denops): Promise<void> {
     parse("denops:///Users/johntitor/.vimrc;foo=foo&bar=bar&bar=bar#README.md"),
     {
       scheme: "denops",
-      path: "/Users/johntitor/.vimrc",
+      expr: "/Users/johntitor/.vimrc",
       params: {
         foo: "foo",
         bar: ["bar", "bar"],

--- a/denops_std/bufname/README.md
+++ b/denops_std/bufname/README.md
@@ -99,6 +99,27 @@ assertEquals(
 );
 ```
 
+This function does not handle path separator differences among platforms (Unix
+uses `/` but Windows uses `\`). That's why it's recommended to normalize the
+`expr` with [`toFileUrl`](https://deno.land/std/path#tofileurl) before when
+constructing a buffer name from a real path. For example
+
+```typescript
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import * as path from "https://deno.land/std/path/mod.ts";
+import { format } from "https://deno.land/x/denops_std/bufname/mod.ts";
+
+// NOTE:
+// Works only on Windows (Use path.win32.toFileUrl instead on other platforms)
+assertEquals(
+  format({
+    scheme: "denops",
+    expr: path.toFileUrl("C:\\Users\John Titor\test.git").pathname,
+  }),
+  "denops:///C:/Users/John%20Titor/test.git",
+);
+```
+
 ### parse
 
 Use `parse()` to parse Vim's buffer name and get a `Bufname` instance like
@@ -149,5 +170,28 @@ assertEquals(
     },
     fragment: "README.md",
   },
+);
+```
+
+This function does not handle path separator differences among platforms. That's
+why it's recommended to restore the `expr` with
+[`fromFileUrl`](https://deno.land/std/path#fromfileurl) after if a buffer name
+was constructed from a real path. For example
+
+```typescript
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import * as path from "https://deno.land/std/path/mod.ts";
+import { parse } from "https://deno.land/x/denops_std/bufname/mod.ts";
+
+const bufname = parse("denops:///C:/Users/John%20Titor/test.git");
+assertEquals(bufname, {
+  scheme: "denops",
+  expr: "/C:/Users/John Titor/test.git",
+});
+// NOTE:
+// Works only on Windows (Use path.win32.fromFileUrl instead on other platforms)
+assertEquals(
+  path.fromFileUrl(`file://${bufname.expr}`),
+  "C:\\Users\\John Titor\\test.git",
 );
 ```

--- a/denops_std/bufname/bufname.ts
+++ b/denops_std/bufname/bufname.ts
@@ -35,7 +35,7 @@ export function format({ scheme, path, params, fragment }: Bufname): string {
       `Scheme '${scheme}' contains unusable characters. Only alphabets are allowed.`,
     );
   }
-  const encodedPath = encode(path).replaceAll(";", "%3b").replaceAll(
+  const encodedPath = encode(path).replaceAll(";", "%3B").replaceAll(
     "#",
     "%23",
   );
@@ -68,7 +68,7 @@ export function parse(expr: string): Bufname {
     );
   }
   const remain = decode(expr.substring(`${scheme}://`.length), [
-    "%3b", // ;
+    "%3B", // ;
     "%23", // #
   ]);
   const m2 = remain.match(pathPattern)!;

--- a/denops_std/bufname/bufname.ts
+++ b/denops_std/bufname/bufname.ts
@@ -27,7 +27,14 @@ const schemePattern = /^(\S+):\/\//;
 const exprPattern = /^(.*?)(?:;(.*?))?(?:#(.*))?$/;
 
 /**
- * Format Bufname instance to construct Vim's buffer name.
+ * Format a `Bufname` instance and return a safe string as Vim's buffer name.
+ *
+ * It throws errors when `scheme` contains unusable characters (non-alphabet characters).
+ *
+ * All unusable characters ("<>|?*) are replaced with percent-encoded characters.
+ * In addition to the above, all semicolons (;) and sharps (#) in `path` are replaced with
+ * percent-encoded characters. It's required to distinguish `params` and or `fragment`.
+ * ```
  */
 export function format(
   { scheme, expr, params, fragment }: Bufname,
@@ -49,7 +56,10 @@ export function format(
 }
 
 /**
- * Parse Vim's buffer name to construct Bufname instance.
+ * Parse Vim's buffer name and return a `Bufname` instance.
+ *
+ * It throws errors when a given `bufname` is not valid Vim's buffer name.
+ * For example, if it contains unusable characters ("<>|?*).
  */
 export function parse(bufname: string): Bufname {
   if (bufnameUnusablePattern.test(bufname)) {

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertThrows } from "../deps_test.ts";
+import { path } from "../deps.ts";
 import { format, parse } from "./bufname.ts";
 
 Deno.test("format throws exception when 'scheme' contains unusable characters", () => {
@@ -191,6 +192,14 @@ Deno.test("format pass example in README.md", () => {
     }),
     "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md",
   );
+
+  assertEquals(
+    format({
+      scheme: "denops",
+      expr: path.win32.toFileUrl("C:\\Users\\John Titor\\test.git").pathname,
+    }),
+    "denops:///C:/Users/John%20Titor/test.git",
+  );
 });
 
 Deno.test("parse throws exception when 'expr' contains unusable characters", () => {
@@ -372,5 +381,18 @@ Deno.test("parse pass example in README.md", () => {
       },
       fragment: "README.md",
     },
+  );
+
+  const bufname = parse("denops:///C:/Users/John%20Titor/test.git");
+  assertEquals(
+    bufname,
+    {
+      scheme: "denops",
+      expr: "/C:/Users/John Titor/test.git",
+    },
+  );
+  assertEquals(
+    path.win32.fromFileUrl(`file://${bufname.expr}`),
+    "C:\\Users\\John Titor\\test.git",
   );
 });

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -60,10 +60,10 @@ Deno.test("format returns buffer name string from Bufname instance", () => {
 Deno.test("format encodes unusable characters in 'path'", () => {
   const src = {
     scheme: "denops",
-    path: "<>|?*",
+    path: "/<>|?*",
   };
   const dst = format(src);
-  const exp = "denops://%3c%3e%7c%3f%2a";
+  const exp = "denops:///%3c%3e%7c%3f%2a";
   assertEquals(dst, exp);
 });
 Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams)", () => {
@@ -131,15 +131,15 @@ Deno.test("format returns buffer name string from Bufname instance (with URLSear
 Deno.test("format encodes ';' and '#' in 'path'", () => {
   const src = {
     scheme: "denops",
-    path: "hello;world#hello",
+    path: "/hello;world#hello",
   };
   const dst = format(src);
-  const exp = "denops://hello%3bworld%23hello";
+  const exp = "denops:///hello%3bworld%23hello";
   assertEquals(dst, exp);
 });
 
 Deno.test("parse throws exception when 'expr' contains unusable characters", () => {
-  const src = "denops://<>|?*";
+  const src = "denops:///<>|?*";
   assertThrows(
     () => {
       parse(src);
@@ -185,11 +185,11 @@ Deno.test("parse returns Bufname instance from buffer name", () => {
   assertEquals(dst, exp);
 });
 Deno.test("parse decodes percent-encoded characters in 'path'", () => {
-  const src = "denops://%3c%3e%7c%3f%2a";
+  const src = "denops:///%3c%3e%7c%3f%2a";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "<>|?*",
+    path: "/<>|?*",
   };
   assertEquals(dst, exp);
 });
@@ -254,11 +254,11 @@ Deno.test("parse returns Bufname instance from buffer name (with params and frag
   assertEquals(dst, exp);
 });
 Deno.test("parse decode percent-encoded characters (';' and '#') in 'path'", () => {
-  const src = "denops://hello%3bworld%23hello";
+  const src = "denops:///hello%3bworld%23hello";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "hello;world#hello",
+    path: "/hello;world#hello",
   };
   assertEquals(dst, exp);
 });

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -137,6 +137,18 @@ Deno.test("format encodes ';' and '#' in 'expr'", () => {
   const exp = "denops:///hello%3Bworld%23hello";
   assertEquals(dst, exp);
 });
+Deno.test("format encodes '#' in 'params'", () => {
+  const src = {
+    scheme: "denops",
+    expr: "/absolute/path/to/worktree",
+    params: {
+      foo: "#foo",
+    },
+  };
+  const dst = format(src);
+  const exp = "denops:///absolute/path/to/worktree;foo=%23foo";
+  assertEquals(dst, exp);
+});
 
 Deno.test("parse throws exception when 'expr' contains unusable characters", () => {
   const src = "denops:///<>|?*";
@@ -259,6 +271,18 @@ Deno.test("parse decode percent-encoded characters (';' and '#') in 'expr'", () 
   const exp = {
     scheme: "denops",
     expr: "/hello;world#hello",
+  };
+  assertEquals(dst, exp);
+});
+Deno.test("parse decode percent-encoded characters ('#') in 'params'", () => {
+  const src = "denops:///absolute/path/to/worktree;foo=%23foo";
+  const dst = parse(src);
+  const exp = {
+    scheme: "denops",
+    expr: "/absolute/path/to/worktree",
+    params: {
+      foo: "#foo",
+    },
   };
   assertEquals(dst, exp);
 });

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -6,7 +6,7 @@ Deno.test("format throws exception when 'scheme' contains unusable characters", 
     () =>
       format({
         scheme: "denops0number",
-        path: "/absolute/path/to/worktree",
+        expr: "/absolute/path/to/worktree",
       }),
     undefined,
     "contains unusable characters",
@@ -15,7 +15,7 @@ Deno.test("format throws exception when 'scheme' contains unusable characters", 
     () =>
       format({
         scheme: "denops+plus",
-        path: "/absolute/path/to/worktree",
+        expr: "/absolute/path/to/worktree",
       }),
     undefined,
     "contains unusable characters",
@@ -24,7 +24,7 @@ Deno.test("format throws exception when 'scheme' contains unusable characters", 
     () =>
       format({
         scheme: "denops-minus",
-        path: "/absolute/path/to/worktree",
+        expr: "/absolute/path/to/worktree",
       }),
     undefined,
     "contains unusable characters",
@@ -33,7 +33,7 @@ Deno.test("format throws exception when 'scheme' contains unusable characters", 
     () =>
       format({
         scheme: "denops.dot",
-        path: "/absolute/path/to/worktree",
+        expr: "/absolute/path/to/worktree",
       }),
     undefined,
     "contains unusable characters",
@@ -42,7 +42,7 @@ Deno.test("format throws exception when 'scheme' contains unusable characters", 
     () =>
       format({
         scheme: "denops_underscore",
-        path: "/absolute/path/to/worktree",
+        expr: "/absolute/path/to/worktree",
       }),
     undefined,
     "contains unusable characters",
@@ -51,16 +51,16 @@ Deno.test("format throws exception when 'scheme' contains unusable characters", 
 Deno.test("format returns buffer name string from Bufname instance", () => {
   const src = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
   };
   const dst = format(src);
   const exp = "denops:///absolute/path/to/worktree";
   assertEquals(dst, exp);
 });
-Deno.test("format encodes unusable characters in 'path'", () => {
+Deno.test("format encodes unusable characters in 'expr'", () => {
   const src = {
     scheme: "denops",
-    path: "/<>|?*",
+    expr: "/<>|?*",
   };
   const dst = format(src);
   const exp = "denops:///%3C%3E%7C%3F%2A";
@@ -69,7 +69,7 @@ Deno.test("format encodes unusable characters in 'path'", () => {
 Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams)", () => {
   const src = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     params: {
       foo: "foo",
       bar: ["bar", "bar"],
@@ -83,7 +83,7 @@ Deno.test("format returns buffer name string from Bufname instance (with URLSear
 Deno.test("format encodes unusable characters in 'params'", () => {
   const src = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     params: {
       foo: "<>|?*",
     },
@@ -95,7 +95,7 @@ Deno.test("format encodes unusable characters in 'params'", () => {
 Deno.test("format returns buffer name string from Bufname instance (with fragment)", () => {
   const src = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     fragment: "Hello World.md",
   };
   const dst = format(src);
@@ -105,7 +105,7 @@ Deno.test("format returns buffer name string from Bufname instance (with fragmen
 Deno.test("format encodes unusable characters in 'fragment'", () => {
   const src = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     fragment: "<>|?*",
   };
   const dst = format(src);
@@ -115,7 +115,7 @@ Deno.test("format encodes unusable characters in 'fragment'", () => {
 Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams and fragment)", () => {
   const src = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     params: {
       foo: "foo",
       bar: ["bar", "bar"],
@@ -128,10 +128,10 @@ Deno.test("format returns buffer name string from Bufname instance (with URLSear
     "denops:///absolute/path/to/worktree;foo=foo&bar=bar&bar=bar#Hello World.md";
   assertEquals(dst, exp);
 });
-Deno.test("format encodes ';' and '#' in 'path'", () => {
+Deno.test("format encodes ';' and '#' in 'expr'", () => {
   const src = {
     scheme: "denops",
-    path: "/hello;world#hello",
+    expr: "/hello;world#hello",
   };
   const dst = format(src);
   const exp = "denops:///hello%3Bworld%23hello";
@@ -180,16 +180,16 @@ Deno.test("parse returns Bufname instance from buffer name", () => {
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
   };
   assertEquals(dst, exp);
 });
-Deno.test("parse decodes percent-encoded characters in 'path'", () => {
+Deno.test("parse decodes percent-encoded characters in 'expr'", () => {
   const src = "denops:///%3C%3E%7C%3F%2A";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/<>|?*",
+    expr: "/<>|?*",
   };
   assertEquals(dst, exp);
 });
@@ -198,7 +198,7 @@ Deno.test("parse returns Bufname instance from buffer name (with params)", () =>
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     params: {
       foo: "foo",
       bar: ["bar", "bar"],
@@ -211,7 +211,7 @@ Deno.test("parse decodes percent-encoded characters in 'params'", () => {
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     params: {
       foo: "<>|?*",
     },
@@ -223,7 +223,7 @@ Deno.test("parse returns Bufname instance from buffer name (with fragment)", () 
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     fragment: "Hello World.md",
   };
   assertEquals(dst, exp);
@@ -233,7 +233,7 @@ Deno.test("parse decodes percent-encoded characters in 'fragment'", () => {
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     fragment: "<>|?*",
   };
   assertEquals(dst, exp);
@@ -244,7 +244,7 @@ Deno.test("parse returns Bufname instance from buffer name (with params and frag
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/absolute/path/to/worktree",
+    expr: "/absolute/path/to/worktree",
     params: {
       foo: "foo",
       bar: ["bar", "bar"],
@@ -253,12 +253,12 @@ Deno.test("parse returns Bufname instance from buffer name (with params and frag
   };
   assertEquals(dst, exp);
 });
-Deno.test("parse decode percent-encoded characters (';' and '#') in 'path'", () => {
+Deno.test("parse decode percent-encoded characters (';' and '#') in 'expr'", () => {
   const src = "denops:///hello%3Bworld%23hello";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
-    path: "/hello;world#hello",
+    expr: "/hello;world#hello",
   };
   assertEquals(dst, exp);
 });

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -149,6 +149,49 @@ Deno.test("format encodes '#' in 'params'", () => {
   const exp = "denops:///absolute/path/to/worktree;foo=%23foo";
   assertEquals(dst, exp);
 });
+Deno.test("format pass example in README.md", () => {
+  assertEquals(
+    format({
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+    }),
+    "denops:///Users/John Titor/test.git",
+  );
+
+  assertEquals(
+    format({
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+      params: {
+        foo: "foo",
+        bar: ["bar1", "bar2"],
+      },
+    }),
+    "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2",
+  );
+
+  assertEquals(
+    format({
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+      fragment: "README.md",
+    }),
+    "denops:///Users/John Titor/test.git#README.md",
+  );
+
+  assertEquals(
+    format({
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+      params: {
+        foo: "foo",
+        bar: ["bar1", "bar2"],
+      },
+      fragment: "README.md",
+    }),
+    "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md",
+  );
+});
 
 Deno.test("parse throws exception when 'expr' contains unusable characters", () => {
   const src = "denops:///<>|?*";
@@ -285,4 +328,49 @@ Deno.test("parse decode percent-encoded characters ('#') in 'params'", () => {
     },
   };
   assertEquals(dst, exp);
+});
+Deno.test("parse pass example in README.md", () => {
+  assertEquals(
+    parse("denops:///Users/John Titor/test.git"),
+    {
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+    },
+  );
+
+  assertEquals(
+    parse("denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2"),
+    {
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+      params: {
+        foo: "foo",
+        bar: ["bar1", "bar2"],
+      },
+    },
+  );
+
+  assertEquals(
+    parse("denops:///Users/John Titor/test.git#README.md"),
+    {
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+      fragment: "README.md",
+    },
+  );
+
+  assertEquals(
+    parse(
+      "denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md",
+    ),
+    {
+      scheme: "denops",
+      expr: "/Users/John Titor/test.git",
+      params: {
+        foo: "foo",
+        bar: ["bar1", "bar2"],
+      },
+      fragment: "README.md",
+    },
+  );
 });

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -63,7 +63,7 @@ Deno.test("format encodes unusable characters in 'path'", () => {
     path: "/<>|?*",
   };
   const dst = format(src);
-  const exp = "denops:///%3c%3e%7c%3f%2a";
+  const exp = "denops:///%3C%3E%7C%3F%2A";
   assertEquals(dst, exp);
 });
 Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams)", () => {
@@ -89,7 +89,7 @@ Deno.test("format encodes unusable characters in 'params'", () => {
     },
   };
   const dst = format(src);
-  const exp = "denops:///absolute/path/to/worktree;foo=%3C%3E%7C%3F%2a";
+  const exp = "denops:///absolute/path/to/worktree;foo=%3C%3E%7C%3F%2A";
   assertEquals(dst, exp);
 });
 Deno.test("format returns buffer name string from Bufname instance (with fragment)", () => {
@@ -109,7 +109,7 @@ Deno.test("format encodes unusable characters in 'fragment'", () => {
     fragment: "<>|?*",
   };
   const dst = format(src);
-  const exp = "denops:///absolute/path/to/worktree#%3c%3e%7c%3f%2a";
+  const exp = "denops:///absolute/path/to/worktree#%3C%3E%7C%3F%2A";
   assertEquals(dst, exp);
 });
 Deno.test("format returns buffer name string from Bufname instance (with URLSearchParams and fragment)", () => {
@@ -134,7 +134,7 @@ Deno.test("format encodes ';' and '#' in 'path'", () => {
     path: "/hello;world#hello",
   };
   const dst = format(src);
-  const exp = "denops:///hello%3bworld%23hello";
+  const exp = "denops:///hello%3Bworld%23hello";
   assertEquals(dst, exp);
 });
 
@@ -185,7 +185,7 @@ Deno.test("parse returns Bufname instance from buffer name", () => {
   assertEquals(dst, exp);
 });
 Deno.test("parse decodes percent-encoded characters in 'path'", () => {
-  const src = "denops:///%3c%3e%7c%3f%2a";
+  const src = "denops:///%3C%3E%7C%3F%2A";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
@@ -207,7 +207,7 @@ Deno.test("parse returns Bufname instance from buffer name (with params)", () =>
   assertEquals(dst, exp);
 });
 Deno.test("parse decodes percent-encoded characters in 'params'", () => {
-  const src = "denops:///absolute/path/to/worktree;foo=%3C%3E%7C%3F%2a";
+  const src = "denops:///absolute/path/to/worktree;foo=%3C%3E%7C%3F%2A";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
@@ -229,7 +229,7 @@ Deno.test("parse returns Bufname instance from buffer name (with fragment)", () 
   assertEquals(dst, exp);
 });
 Deno.test("parse decodes percent-encoded characters in 'fragment'", () => {
-  const src = "denops:///absolute/path/to/worktree#%3c%3e%7c%3f%2a";
+  const src = "denops:///absolute/path/to/worktree#%3C%3E%7C%3F%2A";
   const dst = parse(src);
   const exp = {
     scheme: "denops",
@@ -254,7 +254,7 @@ Deno.test("parse returns Bufname instance from buffer name (with params and frag
   assertEquals(dst, exp);
 });
 Deno.test("parse decode percent-encoded characters (';' and '#') in 'path'", () => {
-  const src = "denops:///hello%3bworld%23hello";
+  const src = "denops:///hello%3Bworld%23hello";
   const dst = parse(src);
   const exp = {
     scheme: "denops",

--- a/denops_std/bufname/mod.ts
+++ b/denops_std/bufname/mod.ts
@@ -1,1 +1,43 @@
+/**
+ * A module to provide functions to handle Vim's buffer name.
+ *
+ * The format of the buffer name assumed in this module is like
+ *
+ * ```text
+ * {scheme}://{expr}[;{params}][#{fragment}]
+ * ```
+ *
+ * Where
+ *
+ * - `{scheme}` is used to distinguish a buffer kind. It contains only alphabet
+ *   characters.
+ * - `{expr}` is used to identify a buffer itself. Unusable characters, semicolons
+ *   (;), and sharps (#) are replaced with percent-encoded characters.
+ * - `{params}` (Optional) is used to add meta information to the buffer name like
+ *   query parameters of URL. Unusable characters and sharps (#) are replaced with
+ *   percent-encoded characters.
+ * - `{fragment}` (Optional) is used to add a suffix to the buffer name for file
+ *   type detection or so on. Unusable characters are replaced with percent-encoded
+ *   characters.
+ *
+ * For example,
+ *
+ * ```text
+ * denops:///Users/John Titor/test.git
+ * └─┬──┘   └───────────┬────────────┘
+ *   scheme             expr
+ *
+ * denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2
+ * └─┬──┘   └───────────┬────────────┘ └───────────┬───────────┘
+ *   scheme             expr                       params
+ *
+ * denops:///Users/John Titor/test.git#README.md
+ * └─┬──┘   └───────────┬────────────┘ └───┬───┘
+ *   scheme             expr               fragment
+ *
+ * denops:///Users/John Titor/test.git;foo=foo&bar=bar1&bar=bar2#README.md
+ * └─┬──┘   └───────────┬────────────┘ └───────────┬───────────┘ └───┬───┘
+ *   scheme             expr                       params            fragment
+ * ```
+ */
 export * from "./bufname.ts";

--- a/denops_std/bufname/utils.ts
+++ b/denops_std/bufname/utils.ts
@@ -10,7 +10,7 @@ const encodedCharacterPattern = /(?:%[0-9a-fA-F]{2})+/g;
 export function encode(expr: string): string {
   expr = expr.replaceAll(
     bufnameUnusablePattern,
-    (c) => `%${c.codePointAt(0)!.toString(16)}`,
+    (c) => `%${c.codePointAt(0)!.toString(16).toUpperCase()}`,
   );
   return expr;
 }
@@ -19,10 +19,11 @@ export function encode(expr: string): string {
  * Decode all percent-encoded characters.
  */
 export function decode(expr: string, excludes?: string[]): string {
+  excludes = (excludes ?? []).map((v) => v.toUpperCase());
   expr = expr.replaceAll(
     encodedCharacterPattern,
     (m) => {
-      if (excludes?.includes(m.toLowerCase())) {
+      if (excludes?.includes(m.toUpperCase())) {
         return m;
       }
       return decodeURIComponent(m);

--- a/denops_std/bufname/utils_test.ts
+++ b/denops_std/bufname/utils_test.ts
@@ -16,7 +16,7 @@ Deno.test("encode does nothing on numeric characters", () => {
 Deno.test('encode encodes some symbol characters ("<>|?*)', () => {
   const src = " !\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~";
   const dst = encode(src);
-  const exp = " !%22#$%&'()%2a+,-./:;%3c=%3e%3f@[\\]^`{%7c}~";
+  const exp = " !%22#$%&'()%2A+,-./:;%3C=%3E%3F@[\\]^`{%7C}~";
   assertEquals(dst, exp);
 });
 Deno.test("encode does nothing on 日本語", () => {
@@ -45,7 +45,7 @@ Deno.test("decode does nothing on numeric characters", () => {
   assertEquals(dst, exp);
 });
 Deno.test('decode decodes encoded characters ("<>|?*)', () => {
-  const src = " !%22#$%&'()%2a+,-./:;%3c=%3e%3f@[\\]^`{%7c}~";
+  const src = " !%22#$%&'()%2A+,-./:;%3C=%3E%3F@[\\]^`{%7C}~";
   const dst = decode(src);
   const exp = " !\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~";
   assertEquals(dst, exp);

--- a/scripts/gen-function/parse.ts
+++ b/scripts/gen-function/parse.ts
@@ -7,7 +7,7 @@ import { Counter, regexIndexOf } from "./utils.ts";
  * It extract a function definition block like below and return
  * a list of `Definition`.
  *
- * ```
+ * ```text
  * cursor({lnum}, {col} [, {off}])                    *cursor()*
  * cursor({list})
  * 		Positions the cursor at the column ...
@@ -38,7 +38,7 @@ export function parse(content: string): Definition[] {
  *
  * A function definition block is constrcuted with following parts
  *
- * ```
+ * ```text
  * cursor({lnum}, {col} [, {off}])                        <- variant
  * cursor({list})                                         <- variant
  * 		Positions the cursor at the column ...    <- document
@@ -84,7 +84,7 @@ function parseBlock(fn: string, body: string): Definition {
  *
  * A variant is constructed with following parts
  *
- * ```
+ * ```text
  *   fn            args
  * ~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~
  * cursor({lnum}, {col} [, {off}])

--- a/scripts/gen-option/parse.ts
+++ b/scripts/gen-option/parse.ts
@@ -7,7 +7,7 @@ import { regexIndexOf } from "./utils.ts";
  * It extract a option definition block like below and return
  * a list of `Definition`.
  *
- * ```
+ * ```text
  * 					*'aleph'* *'al'* *aleph* *Aleph*
  * 'aleph' 'al'		number	(default 224)
  * 			global


### PR DESCRIPTION
This PR includes the following breaking change

- Rename `path` attribute to `expr` in `Bufname`