### PR TITLE
:+1: Improve `buffer.open()` functionality

### DIFF
--- a/denops_std/buffer/README.md
+++ b/denops_std/buffer/README.md
@@ -29,23 +29,33 @@ export async function main(denops: Denops): Promise<void> {
 }
 ```
 
-Use `split`, `vsplit`, `tabedit`, `pedit`, or whatever before if you'd like to
-open a buffer with non current window like:
+Use `split`, `vsplit`, `tabedit`, `pedit`, or whatever in `opener` attribute of
+the option like:
 
 ```typescript
 import { Denops } from "../mod.ts";
-import { batch } from "../batch/mod.ts";
 import { open } from "../buffer/mod.ts";
 
 export async function main(denops: Denops): Promise<void> {
-  await batch(denops, async (denops) => {
-    await denops.cmd("split");
-    await open(denops, "README.md");
-  });
+  await open(denops, "README.md", { opener: "split" });
 }
 ```
 
-See [`batch`](../batch/README.md) documentation for `batch()` part.
+Use a result value if you need window id, buffer number, window number, or
+tabpage number like:
+
+```typescript
+import { Denops } from "../mod.ts";
+import { open } from "../buffer/mod.ts";
+
+export async function main(denops: Denops): Promise<void> {
+  const info = await open(denops, "README.md");
+  console.log("winid:", info.winid);
+  console.log("bufnr:", info.bufnr);
+  console.log("winnr:", info.winnr);
+  console.log("tabpagenr:", info.tabpagenr);
+}
+```
 
 ### reload
 

--- a/denops_std/buffer/buffer_test.ts
+++ b/denops_std/buffer/buffer_test.ts
@@ -15,18 +15,26 @@ test({
   mode: "all",
   name: "open opens a new buffer",
   fn: async (denops) => {
-    await open(denops, "Hello world");
+    const info = await open(denops, "Hello world");
     const bufname = await fn.bufname(denops);
     assertEquals("Hello world", bufname);
+    assertEquals(await fn.win_getid(denops), info.winid);
+    assertEquals(await fn.bufnr(denops), info.bufnr);
+    assertEquals(await fn.winnr(denops), info.winnr);
+    assertEquals(await fn.tabpagenr(denops), info.tabpagenr);
   },
 });
 test({
   mode: "all",
   name: "open opens a new buffer (remote buffer name)",
   fn: async (denops) => {
-    await open(denops, "gin://this-is-valid-remote-buffer-name");
+    const info = await open(denops, "gin://this-is-valid-remote-buffer-name");
     const bufname = await fn.bufname(denops);
     assertEquals("gin://this-is-valid-remote-buffer-name", bufname);
+    assertEquals(await fn.win_getid(denops), info.winid);
+    assertEquals(await fn.bufnr(denops), info.bufnr);
+    assertEquals(await fn.winnr(denops), info.winnr);
+    assertEquals(await fn.tabpagenr(denops), info.tabpagenr);
   },
 });
 test({
@@ -34,9 +42,13 @@ test({
   name: "open opens a new buffer (symobls with percent-encoding)",
   fn: async (denops) => {
     const symbols = " !%22#$%&'()%2a+,-./:;%3c=%3e%3f@[\\]^`{%7c}~";
-    await open(denops, `test://${symbols}`);
+    const info = await open(denops, `test://${symbols}`);
     const bufname = await fn.bufname(denops);
     assertEquals(`test://${symbols}`, bufname);
+    assertEquals(await fn.win_getid(denops), info.winid);
+    assertEquals(await fn.bufnr(denops), info.bufnr);
+    assertEquals(await fn.winnr(denops), info.winnr);
+    assertEquals(await fn.tabpagenr(denops), info.tabpagenr);
   },
 });
 


### PR DESCRIPTION
It's important to call `win_getid()` or whatever synchronously to make sure that the current buffer is what we assumed. That's why we improved the functionality of `buffer.open()` to return those result.