### PR TITLE
:+1: Add `path/native` module to handle native path

### DIFF
--- a/denops_std/path/native/cygpath.ts
+++ b/denops_std/path/native/cygpath.ts
@@ -1,0 +1,28 @@
+import type { Denops } from "https://deno.land/x/denops_core@v3.1.0/mod.ts";
+import { LRU } from "https://deno.land/x/lru@1.0.2/mod.ts";
+
+const cache = new LRU<string>(500);
+
+export async function to(denops: Denops, p: string): Promise<string> {
+  let value = cache.get(p);
+  if (value) {
+    return value;
+  }
+  value = await denops.eval(`trim(system(printf("cygpath -m '%s'", path)))`, {
+    path: p,
+  }) as string;
+  cache.set(p, value);
+  return value;
+}
+
+export async function from(denops: Denops, p: string): Promise<string> {
+  let value = cache.get(p);
+  if (value) {
+    return value;
+  }
+  value = await denops.eval(`trim(system(printf("cygpath -u '%s'", path)))`, {
+    path: p,
+  }) as string;
+  cache.set(p, value);
+  return value;
+}

--- a/denops_std/path/native/mod.ts
+++ b/denops_std/path/native/mod.ts
@@ -1,0 +1,38 @@
+import type { Denops } from "https://deno.land/x/denops_core@v3.1.0/mod.ts";
+import * as fn from "../../function/mod.ts";
+import * as cygpath from "./cygpath.ts";
+
+type Translator = (denops: Denops, p: string) => Promise<string>;
+
+const nullTranslator: Translator = (_denops: Denops, p: string) =>
+  Promise.resolve(p);
+
+let impl: { to: Translator; from: Translator } | undefined;
+
+async function ensurePrerequisites(denops: Denops): Promise<void> {
+  if (impl) {
+    return;
+  }
+  const win32unix = await fn.exists(denops, "win32unix");
+  if (win32unix) {
+    impl = {
+      to: cygpath.to,
+      from: cygpath.from,
+    };
+  } else {
+    impl = {
+      to: nullTranslator,
+      from: nullTranslator,
+    };
+  }
+}
+
+export async function to(denops: Denops, p: string): Promise<string> {
+  await ensurePrerequisites(denops);
+  return await impl!.to(denops, p);
+}
+
+export async function from(denops: Denops, p: string): Promise<string> {
+  await ensurePrerequisites(denops);
+  return await impl!.from(denops, p);
+}


### PR DESCRIPTION
Try with

```typescript
import * as native from "https://raw.githubusercontent.com/vim-denops/deno-denops-std/d0e0116375ef2b2620124518f8f3d554ec538242/denops_std/path/native/mod.ts";

await native.to(denops, path);
await native.from(denops, path);
```