### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/denops_std/deps.ts
+++ b/denops_std/deps.ts
@@ -1,8 +1,8 @@
-export * as fs from "https://deno.land/std@0.126.0/fs/mod.ts";
-export * as hash from "https://deno.land/std@0.126.0/hash/mod.ts";
-export * as path from "https://deno.land/std@0.126.0/path/mod.ts";
-export { deferred } from "https://deno.land/std@0.126.0/async/mod.ts";
+export * as fs from "https://deno.land/std@0.127.0/fs/mod.ts";
+export * as hash from "https://deno.land/std@0.127.0/hash/mod.ts";
+export * as path from "https://deno.land/std@0.127.0/path/mod.ts";
+export { deferred } from "https://deno.land/std@0.127.0/async/mod.ts";
 
 export * from "https://deno.land/x/denops_core@v3.0.0/mod.ts#^";
 
-export * from "https://deno.land/x/unknownutil@v1.1.4/mod.ts#^";
+export * from "https://deno.land/x/unknownutil@v1.2.1/mod.ts#^";

--- a/denops_std/deps_test.ts
+++ b/denops_std/deps_test.ts
@@ -1,3 +1,3 @@
-export * from "https://deno.land/std@0.126.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.127.0/testing/asserts.ts";
 
 export * from "https://deno.land/x/denops_core@v3.0.0/test/mod.ts#^";


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/mod_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/parser.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/parser_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/input.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/echo.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/load.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/input_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/execute.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/execute_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/load_test.ts
[1/1] Looking for releases: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=
[1/1] Using latest: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/batch.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/echo_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/batch_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/deps.ts
[1/6] Looking for releases: https://deno.land/std@0.126.0/fs/mod.ts
[1/6] Attempting update: https://deno.land/std@0.126.0/fs/mod.ts -> 0.127.0
[1/6] Update successful: https://deno.land/std@0.126.0/fs/mod.ts -> 0.127.0
[2/6] Looking for releases: https://deno.land/std@0.126.0/hash/mod.ts
[2/6] Attempting update: https://deno.land/std@0.126.0/hash/mod.ts -> 0.127.0
[2/6] Update successful: https://deno.land/std@0.126.0/hash/mod.ts -> 0.127.0
[3/6] Looking for releases: https://deno.land/std@0.126.0/path/mod.ts
[3/6] Attempting update: https://deno.land/std@0.126.0/path/mod.ts -> 0.127.0
[3/6] Update successful: https://deno.land/std@0.126.0/path/mod.ts -> 0.127.0
[4/6] Looking for releases: https://deno.land/std@0.126.0/async/mod.ts
[4/6] Attempting update: https://deno.land/std@0.126.0/async/mod.ts -> 0.127.0
[4/6] Update successful: https://deno.land/std@0.126.0/async/mod.ts -> 0.127.0
[5/6] Looking for releases: https://deno.land/x/denops_core@v3.0.0/mod.ts#^
[5/6] Using latest: https://deno.land/x/denops_core@v3.0.0/mod.ts#^
[6/6] Looking for releases: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^
[6/6] Attempting update: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^ -> v1.2.1
[6/6] Update successful: https://deno.land/x/unknownutil@v1.1.4/mod.ts#^ -> v1.2.1

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/_generated.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/_generated.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/_generated.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/variable.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/register.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/option.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/option_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/environment_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/register_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/variable_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/environment.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/common_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/group_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/group.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/common.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/various_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/cursor_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/input.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/_generated.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/cursor.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/various.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/input_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/_generated.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/buffer.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/_generated.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/common.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/mod_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/gather_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/gather.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/batch.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/batch_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/utils.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/bufname_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/utils_test.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/bufname.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/deps_test.ts
[1/2] Looking for releases: https://deno.land/std@0.126.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.126.0/testing/asserts.ts -> 0.127.0
[1/2] Update successful: https://deno.land/std@0.126.0/testing/asserts.ts -> 0.127.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.0.0/test/mod.ts#^
[2/2] Using latest: https://deno.land/x/denops_core@v3.0.0/test/mod.ts#^

Already latest version:
https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#= == v1.9.1
https://deno.land/x/denops_core@v3.0.0/mod.ts#^ == v3.0.0
https://deno.land/x/denops_core@v3.0.0/test/mod.ts#^ == v3.0.0

Successfully updated:
https://deno.land/std@0.126.0/fs/mod.ts 0.126.0 -> 0.127.0
https://deno.land/std@0.126.0/hash/mod.ts 0.126.0 -> 0.127.0
https://deno.land/std@0.126.0/path/mod.ts 0.126.0 -> 0.127.0
https://deno.land/std@0.126.0/async/mod.ts 0.126.0 -> 0.127.0
https://deno.land/x/unknownutil@v1.1.4/mod.ts#^ v1.1.4 -> v1.2.1
https://deno.land/std@0.126.0/testing/asserts.ts 0.126.0 -> 0.127.0
make[1]: Entering directory '/home/runner/work/deno-denops-std/deno-denops-std'
make[1]: Leaving directory '/home/runner/work/deno-denops-std/deno-denops-std'

```