### PR TITLE
:herb: Fix test failure on Vim

### DIFF
--- a/denops_std/mapping/mod_test.ts
+++ b/denops_std/mapping/mod_test.ts
@@ -263,7 +263,7 @@ test({
         });
       },
       undefined,
-      "E227: mapping already exists",
+      "E227:",
     );
   },
   prelude: ["let g:denops#enable_workaround_vim_before_8_2_3081 = 1"],


### PR DESCRIPTION
It seems the latest Vim change the error message to "E227: Mapping already exists"