### PR TITLE
:coffee: Upgrade `action/cache` to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "${{ matrix.version }}"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ runner.os }}-deno-${{ matrix.version }}-${{ hashFiles('**/*.ts') }}
@@ -85,7 +85,7 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "${{ matrix.version }}"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: ${{ env.DENO_DIR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
         if: runner.os == 'Windows'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "${{ matrix.version }}"
@@ -75,10 +75,10 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
         if: runner.os == 'Windows'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: "./repo"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: "vim-denops/denops.vim"
           path: "./denops.vim"

--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -9,7 +9,7 @@ jobs:
   udd:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: denoland/setup-deno@v1
         with:
           deno-version: "1.x"


### PR DESCRIPTION
To avoid Node.js 12 actions are deprecated warnings