### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/denops_std/anonymous/mod_test.ts
+++ b/denops_std/anonymous/mod_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import * as anonymous from "./mod.ts";
 

--- a/denops_std/argument/flags_test.ts
+++ b/denops_std/argument/flags_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { parseFlags } from "./flags.ts";
 
 Deno.test("parseFlags", () => {

--- a/denops_std/argument/mod_test.ts
+++ b/denops_std/argument/mod_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { parse } from "./mod.ts";
 
 Deno.test("parse", () => {

--- a/denops_std/argument/opts_test.ts
+++ b/denops_std/argument/opts_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { parseOpts } from "./opts.ts";
 
 Deno.test("parseOpts", () => {

--- a/denops_std/autocmd/common_test.ts
+++ b/denops_std/autocmd/common_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { globals } from "../variable/mod.ts";
 import { define, emit, emitAll, list, remove } from "./common.ts";

--- a/denops_std/autocmd/group_test.ts
+++ b/denops_std/autocmd/group_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { globals } from "../variable/mod.ts";
 import { group } from "./group.ts";

--- a/denops_std/batch/batch_test.ts
+++ b/denops_std/batch/batch_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { batch, BatchHelper } from "./batch.ts";
 

--- a/denops_std/batch/gather_test.ts
+++ b/denops_std/batch/gather_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { gather, GatherHelper } from "./gather.ts";
 

--- a/denops_std/buffer/buffer_test.ts
+++ b/denops_std/buffer/buffer_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "../test/mod.ts";
 import { default as Encoding } from "https://cdn.skypack.dev/encoding-japanese@2.0.0/";
 import * as fn from "../function/mod.ts";

--- a/denops_std/buffer/fileencoding_test.ts
+++ b/denops_std/buffer/fileencoding_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { default as Encoding } from "https://cdn.skypack.dev/encoding-japanese@2.0.0/";
 import { tryDecode } from "./fileencoding.ts";
 

--- a/denops_std/buffer/fileformat_test.ts
+++ b/denops_std/buffer/fileformat_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { FileFormat, findFileFormat, splitText } from "./fileformat.ts";
 
 Deno.test("splitText", async (t) => {

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
-import * as path from "https://deno.land/std@0.150.0/path/mod.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
+import * as path from "https://deno.land/std@0.151.0/path/mod.ts";
 import { format, parse } from "./bufname.ts";
 
 Deno.test("format throws exception when 'scheme' contains unusable characters", () => {

--- a/denops_std/bufname/utils_test.ts
+++ b/denops_std/bufname/utils_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { decode, encode } from "./utils.ts";
 
 Deno.test("encode does nothing on alphabet characters", () => {

--- a/denops_std/function/cursor_test.ts
+++ b/denops_std/function/cursor_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { assertNumber } from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import * as cursor from "./cursor.ts";

--- a/denops_std/function/input_test.ts
+++ b/denops_std/function/input_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { input, inputlist, inputsecret } from "./input.ts";
 import * as autocmd from "../autocmd/mod.ts";

--- a/denops_std/function/various_test.ts
+++ b/denops_std/function/various_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import * as various from "./various.ts";
 

--- a/denops_std/helper/batch_test.ts
+++ b/denops_std/helper/batch_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import * as fn from "../function/mod.ts";
 import { batch } from "./batch.ts";

--- a/denops_std/helper/execute_test.ts
+++ b/denops_std/helper/execute_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { execute } from "./execute.ts";
 

--- a/denops_std/helper/input_test.ts
+++ b/denops_std/helper/input_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { input } from "./input.ts";
 import { execute } from "./execute.ts";

--- a/denops_std/helper/load.ts
+++ b/denops_std/helper/load.ts
@@ -1,7 +1,7 @@
 import type { Denops } from "https://deno.land/x/denops_core@v3.1.0/mod.ts";
-import * as fs from "https://deno.land/std@0.150.0/fs/mod.ts";
-import * as hash from "https://deno.land/std@0.150.0/hash/mod.ts";
-import * as path from "https://deno.land/std@0.150.0/path/mod.ts";
+import * as fs from "https://deno.land/std@0.151.0/fs/mod.ts";
+import * as hash from "https://deno.land/std@0.151.0/hash/mod.ts";
+import * as path from "https://deno.land/std@0.151.0/path/mod.ts";
 import { execute } from "./execute.ts";
 
 const loaded = new Set<URL>();

--- a/denops_std/helper/load_test.ts
+++ b/denops_std/helper/load_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { load } from "./load.ts";
 

--- a/denops_std/mapping/mod_test.ts
+++ b/denops_std/mapping/mod_test.ts
@@ -2,7 +2,7 @@ import type { Denops } from "https://deno.land/x/denops_core@v3.1.0/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { Mapping, Mode } from "./types.ts";
 import * as mapping from "./mod.ts";

--- a/denops_std/mapping/parser_test.ts
+++ b/denops_std/mapping/parser_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { Mapping } from "./types.ts";
 import { parse } from "./parser.ts";
 

--- a/denops_std/variable/environment_test.ts
+++ b/denops_std/variable/environment_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { environment } from "./environment.ts";
 

--- a/denops_std/variable/option_test.ts
+++ b/denops_std/variable/option_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { globalOptions, localOptions, options } from "./option.ts";
 

--- a/denops_std/variable/register_test.ts
+++ b/denops_std/variable/register_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.150.0/testing/asserts.ts";
+} from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { register } from "./register.ts";
 

--- a/denops_std/variable/variable_test.ts
+++ b/denops_std/variable/variable_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.151.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.1.0/test/mod.ts";
 import { buffers, globals, tabpages, vim, windows } from "./variable.ts";
 

--- a/scripts/gen-function/gen-function.ts
+++ b/scripts/gen-function/gen-function.ts
@@ -2,7 +2,7 @@ import {
   difference,
   intersection,
 } from "https://deno.land/x/set_operations@v1.0.3/mod.ts";
-import * as path from "https://deno.land/std@0.150.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.151.0/path/mod.ts";
 import * as commonManual from "../../denops_std/function/_manual.ts";
 import * as vimManual from "../../denops_std/function/vim/_manual.ts";
 import * as nvimManual from "../../denops_std/function/nvim/_manual.ts";

--- a/scripts/gen-function/utils.ts
+++ b/scripts/gen-function/utils.ts
@@ -1,4 +1,4 @@
-import * as io from "https://deno.land/std@0.150.0/io/mod.ts";
+import * as io from "https://deno.land/std@0.151.0/io/mod.ts";
 
 export async function downloadString(url: string): Promise<string> {
   const textDecoder = new TextDecoder();

--- a/scripts/gen-option/gen-option.ts
+++ b/scripts/gen-option/gen-option.ts
@@ -2,7 +2,7 @@ import {
   difference,
   intersection,
 } from "https://deno.land/x/set_operations@v1.0.3/mod.ts";
-import * as path from "https://deno.land/std@0.150.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.151.0/path/mod.ts";
 import * as commonManual from "../../denops_std/option/_manual.ts";
 import * as vimManual from "../../denops_std/option/vim/_manual.ts";
 import * as nvimManual from "../../denops_std/option/nvim/_manual.ts";

--- a/scripts/gen-option/utils.ts
+++ b/scripts/gen-option/utils.ts
@@ -1,4 +1,4 @@
-import * as io from "https://deno.land/std@0.150.0/io/mod.ts";
+import * as io from "https://deno.land/std@0.151.0/io/mod.ts";
 
 export async function downloadString(url: string): Promise<string> {
   const textDecoder = new TextDecoder();


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/mod.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/parser.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/mod_test.ts
[1/3] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/3] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts
[2/3] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[2/3] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/3] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[3/3] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[3/3] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/parser_test.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mod.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/buffer.ts
[1/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/2] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts
[2/2] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[2/2] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileformat.ts
[1/1] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[1/1] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileencoding_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://cdn.skypack.dev/encoding-japanese@2.0.0/
[2/2] Using latest: https://cdn.skypack.dev/encoding-japanese@2.0.0/

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileformat_test.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/buffer_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://cdn.skypack.dev/encoding-japanese@2.0.0/
[2/2] Using latest: https://cdn.skypack.dev/encoding-japanese@2.0.0/

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileencoding.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/decoration.ts
[1/3] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/3] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts
[2/3] Looking for releases: https://deno.land/x/itertools@v1.0.2/mod.ts
[2/3] Using latest: https://deno.land/x/itertools@v1.0.2/mod.ts
[3/3] Looking for releases: https://deno.land/x/unreachable@v0.1.0/mod.ts
[3/3] Using latest: https://deno.land/x/unreachable@v0.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/register_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/types.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/register.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/environment_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/option_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/option.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/variable_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/environment.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/variable.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/flags_test.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/opts_test.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/mod_test.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/opts.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/util.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/flags.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/buffer.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/types.ts
[1/1] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[1/1] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/various.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/common.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/input.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/various_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/cursor.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/cursor_test.ts
[1/3] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/3] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/3] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[2/3] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[3/3] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[3/3] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/input_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/batch.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/echo_test.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/echo.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/input.ts
[1/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/2] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts
[2/2] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[2/2] Using latest: https://deno.land/x/unknownutil@v2.0.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/execute_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/load_test.ts
[1/3] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/3] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/3] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/3] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[3/3] Looking for releases: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=
[3/3] Using latest: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/execute.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/batch_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/load.ts
[1/4] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/4] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts
[2/4] Looking for releases: https://deno.land/std@0.150.0/fs/mod.ts
[2/4] Attempting update: https://deno.land/std@0.150.0/fs/mod.ts -> 0.151.0
[2/4] Update successful: https://deno.land/std@0.150.0/fs/mod.ts -> 0.151.0
[3/4] Looking for releases: https://deno.land/std@0.150.0/hash/mod.ts
[3/4] Attempting update: https://deno.land/std@0.150.0/hash/mod.ts -> 0.151.0
[3/4] Update successful: https://deno.land/std@0.150.0/hash/mod.ts -> 0.151.0
[4/4] Looking for releases: https://deno.land/std@0.150.0/path/mod.ts
[4/4] Attempting update: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0
[4/4] Update successful: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/input_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/bufname_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/std@0.150.0/path/mod.ts
[2/2] Attempting update: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0
[2/2] Update successful: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/bufname.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/utils.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/utils_test.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/mod.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/mod_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/test/mod.ts
[1/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[1/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/batch.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/gather.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/gather_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/batch_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/common_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/group.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/common.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/group_test.ts
[1/2] Looking for releases: https://deno.land/std@0.150.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[1/2] Update successful: https://deno.land/std@0.150.0/testing/asserts.ts -> 0.151.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.1.0/test/mod.ts
[2/2] Using latest: https://deno.land/x/denops_core@v3.1.0/test/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/util.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/README.md

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/format.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/parse.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/gen-function.ts
[1/3] Looking for releases: https://deno.land/x/set_operations@v1.0.3/mod.ts
[1/3] Using latest: https://deno.land/x/set_operations@v1.0.3/mod.ts
[2/3] Looking for releases: https://deno.land/std@0.150.0/path/mod.ts
[2/3] Attempting update: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0
[2/3] Update successful: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0
[3/3] Looking for releases: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
].map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);

const nvimHelps = await Promise.all([
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
].map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimFnSet = difference(
  new Set(nvimDefs.map((def) => def.fn)),
  manualFnSet,
);

const commonFnSet = intersection(vimFnSet, nvimFnSet);
const vimOnlyFnSet = difference(vimFnSet, nvimFnSet);
const nvimOnlyFnSet = difference(nvimFnSet, vimFnSet);

const commonCode = format(
  vimDefs.filter((def) => commonFnSet.has(def.fn)),
);
const vimOnlyCode = format(
  vimDefs.filter((def) => vimOnlyFnSet.has(def.fn)),
);
const nvimOnlyCode = format(
  nvimDefs.filter((def) => nvimOnlyFnSet.has(def.fn)),
);

await Deno.writeTextFile(
  path.fromFileUrl(
    new URL(
[3/3] Skip updating: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
].map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);

const nvimHelps = await Promise.all([
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
].map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimFnSet = difference(
  new Set(nvimDefs.map((def) => def.fn)),
  manualFnSet,
);

const commonFnSet = intersection(vimFnSet, nvimFnSet);
const vimOnlyFnSet = difference(vimFnSet, nvimFnSet);
const nvimOnlyFnSet = difference(nvimFnSet, vimFnSet);

const commonCode = format(
  vimDefs.filter((def) => commonFnSet.has(def.fn)),
);
const vimOnlyCode = format(
  vimDefs.filter((def) => vimOnlyFnSet.has(def.fn)),
);
const nvimOnlyCode = format(
  nvimDefs.filter((def) => nvimOnlyFnSet.has(def.fn)),
);

await Deno.writeTextFile(
  path.fromFileUrl(
    new URL(

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/utils.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/io/mod.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/io/mod.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/io/mod.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/gen-option.ts
[1/3] Looking for releases: https://deno.land/x/set_operations@v1.0.3/mod.ts
[1/3] Using latest: https://deno.land/x/set_operations@v1.0.3/mod.ts
[2/3] Looking for releases: https://deno.land/std@0.150.0/path/mod.ts
[2/3] Attempting update: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0
[2/3] Update successful: https://deno.land/std@0.150.0/path/mod.ts -> 0.151.0
[3/3] Looking for releases: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/options.txt`,
);
const vimDefs = parse(vimHelp);
const vimOptionSet = difference(
  new Set(vimDefs.map((def) => def.name)),
  manualOptionSet,
);

const nvimHelp = await downloadString(
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/options.txt`,
);
const nvimDefs = parse(nvimHelp);
const nvimOptionSet = difference(
  new Set(nvimDefs.map((def) => def.name)),
  manualOptionSet,
);

const commonOptionSet = intersection(vimOptionSet, nvimOptionSet);
const vimOnlyOptionSet = difference(vimOptionSet, nvimOptionSet);
const nvimOnlyOptionSet = difference(nvimOptionSet, vimOptionSet);

const commonCode = format(
  vimDefs.filter((def) => commonOptionSet.has(def.name)),
  
[3/3] Skip updating: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/options.txt`,
);
const vimDefs = parse(vimHelp);
const vimOptionSet = difference(
  new Set(vimDefs.map((def) => def.name)),
  manualOptionSet,
);

const nvimHelp = await downloadString(
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/options.txt`,
);
const nvimDefs = parse(nvimHelp);
const nvimOptionSet = difference(
  new Set(nvimDefs.map((def) => def.name)),
  manualOptionSet,
);

const commonOptionSet = intersection(vimOptionSet, nvimOptionSet);
const vimOnlyOptionSet = difference(vimOptionSet, nvimOptionSet);
const nvimOnlyOptionSet = difference(nvimOptionSet, vimOptionSet);

const commonCode = format(
  vimDefs.filter((def) => commonOptionSet.has(def.name)),
  

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/format.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.1.0/mod.ts
[1/1] Using latest: https://deno.land/x/denops_core@v3.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/parse.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/utils.ts
[1/1] Looking for releases: https://deno.land/std@0.150.0/io/mod.ts
[1/1] Attempting update: https://deno.land/std@0.150.0/io/mod.ts -> 0.151.0
[1/1] Update successful: https://deno.land/std@0.150.0/io/mod.ts -> 0.151.0

/home/runner/work/deno-denops-std/deno-denops-std/README.md

Already latest version:
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts == v2.0.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts == v2.0.0
https://cdn.skypack.dev/encoding-japanese@2.0.0/ == 2.0.0
https://cdn.skypack.dev/encoding-japanese@2.0.0/ == 2.0.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/itertools@v1.0.2/mod.ts == v1.0.2
https://deno.land/x/unreachable@v0.1.0/mod.ts == v0.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts == v2.0.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts == v2.0.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts == v2.0.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#= == v1.9.1
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/test/mod.ts == v3.1.0
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0
https://deno.land/x/set_operations@v1.0.3/mod.ts == v1.0.3
https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
].map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);

const nvimHelps = await Promise.all([
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
].map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimFnSet = difference(
  new Set(nvimDefs.map((def) => def.fn)),
  manualFnSet,
);

const commonFnSet = intersection(vimFnSet, nvimFnSet);
const vimOnlyFnSet = difference(vimFnSet, nvimFnSet);
const nvimOnlyFnSet = difference(nvimFnSet, vimFnSet);

const commonCode = format(
  vimDefs.filter((def) => commonFnSet.has(def.fn)),
);
const vimOnlyCode = format(
  vimDefs.filter((def) => vimOnlyFnSet.has(def.fn)),
);
const nvimOnlyCode = format(
  nvimDefs.filter((def) => nvimOnlyFnSet.has(def.fn)),
);

await Deno.writeTextFile(
  path.fromFileUrl(
    new URL( == v${VIM_VERSION}
https://deno.land/x/set_operations@v1.0.3/mod.ts == v1.0.3
https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/options.txt`,
);
const vimDefs = parse(vimHelp);
const vimOptionSet = difference(
  new Set(vimDefs.map((def) => def.name)),
  manualOptionSet,
);

const nvimHelp = await downloadString(
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/options.txt`,
);
const nvimDefs = parse(nvimHelp);
const nvimOptionSet = difference(
  new Set(nvimDefs.map((def) => def.name)),
  manualOptionSet,
);

const commonOptionSet = intersection(vimOptionSet, nvimOptionSet);
const vimOnlyOptionSet = difference(vimOptionSet, nvimOptionSet);
const nvimOnlyOptionSet = difference(nvimOptionSet, vimOptionSet);

const commonCode = format(
  vimDefs.filter((def) => commonOptionSet.has(def.name)),
   == v${VIM_VERSION}
https://deno.land/x/denops_core@v3.1.0/mod.ts == v3.1.0

Successfully updated:
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/fs/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/hash/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/path/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/path/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/testing/asserts.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/path/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/io/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/path/mod.ts 0.150.0 -> 0.151.0
https://deno.land/std@0.150.0/io/mod.ts 0.150.0 -> 0.151.0
make[1]: Entering directory '/home/runner/work/deno-denops-std/deno-denops-std'
make[1]: Leaving directory '/home/runner/work/deno-denops-std/deno-denops-std'

```