### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/denops_std/anonymous/mod_test.ts
+++ b/denops_std/anonymous/mod_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync } from "../deps_test.ts";
+import { assertEquals, assertRejects } from "../deps_test.ts";
 import { test } from "../deps_test.ts";
 import * as anonymous from "./mod.ts";
 
@@ -36,21 +36,21 @@ test({
     assertEquals(await denops.dispatch(denops.name, ids[2]), "2");
 
     // The method will be removed
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await denops.dispatch(denops.name, ids[0]);
       },
       undefined,
       `No method '${ids[0]}' exists`,
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await denops.dispatch(denops.name, ids[1]);
       },
       undefined,
       `No method '${ids[1]}' exists`,
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await denops.dispatch(denops.name, ids[2]);
       },
@@ -74,21 +74,21 @@ test({
     assertEquals(anonymous.remove(denops, ...ids), [true, true, true]);
 
     // The method is removed
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await denops.dispatch(denops.name, ids[0]);
       },
       undefined,
       `No method '${ids[0]}' exists`,
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await denops.dispatch(denops.name, ids[1]);
       },
       undefined,
       `No method '${ids[1]}' exists`,
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await denops.dispatch(denops.name, ids[2]);
       },

--- a/denops_std/batch/gather_test.ts
+++ b/denops_std/batch/gather_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { gather, GatherHelper } from "./gather.ts";
 
 test({
@@ -45,7 +45,7 @@ test({
   mode: "any",
   name: "gather() throws an error when 'denops.batch()' is called.",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await gather(denops, async (denops) => {
           await denops.batch();
@@ -70,21 +70,21 @@ test({
       helper = denops;
       return Promise.resolve();
     });
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await helper!.call("execute", "DenopsGatherTest");
       },
       undefined,
       "not available outside",
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await helper.cmd("DenopsGatherTest");
       },
       undefined,
       "not available outside",
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         const _ = await helper.eval("v:version");
       },

--- a/denops_std/deps.ts
+++ b/denops_std/deps.ts
@@ -1,7 +1,7 @@
-export * as fs from "https://deno.land/std@0.113.0/fs/mod.ts";
-export * as hash from "https://deno.land/std@0.113.0/hash/mod.ts";
-export * as path from "https://deno.land/std@0.113.0/path/mod.ts";
-export { deferred } from "https://deno.land/std@0.113.0/async/mod.ts";
+export * as fs from "https://deno.land/std@0.119.0/fs/mod.ts";
+export * as hash from "https://deno.land/std@0.119.0/hash/mod.ts";
+export * as path from "https://deno.land/std@0.119.0/path/mod.ts";
+export { deferred } from "https://deno.land/std@0.119.0/async/mod.ts";
 
 export * from "https://deno.land/x/denops_core@v2.1.2/mod.ts#^";
 

--- a/denops_std/deps_test.ts
+++ b/denops_std/deps_test.ts
@@ -1,3 +1,3 @@
-export * from "https://deno.land/std@0.113.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.119.0/testing/asserts.ts";
 
 export * from "https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^";

--- a/denops_std/function/input_test.ts
+++ b/denops_std/function/input_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { input, inputlist, inputsecret } from "./input.ts";
 import * as autocmd from "../autocmd/mod.ts";
 import { execute } from "../helper/execute.ts";
@@ -72,7 +72,7 @@ test({
   mode: "all",
   name: "input() throws an error when invalid completion is specified",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await input(denops, "Test: ", "", "custom:Invalid");
       },

--- a/denops_std/helper/execute_test.ts
+++ b/denops_std/helper/execute_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { execute } from "./execute.ts";
 
 test({
@@ -31,7 +31,7 @@ test({
   mode: "any",
   name: "execute() executes multi-line Vim script but stop on errors",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await execute(
           denops,

--- a/denops_std/helper/input_test.ts
+++ b/denops_std/helper/input_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { input } from "./input.ts";
 import { execute } from "./execute.ts";
 import * as autocmd from "../autocmd/mod.ts";
@@ -105,7 +105,7 @@ test({
   mode: "all",
   name: "input() throws an error when invalid completion is specified",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await input(denops, { completion: "custom:Invalid" });
       },

--- a/denops_std/helper/load_test.ts
+++ b/denops_std/helper/load_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { load } from "./load.ts";
 
 const loadScriptUrlBase =
@@ -30,7 +30,7 @@ test({
   mode: "any",
   name: "load() load not exists local Vim script file",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await load(
           denops,
@@ -47,7 +47,7 @@ test({
   mode: "any",
   name: "load() load not exists remote Vim script file",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         const loadScriptUrl = new URL(
           "load_test_not_exists.vim",

--- a/denops_std/mapping/mod_test.ts
+++ b/denops_std/mapping/mod_test.ts
@@ -1,5 +1,5 @@
 import { Denops } from "../deps.ts";
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { Mapping, Mode } from "./types.ts";
 import * as mapping from "./mod.ts";
 
@@ -252,7 +252,7 @@ test({
         rhs: "Hello",
       },
     );
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await mapping.map(denops, "<Plug>(test-denops-std)", "Hello", {
           unique: true,
@@ -276,7 +276,7 @@ for (const mode of modes) {
       await mapping.unmap(denops, "<Plug>(test-denops-std)", {
         mode,
       });
-      await assertThrowsAsync(
+      await assertRejects(
         async () => {
           await mapping.read(denops, "<Plug>(test-denops-std)", { mode });
         },
@@ -299,7 +299,7 @@ test({
       mode: modes,
     });
     for (const mode of modes) {
-      await assertThrowsAsync(
+      await assertRejects(
         async () => {
           await mapping.read(denops, "<Plug>(test-denops-std)", { mode });
         },

--- a/denops_std/variable/register_test.ts
+++ b/denops_std/variable/register_test.ts
@@ -1,11 +1,11 @@
-import { assertEquals, assertThrowsAsync, test } from "../deps_test.ts";
+import { assertEquals, assertRejects, test } from "../deps_test.ts";
 import { register } from "./register.ts";
 
 test({
   mode: "any",
   name: "register.get() throws an error when 'prop' is invalid",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await register.get(denops, "aa");
       },
@@ -42,7 +42,7 @@ test({
   mode: "any",
   name: "register.set() throws an error when 'prop' is invalid",
   fn: async (denops) => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await register.set(denops, "aa", "world");
       },


### PR DESCRIPTION
The output of `make update` is

```
./denops_std/bufname/mod.ts

./denops_std/bufname/utils.ts

./denops_std/bufname/bufname_test.ts

./denops_std/bufname/utils_test.ts

./denops_std/bufname/bufname.ts

./denops_std/anonymous/mod.ts

./denops_std/anonymous/mod_test.ts

./denops_std/mod.ts

./denops_std/deps.ts
[1/6] Looking for releases: https://deno.land/std@0.113.0/fs/mod.ts
[1/6] Attempting update: https://deno.land/std@0.113.0/fs/mod.ts -> 0.119.0
[1/6] Update successful: https://deno.land/std@0.113.0/fs/mod.ts -> 0.119.0
[2/6] Looking for releases: https://deno.land/std@0.113.0/hash/mod.ts
[2/6] Attempting update: https://deno.land/std@0.113.0/hash/mod.ts -> 0.119.0
[2/6] Update successful: https://deno.land/std@0.113.0/hash/mod.ts -> 0.119.0
[3/6] Looking for releases: https://deno.land/std@0.113.0/path/mod.ts
[3/6] Attempting update: https://deno.land/std@0.113.0/path/mod.ts -> 0.119.0
[3/6] Update successful: https://deno.land/std@0.113.0/path/mod.ts -> 0.119.0
[4/6] Looking for releases: https://deno.land/std@0.113.0/async/mod.ts
[4/6] Attempting update: https://deno.land/std@0.113.0/async/mod.ts -> 0.119.0
[4/6] Update successful: https://deno.land/std@0.113.0/async/mod.ts -> 0.119.0
[5/6] Looking for releases: https://deno.land/x/denops_core@v2.1.2/mod.ts#^
[5/6] Using latest: https://deno.land/x/denops_core@v2.1.2/mod.ts#^
[6/6] Looking for releases: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^
[6/6] Using latest: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^

./denops_std/test/mod.ts

./denops_std/function/cursor.ts

./denops_std/function/mod.ts

./denops_std/function/various_test.ts

./denops_std/function/_generated.ts

./denops_std/function/_manual.ts

./denops_std/function/common.ts

./denops_std/function/buffer.ts

./denops_std/function/nvim/mod.ts

./denops_std/function/nvim/_generated.ts

./denops_std/function/nvim/_manual.ts

./denops_std/function/input.ts

./denops_std/function/cursor_test.ts

./denops_std/function/vim/mod.ts

./denops_std/function/vim/_generated.ts

./denops_std/function/vim/_manual.ts

./denops_std/function/input_test.ts

./denops_std/function/various.ts

./denops_std/function/types.ts

./denops_std/batch/mod.ts

./denops_std/batch/gather_test.ts

./denops_std/batch/batch_test.ts

./denops_std/batch/batch.ts

./denops_std/batch/gather.ts

./denops_std/mapping/mod.ts

./denops_std/mapping/mod_test.ts

./denops_std/mapping/parser.ts

./denops_std/mapping/parser_test.ts

./denops_std/mapping/types.ts

./denops_std/helper/mod.ts

./denops_std/helper/execute.ts

./denops_std/helper/echo.ts

./denops_std/helper/batch_test.ts

./denops_std/helper/input.ts

./denops_std/helper/execute_test.ts

./denops_std/helper/load.ts

./denops_std/helper/load_test.ts
[1/1] Looking for releases: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=
[1/1] Using latest: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=

./denops_std/helper/echo_test.ts

./denops_std/helper/batch.ts

./denops_std/helper/input_test.ts

./denops_std/autocmd/group.ts

./denops_std/autocmd/mod.ts

./denops_std/autocmd/common.ts

./denops_std/autocmd/group_test.ts

./denops_std/autocmd/common_test.ts

./denops_std/autocmd/types.ts

./denops_std/deps_test.ts
[1/2] Looking for releases: https://deno.land/std@0.113.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.113.0/testing/asserts.ts -> 0.119.0
[1/2] Update successful: https://deno.land/std@0.113.0/testing/asserts.ts -> 0.119.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^
[2/2] Using latest: https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^

./denops_std/option/mod.ts

./denops_std/option/_generated.ts

./denops_std/option/_manual.ts

./denops_std/option/nvim/mod.ts

./denops_std/option/nvim/_generated.ts

./denops_std/option/nvim/_manual.ts

./denops_std/option/vim/mod.ts

./denops_std/option/vim/_generated.ts

./denops_std/option/vim/_manual.ts

./denops_std/variable/variable.ts

./denops_std/variable/register.ts

./denops_std/variable/option_test.ts

./denops_std/variable/mod.ts

./denops_std/variable/environment.ts

./denops_std/variable/register_test.ts

./denops_std/variable/variable_test.ts

./denops_std/variable/environment_test.ts

./denops_std/variable/option.ts

./denops_std/variable/types.ts

Already latest version:
https://deno.land/x/denops_core@v2.1.2/mod.ts#^ == v2.1.2
https://deno.land/x/unknownutil@v1.1.4/mod.ts#^ == v1.1.4
https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#= == v1.9.1
https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^ == v2.1.2

Successfully updated:
https://deno.land/std@0.113.0/fs/mod.ts 0.113.0 -> 0.119.0
https://deno.land/std@0.113.0/hash/mod.ts 0.113.0 -> 0.119.0
https://deno.land/std@0.113.0/path/mod.ts 0.113.0 -> 0.119.0
https://deno.land/std@0.113.0/async/mod.ts 0.113.0 -> 0.119.0
https://deno.land/std@0.113.0/testing/asserts.ts 0.113.0 -> 0.119.0
make[1]: Entering directory '/home/runner/work/deno-denops-std/deno-denops-std'
make[1]: Leaving directory '/home/runner/work/deno-denops-std/deno-denops-std'

```