### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/denops_std/deps.ts
+++ b/denops_std/deps.ts
@@ -3,6 +3,6 @@ export * as hash from "https://deno.land/std@0.119.0/hash/mod.ts";
 export * as path from "https://deno.land/std@0.119.0/path/mod.ts";
 export { deferred } from "https://deno.land/std@0.119.0/async/mod.ts";
 
-export * from "https://deno.land/x/denops_core@v2.1.2/mod.ts#^";
+export * from "https://deno.land/x/denops_core@v2.2.0/mod.ts#^";
 
 export * from "https://deno.land/x/unknownutil@v1.1.4/mod.ts#^";

--- a/denops_std/deps_test.ts
+++ b/denops_std/deps_test.ts
@@ -1,3 +1,3 @@
 export * from "https://deno.land/std@0.119.0/testing/asserts.ts";
 
-export * from "https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^";
+export * from "https://deno.land/x/denops_core@v2.2.0/test/mod.ts#^";


### PR DESCRIPTION
The output of `make update` is

```
./denops_std/bufname/mod.ts

./denops_std/bufname/utils.ts

./denops_std/bufname/bufname_test.ts

./denops_std/bufname/utils_test.ts

./denops_std/bufname/bufname.ts

./denops_std/anonymous/mod.ts

./denops_std/anonymous/mod_test.ts

./denops_std/mod.ts

./denops_std/deps.ts
[1/6] Looking for releases: https://deno.land/std@0.119.0/fs/mod.ts
[1/6] Using latest: https://deno.land/std@0.119.0/fs/mod.ts
[2/6] Looking for releases: https://deno.land/std@0.119.0/hash/mod.ts
[2/6] Using latest: https://deno.land/std@0.119.0/hash/mod.ts
[3/6] Looking for releases: https://deno.land/std@0.119.0/path/mod.ts
[3/6] Using latest: https://deno.land/std@0.119.0/path/mod.ts
[4/6] Looking for releases: https://deno.land/std@0.119.0/async/mod.ts
[4/6] Using latest: https://deno.land/std@0.119.0/async/mod.ts
[5/6] Looking for releases: https://deno.land/x/denops_core@v2.1.2/mod.ts#^
[5/6] Attempting update: https://deno.land/x/denops_core@v2.1.2/mod.ts#^ -> v2.2.0
[5/6] Update successful: https://deno.land/x/denops_core@v2.1.2/mod.ts#^ -> v2.2.0
[6/6] Looking for releases: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^
[6/6] Using latest: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^

./denops_std/test/mod.ts

./denops_std/function/cursor.ts

./denops_std/function/mod.ts

./denops_std/function/various_test.ts

./denops_std/function/_generated.ts

./denops_std/function/_manual.ts

./denops_std/function/common.ts

./denops_std/function/buffer.ts

./denops_std/function/nvim/mod.ts

./denops_std/function/nvim/_generated.ts

./denops_std/function/nvim/_manual.ts

./denops_std/function/input.ts

./denops_std/function/cursor_test.ts

./denops_std/function/vim/mod.ts

./denops_std/function/vim/_generated.ts

./denops_std/function/vim/_manual.ts

./denops_std/function/input_test.ts

./denops_std/function/various.ts

./denops_std/function/types.ts

./denops_std/batch/mod.ts

./denops_std/batch/gather_test.ts

./denops_std/batch/batch_test.ts

./denops_std/batch/batch.ts

./denops_std/batch/gather.ts

./denops_std/mapping/mod.ts

./denops_std/mapping/mod_test.ts

./denops_std/mapping/parser.ts

./denops_std/mapping/parser_test.ts

./denops_std/mapping/types.ts

./denops_std/helper/mod.ts

./denops_std/helper/execute.ts

./denops_std/helper/echo.ts

./denops_std/helper/batch_test.ts

./denops_std/helper/input.ts

./denops_std/helper/execute_test.ts

./denops_std/helper/load.ts

./denops_std/helper/load_test.ts
[1/1] Looking for releases: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=
[1/1] Using latest: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=

./denops_std/helper/echo_test.ts

./denops_std/helper/batch.ts

./denops_std/helper/input_test.ts

./denops_std/autocmd/group.ts

./denops_std/autocmd/mod.ts

./denops_std/autocmd/common.ts

./denops_std/autocmd/group_test.ts

./denops_std/autocmd/common_test.ts

./denops_std/autocmd/types.ts

./denops_std/deps_test.ts
[1/2] Looking for releases: https://deno.land/std@0.119.0/testing/asserts.ts
[1/2] Using latest: https://deno.land/std@0.119.0/testing/asserts.ts
[2/2] Looking for releases: https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^
[2/2] Attempting update: https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^ -> v2.2.0
[2/2] Update successful: https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^ -> v2.2.0

./denops_std/option/mod.ts

./denops_std/option/_generated.ts

./denops_std/option/_manual.ts

./denops_std/option/nvim/mod.ts

./denops_std/option/nvim/_generated.ts

./denops_std/option/nvim/_manual.ts

./denops_std/option/vim/mod.ts

./denops_std/option/vim/_generated.ts

./denops_std/option/vim/_manual.ts

./denops_std/variable/variable.ts

./denops_std/variable/register.ts

./denops_std/variable/option_test.ts

./denops_std/variable/mod.ts

./denops_std/variable/environment.ts

./denops_std/variable/register_test.ts

./denops_std/variable/variable_test.ts

./denops_std/variable/environment_test.ts

./denops_std/variable/option.ts

./denops_std/variable/types.ts

Already latest version:
https://deno.land/std@0.119.0/fs/mod.ts == 0.119.0
https://deno.land/std@0.119.0/hash/mod.ts == 0.119.0
https://deno.land/std@0.119.0/path/mod.ts == 0.119.0
https://deno.land/std@0.119.0/async/mod.ts == 0.119.0
https://deno.land/x/unknownutil@v1.1.4/mod.ts#^ == v1.1.4
https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#= == v1.9.1
https://deno.land/std@0.119.0/testing/asserts.ts == 0.119.0

Successfully updated:
https://deno.land/x/denops_core@v2.1.2/mod.ts#^ v2.1.2 -> v2.2.0
https://deno.land/x/denops_core@v2.1.2/test/mod.ts#^ v2.1.2 -> v2.2.0
make[1]: Entering directory '/home/runner/work/deno-denops-std/deno-denops-std'
make[1]: Leaving directory '/home/runner/work/deno-denops-std/deno-denops-std'

```