### PR TITLE
:package: Update Deno dependencies

### DIFF
--- a/denops_std/anonymous/mod.ts
+++ b/denops_std/anonymous/mod.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 // https://github.com/microsoft/TypeScript/issues/26223#issuecomment-674500430
 export type TupleOf<T, N extends number> = N extends N

--- a/denops_std/anonymous/mod_test.ts
+++ b/denops_std/anonymous/mod_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import * as anonymous from "./mod.ts";
 
 test({

--- a/denops_std/argument/flags_test.ts
+++ b/denops_std/argument/flags_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { parseFlags } from "./flags.ts";
 
 Deno.test("parseFlags", () => {

--- a/denops_std/argument/mod_test.ts
+++ b/denops_std/argument/mod_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { parse } from "./mod.ts";
 
 Deno.test("parse", () => {

--- a/denops_std/argument/opts_test.ts
+++ b/denops_std/argument/opts_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { parseOpts } from "./opts.ts";
 
 Deno.test("parseOpts", () => {

--- a/denops_std/autocmd/common.ts
+++ b/denops_std/autocmd/common.ts
@@ -1,4 +1,4 @@
-import { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { AutocmdEvent } from "./types.ts";
 
 type CommonOptions = {

--- a/denops_std/autocmd/common_test.ts
+++ b/denops_std/autocmd/common_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { globals } from "../variable/mod.ts";
 import { define, emit, emitAll, list, remove } from "./common.ts";
 

--- a/denops_std/autocmd/group.ts
+++ b/denops_std/autocmd/group.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { execute } from "../helper/execute.ts";
 import { AutocmdEvent } from "./types.ts";
 import {

--- a/denops_std/autocmd/group_test.ts
+++ b/denops_std/autocmd/group_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { globals } from "../variable/mod.ts";
 import { group } from "./group.ts";
 

--- a/denops_std/batch/batch.ts
+++ b/denops_std/batch/batch.ts
@@ -3,7 +3,7 @@ import type {
   Denops,
   Dispatcher,
   Meta,
-} from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+} from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 type Redraw = undefined | boolean;
 

--- a/denops_std/batch/batch_test.ts
+++ b/denops_std/batch/batch_test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import {
   assertSpyCall,
   assertSpyCalls,
   spy,
-} from "https://deno.land/std@0.160.0/testing/mock.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/mock.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { batch, BatchHelper } from "./batch.ts";
 
 test({

--- a/denops_std/batch/gather.ts
+++ b/denops_std/batch/gather.ts
@@ -3,7 +3,7 @@ import type {
   Denops,
   Dispatcher,
   Meta,
-} from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+} from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 class GatherHelper implements Denops {
   #denops: Denops;

--- a/denops_std/batch/gather_test.ts
+++ b/denops_std/batch/gather_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { gather, GatherHelper } from "./gather.ts";
 
 test({

--- a/denops_std/buffer/buffer.ts
+++ b/denops_std/buffer/buffer.ts
@@ -1,9 +1,9 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import * as autocmd from "../autocmd/mod.ts";
 import * as batch from "../batch/mod.ts";
 import * as fn from "../function/mod.ts";
 import { execute } from "../helper/mod.ts";
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
 import {
   assertFileFormat,
   FileFormat,

--- a/denops_std/buffer/buffer_test.ts
+++ b/denops_std/buffer/buffer_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { test } from "../test/mod.ts";
 import { default as Encoding } from "https://cdn.skypack.dev/encoding-japanese@2.0.0/";
 import * as fn from "../function/mod.ts";

--- a/denops_std/buffer/decoration.ts
+++ b/denops_std/buffer/decoration.ts
@@ -1,8 +1,8 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import * as batch from "../batch/mod.ts";
 import * as vimFn from "../function/vim/mod.ts";
 import * as nvimFn from "../function/nvim/mod.ts";
-import * as itertools from "https://deno.land/x/itertools@v1.0.2/mod.ts";
+import * as itertools from "https://deno.land/x/itertools@v1.1.0/mod.ts";
 import { unreachable } from "https://deno.land/x/unreachable@v0.1.0/mod.ts";
 
 const cacheKey = Symbol("denops_std/buffer/decoration/vimDecorate/rs");

--- a/denops_std/buffer/fileencoding_test.ts
+++ b/denops_std/buffer/fileencoding_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { default as Encoding } from "https://cdn.skypack.dev/encoding-japanese@2.0.0/";
 import { tryDecode } from "./fileencoding.ts";
 

--- a/denops_std/buffer/fileformat.ts
+++ b/denops_std/buffer/fileformat.ts
@@ -1,4 +1,4 @@
-import * as unknownutil from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
+import * as unknownutil from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
 
 export type FileFormat = "unix" | "dos" | "mac";
 

--- a/denops_std/buffer/fileformat_test.ts
+++ b/denops_std/buffer/fileformat_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { FileFormat, findFileFormat, splitText } from "./fileformat.ts";
 
 Deno.test("splitText", async (t) => {

--- a/denops_std/bufname/bufname_test.ts
+++ b/denops_std/bufname/bufname_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import * as path from "https://deno.land/std@0.160.0/path/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
 import { format, parse } from "./bufname.ts";
 
 Deno.test("format throws exception when 'scheme' contains unusable characters", () => {

--- a/denops_std/bufname/utils_test.ts
+++ b/denops_std/bufname/utils_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { decode, encode } from "./utils.ts";
 
 Deno.test("encode does nothing on alphabet characters", () => {

--- a/denops_std/function/_generated.ts
+++ b/denops_std/function/_generated.ts
@@ -1,6 +1,6 @@
 // NOTE: This file is generated. Do NOT modify it manually.
 // deno-lint-ignore-file camelcase
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * Return the absolute value of {expr}.  When {expr} evaluates to

--- a/denops_std/function/buffer.ts
+++ b/denops_std/function/buffer.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * Add a buffer to the buffer list with {name}.

--- a/denops_std/function/common.ts
+++ b/denops_std/function/common.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * The result is a Number, which is |TRUE| if {expr} is

--- a/denops_std/function/cursor.ts
+++ b/denops_std/function/cursor.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import type { Position, ScreenPos } from "./types.ts";
 
 /**

--- a/denops_std/function/cursor_test.ts
+++ b/denops_std/function/cursor_test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { assertNumber } from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { assertNumber } from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import * as cursor from "./cursor.ts";
 import { assertPosition, assertScreenPos, isScreenPos } from "./types.ts";
 

--- a/denops_std/function/input.ts
+++ b/denops_std/function/input.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { BuiltinCompletion, isValidBuiltinCompletion } from "./types.ts";
 
 /**

--- a/denops_std/function/input_test.ts
+++ b/denops_std/function/input_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { input, inputlist, inputsecret } from "./input.ts";
 import * as autocmd from "../autocmd/mod.ts";
 import { execute } from "../helper/execute.ts";

--- a/denops_std/function/nvim/_generated.ts
+++ b/denops_std/function/nvim/_generated.ts
@@ -1,6 +1,6 @@
 // NOTE: This file is generated. Do NOT modify it manually.
 // deno-lint-ignore-file camelcase
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * Returns Dictionary of |api-metadata|.

--- a/denops_std/function/types.ts
+++ b/denops_std/function/types.ts
@@ -1,7 +1,7 @@
 import {
   AssertError,
   isLike,
-} from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
+} from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
 
 /**
  * Type of `screenpos()` result.

--- a/denops_std/function/various.ts
+++ b/denops_std/function/various.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * Return a string that indicates the current mode.

--- a/denops_std/function/various_test.ts
+++ b/denops_std/function/various_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import * as various from "./various.ts";
 
 test({

--- a/denops_std/function/vim/_generated.ts
+++ b/denops_std/function/vim/_generated.ts
@@ -1,6 +1,6 @@
 // NOTE: This file is generated. Do NOT modify it manually.
 // deno-lint-ignore-file camelcase
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * Return the current text in the balloon.  Only for the string,

--- a/denops_std/helper/batch.ts
+++ b/denops_std/helper/batch.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import type { GatherHelper } from "../batch/mod.ts";
 import { gather } from "../batch/mod.ts";
 

--- a/denops_std/helper/batch_test.ts
+++ b/denops_std/helper/batch_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import * as fn from "../function/mod.ts";
 import { batch } from "./batch.ts";
 

--- a/denops_std/helper/echo.ts
+++ b/denops_std/helper/echo.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { execute } from "./execute.ts";
 import { batch } from "../batch/mod.ts";
 import { generateUniqueString } from "../util.ts";

--- a/denops_std/helper/echo_test.ts
+++ b/denops_std/helper/echo_test.ts
@@ -1,4 +1,4 @@
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { echo } from "./echo.ts";
 
 test({

--- a/denops_std/helper/execute.ts
+++ b/denops_std/helper/execute.ts
@@ -1,7 +1,7 @@
 import type {
   Context,
   Denops,
-} from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+} from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 /**
  * Execute Vim script directly

--- a/denops_std/helper/execute_test.ts
+++ b/denops_std/helper/execute_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { execute } from "./execute.ts";
 
 test({

--- a/denops_std/helper/input.ts
+++ b/denops_std/helper/input.ts
@@ -1,8 +1,8 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import {
   assertNumber,
   assertString,
-} from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
+} from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
 import * as fn from "../function/mod.ts";
 import * as anonymous from "../anonymous/mod.ts";
 import { execute } from "./execute.ts";

--- a/denops_std/helper/input_test.ts
+++ b/denops_std/helper/input_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { input } from "./input.ts";
 import { execute } from "./execute.ts";
 import * as autocmd from "../autocmd/mod.ts";

--- a/denops_std/helper/load.ts
+++ b/denops_std/helper/load.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
-import * as fs from "https://deno.land/std@0.160.0/fs/mod.ts";
-import * as path from "https://deno.land/std@0.160.0/path/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
+import * as fs from "https://deno.land/std@0.167.0/fs/mod.ts";
+import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
 import { execute } from "./execute.ts";
 
 const loaded = new Set<URL>();

--- a/denops_std/helper/load_test.ts
+++ b/denops_std/helper/load_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { load } from "./load.ts";
 
 const loadScriptUrlBase =

--- a/denops_std/mapping/mod.ts
+++ b/denops_std/mapping/mod.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import * as fn from "../function/mod.ts";
 import * as batch from "../batch/mod.ts";
 import { Mapping, Mode } from "./types.ts";

--- a/denops_std/mapping/mod_test.ts
+++ b/denops_std/mapping/mod_test.ts
@@ -1,9 +1,9 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { Mapping, Mode } from "./types.ts";
 import * as mapping from "./mod.ts";
 

--- a/denops_std/mapping/parser_test.ts
+++ b/denops_std/mapping/parser_test.ts
@@ -1,7 +1,7 @@
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { Mapping } from "./types.ts";
 import { parse } from "./parser.ts";
 

--- a/denops_std/mod.ts
+++ b/denops_std/mod.ts
@@ -5,4 +5,4 @@ export type {
   Denops,
   Dispatcher,
   Meta,
-} from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+} from "https://deno.land/x/denops_core@v3.2.2/mod.ts";

--- a/denops_std/option/_generated.ts
+++ b/denops_std/option/_generated.ts
@@ -1,5 +1,5 @@
 // NOTE: This file is generated. Do NOT modify it manually.
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { globalOptions, localOptions, options } from "./../variable/mod.ts";
 
 /**

--- a/denops_std/option/nvim/_generated.ts
+++ b/denops_std/option/nvim/_generated.ts
@@ -1,5 +1,5 @@
 // NOTE: This file is generated. Do NOT modify it manually.
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { globalOptions, localOptions, options } from "../../variable/mod.ts";
 
 /**

--- a/denops_std/option/vim/_generated.ts
+++ b/denops_std/option/vim/_generated.ts
@@ -1,5 +1,5 @@
 // NOTE: This file is generated. Do NOT modify it manually.
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { globalOptions, localOptions, options } from "../../variable/mod.ts";
 
 /**

--- a/denops_std/test/mod.ts
+++ b/denops_std/test/mod.ts
@@ -1,3 +1,3 @@
 // Re-export
-export { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
-export type { TestDefinition } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+export { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
+export type { TestDefinition } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";

--- a/denops_std/variable/environment.ts
+++ b/denops_std/variable/environment.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { Getter, Remover, Setter } from "./types.ts";
 
 /**

--- a/denops_std/variable/environment_test.ts
+++ b/denops_std/variable/environment_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { environment } from "./environment.ts";
 
 test({

--- a/denops_std/variable/option.ts
+++ b/denops_std/variable/option.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { Getter, Remover, Setter } from "./types.ts";
 
 type OptionGroup = "" | "l" | "g";

--- a/denops_std/variable/option_test.ts
+++ b/denops_std/variable/option_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { globalOptions, localOptions, options } from "./option.ts";
 
 test({

--- a/denops_std/variable/register.ts
+++ b/denops_std/variable/register.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { Getter, Setter } from "./types.ts";
 
 /**

--- a/denops_std/variable/register_test.ts
+++ b/denops_std/variable/register_test.ts
@@ -1,8 +1,8 @@
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+} from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { register } from "./register.ts";
 
 test({

--- a/denops_std/variable/types.ts
+++ b/denops_std/variable/types.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 export interface Getter {
   get<T = unknown>(

--- a/denops_std/variable/variable.ts
+++ b/denops_std/variable/variable.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 import { Getter, Remover, Setter } from "./types.ts";
 
 type VariableGroup = "g" | "b" | "w" | "t" | "v";

--- a/denops_std/variable/variable_test.ts
+++ b/denops_std/variable/variable_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.160.0/testing/asserts.ts";
-import { test } from "https://deno.land/x/denops_core@v3.2.0/test/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.167.0/testing/asserts.ts";
+import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
 import { buffers, globals, tabpages, vim, windows } from "./variable.ts";
 
 test({

--- a/scripts/gen-function/format.ts
+++ b/scripts/gen-function/format.ts
@@ -1,6 +1,6 @@
 import { Definition, Variant } from "./types.ts";
 
-const denops = "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+const denops = "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 const translate: Record<string, string> = {
   "*config": "config",

--- a/scripts/gen-function/gen-function.ts
+++ b/scripts/gen-function/gen-function.ts
@@ -1,8 +1,8 @@
 import {
   difference,
   intersection,
-} from "https://deno.land/x/set_operations@v1.0.3/mod.ts";
-import * as path from "https://deno.land/std@0.160.0/path/mod.ts";
+} from "https://deno.land/x/set_operations@v1.1.0/mod.ts";
+import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
 import * as commonManual from "../../denops_std/function/_manual.ts";
 import * as vimManual from "../../denops_std/function/vim/_manual.ts";
 import * as nvimManual from "../../denops_std/function/nvim/_manual.ts";

--- a/scripts/gen-function/utils.ts
+++ b/scripts/gen-function/utils.ts
@@ -1,4 +1,4 @@
-import * as streams from "https://deno.land/std@0.160.0/streams/mod.ts";
+import * as streams from "https://deno.land/std@0.167.0/streams/mod.ts";
 
 export async function downloadString(url: string): Promise<string> {
   const textDecoder = new TextDecoder();

--- a/scripts/gen-option/format.ts
+++ b/scripts/gen-option/format.ts
@@ -1,6 +1,6 @@
 import { Option } from "./types.ts";
 
-const denops = "https://deno.land/x/denops_core@v3.2.0/mod.ts";
+const denops = "https://deno.land/x/denops_core@v3.2.2/mod.ts";
 
 const translate: Record<string, string> = {
   "default": "defaultValue",

--- a/scripts/gen-option/gen-option.ts
+++ b/scripts/gen-option/gen-option.ts
@@ -1,8 +1,8 @@
 import {
   difference,
   intersection,
-} from "https://deno.land/x/set_operations@v1.0.3/mod.ts";
-import * as path from "https://deno.land/std@0.160.0/path/mod.ts";
+} from "https://deno.land/x/set_operations@v1.1.0/mod.ts";
+import * as path from "https://deno.land/std@0.167.0/path/mod.ts";
 import * as commonManual from "../../denops_std/option/_manual.ts";
 import * as vimManual from "../../denops_std/option/vim/_manual.ts";
 import * as nvimManual from "../../denops_std/option/nvim/_manual.ts";

--- a/scripts/gen-option/utils.ts
+++ b/scripts/gen-option/utils.ts
@@ -1,4 +1,4 @@
-import * as streams from "https://deno.land/std@0.160.0/streams/mod.ts";
+import * as streams from "https://deno.land/std@0.167.0/streams/mod.ts";
 
 export async function downloadString(url: string): Promise<string> {
   const textDecoder = new TextDecoder();


### PR DESCRIPTION
The output of `make update` is

```
/home/runner/work/deno-denops-std/deno-denops-std/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/utils.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/bufname_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/std@0.160.0/path/mod.ts
[2/2] Attempting update: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0
[2/2] Update successful: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/bufname.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/bufname/utils_test.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/decoration.ts
[1/3] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/3] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/3] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[2/3] Looking for releases: https://deno.land/x/itertools@v1.0.2/mod.ts
[2/3] Attempting update: https://deno.land/x/itertools@v1.0.2/mod.ts -> v1.1.0
[2/3] Update successful: https://deno.land/x/itertools@v1.0.2/mod.ts -> v1.1.0
[3/3] Looking for releases: https://deno.land/x/unreachable@v0.1.0/mod.ts
[3/3] Using latest: https://deno.land/x/unreachable@v0.1.0/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileformat_test.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileformat.ts
[1/1] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[1/1] Attempting update: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0
[1/1] Update successful: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/buffer.ts
[1/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/2] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[2/2] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[2/2] Attempting update: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0
[2/2] Update successful: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileencoding.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/fileencoding_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://cdn.skypack.dev/encoding-japanese@2.0.0/
[2/2] Using latest: https://cdn.skypack.dev/encoding-japanese@2.0.0/

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/buffer_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://cdn.skypack.dev/encoding-japanese@2.0.0/
[2/2] Using latest: https://cdn.skypack.dev/encoding-japanese@2.0.0/

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/buffer/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/opts_test.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/flags.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/util.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/opts.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/flags_test.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/argument/mod_test.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/nvim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/vim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/option/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/parser_test.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/parser.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/mod.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mapping/mod_test.ts
[1/3] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/3] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/3] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[2/3] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[2/3] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/3] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[3/3] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[3/3] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[3/3] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/variable_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/register_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/option.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/option_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/variable.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/types.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/register.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/environment.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/environment_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/variable/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/batch.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/gather_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/gather.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/batch_test.ts
[1/3] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/3] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/3] Looking for releases: https://deno.land/std@0.160.0/testing/mock.ts
[2/3] Attempting update: https://deno.land/std@0.160.0/testing/mock.ts -> 0.167.0
[2/3] Update successful: https://deno.land/std@0.160.0/testing/mock.ts -> 0.167.0
[3/3] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[3/3] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[3/3] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/batch/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/util.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/test/mod.ts
[1/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[1/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[1/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/various_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/cursor_test.ts
[1/3] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/3] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/3] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[2/3] Attempting update: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0
[2/3] Update successful: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0
[3/3] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[3/3] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[3/3] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/cursor.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/buffer.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/nvim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/input.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/various.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/_manual.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/vim/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/types.ts
[1/1] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[1/1] Attempting update: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0
[1/1] Update successful: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/input_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/common.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/function/_generated.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/echo.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/load.ts
[1/4] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/4] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/4] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[2/4] Looking for releases: https://deno.land/std@0.160.0/fs/mod.ts
[2/4] Attempting update: https://deno.land/std@0.160.0/fs/mod.ts -> 0.167.0
[2/4] Update successful: https://deno.land/std@0.160.0/fs/mod.ts -> 0.167.0
[3/4] Looking for releases: https://deno.land/std@0.160.0/hash/mod.ts
[3/4] Attempting update: https://deno.land/std@0.160.0/hash/mod.ts -> 0.167.0
[3/4] Update successful: https://deno.land/std@0.160.0/hash/mod.ts -> 0.167.0
[4/4] Looking for releases: https://deno.land/std@0.160.0/path/mod.ts
[4/4] Attempting update: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0
[4/4] Update successful: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/batch.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/echo_test.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/input.ts
[1/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/2] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[2/2] Looking for releases: https://deno.land/x/unknownutil@v2.0.0/mod.ts
[2/2] Attempting update: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0
[2/2] Update successful: https://deno.land/x/unknownutil@v2.0.0/mod.ts -> v2.1.0

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/batch_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/execute_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/input_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/execute.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/load_test.ts
[1/3] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/3] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/3] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/3] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/3] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/3] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[3/3] Looking for releases: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=
[3/3] Using latest: https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#=

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/helper/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/mod.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/mod.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/anonymous/mod_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/group_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/group.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/common_test.ts
[1/2] Looking for releases: https://deno.land/std@0.160.0/testing/asserts.ts
[1/2] Attempting update: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[1/2] Update successful: https://deno.land/std@0.160.0/testing/asserts.ts -> 0.167.0
[2/2] Looking for releases: https://deno.land/x/denops_core@v3.2.0/test/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2
[2/2] Update successful: https://deno.land/x/denops_core@v3.2.0/test/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/common.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/README.md

/home/runner/work/deno-denops-std/deno-denops-std/denops_std/autocmd/mod.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/utils.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/streams/mod.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/streams/mod.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/streams/mod.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/gen-option.ts
[1/3] Looking for releases: https://deno.land/x/set_operations@v1.0.3/mod.ts
[1/3] Attempting update: https://deno.land/x/set_operations@v1.0.3/mod.ts -> v1.1.0
[1/3] Update successful: https://deno.land/x/set_operations@v1.0.3/mod.ts -> v1.1.0
[2/3] Looking for releases: https://deno.land/std@0.160.0/path/mod.ts
[2/3] Attempting update: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0
[2/3] Update successful: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0
[3/3] Looking for releases: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/options.txt`,
];
for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
  console.log(`Download from ${vimHelpDownloadUrl}`);
}
const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimOptionSet = difference(
  new Set(vimDefs.map((def) => def.name)),
  manualOptionSet,
);

const nvimHelpDownloadUrls = [
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/options.txt`,
];
for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
  console.log(`Download from ${nvimHelpDownloadUrl}`);
}
const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimOptionSet = difference(
  new Set(nvimDefs.map((def) => def.name)),
  manualOptionSet,
);

const commonOptionSet = intersection(vimOptionSet, nvimOptionSet);
const vimOnlyOptionSet = difference(vimOptionSet, nvimOptionSet);
const nvimOnlyOptionSet = difference(nvimOptionSet, vimOptionSet);

const commonCode = format(
  vimDefs.filter((def) => commonOptionSet.has(def.name)),
  
[3/3] Skip updating: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/options.txt`,
];
for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
  console.log(`Download from ${vimHelpDownloadUrl}`);
}
const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimOptionSet = difference(
  new Set(vimDefs.map((def) => def.name)),
  manualOptionSet,
);

const nvimHelpDownloadUrls = [
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/options.txt`,
];
for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
  console.log(`Download from ${nvimHelpDownloadUrl}`);
}
const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimOptionSet = difference(
  new Set(nvimDefs.map((def) => def.name)),
  manualOptionSet,
);

const commonOptionSet = intersection(vimOptionSet, nvimOptionSet);
const vimOnlyOptionSet = difference(vimOptionSet, nvimOptionSet);
const nvimOnlyOptionSet = difference(nvimOptionSet, vimOptionSet);

const commonCode = format(
  vimDefs.filter((def) => commonOptionSet.has(def.name)),
  

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/parse.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/format.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-option/types.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/utils.ts
[1/1] Looking for releases: https://deno.land/std@0.160.0/streams/mod.ts
[1/1] Attempting update: https://deno.land/std@0.160.0/streams/mod.ts -> 0.167.0
[1/1] Update successful: https://deno.land/std@0.160.0/streams/mod.ts -> 0.167.0

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/parse.ts

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/format.ts
[1/1] Looking for releases: https://deno.land/x/denops_core@v3.2.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2
[1/1] Update successful: https://deno.land/x/denops_core@v3.2.0/mod.ts -> v3.2.2

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/gen-function.ts
[1/3] Looking for releases: https://deno.land/x/set_operations@v1.0.3/mod.ts
[1/3] Attempting update: https://deno.land/x/set_operations@v1.0.3/mod.ts -> v1.1.0
[1/3] Update successful: https://deno.land/x/set_operations@v1.0.3/mod.ts -> v1.1.0
[2/3] Looking for releases: https://deno.land/std@0.160.0/path/mod.ts
[2/3] Attempting update: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0
[2/3] Update successful: https://deno.land/std@0.160.0/path/mod.ts -> 0.167.0
[3/3] Looking for releases: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
];
for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
  console.log(`Download from ${vimHelpDownloadUrl}`);
}
const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);

const nvimHelpDownloadUrls = [
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
];
for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
  console.log(`Download from ${nvimHelpDownloadUrl}`);
}
const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimFnSet = difference(
  new Set(nvimDefs.map((def) => def.fn)),
  manualFnSet,
);

const commonFnSet = intersection(vimFnSet, nvimFnSet);
const vimOnlyFnSet = difference(vimFnSet, nvimFnSet);
const nvimOnlyFnSet = difference(nvimFnSet, vimFnSet);

const commonCode = format(
  vimDefs.filter((def) => commonFnSet.has(def.fn)),
);
const vimOnlyCode = format(
  vimDefs.filter((def) => vimOnlyFnSet.has(def.fn)),
);
const nvimOnlyCode = format(
  nvimDefs.filter((def) => nvimOnlyFnSet.has(def.fn)),
);

await Deno.writeTextFile(
  path.fromFileUrl(
    new URL(
[3/3] Skip updating: https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
];
for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
  console.log(`Download from ${vimHelpDownloadUrl}`);
}
const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);

const nvimHelpDownloadUrls = [
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
];
for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
  console.log(`Download from ${nvimHelpDownloadUrl}`);
}
const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimFnSet = difference(
  new Set(nvimDefs.map((def) => def.fn)),
  manualFnSet,
);

const commonFnSet = intersection(vimFnSet, nvimFnSet);
const vimOnlyFnSet = difference(vimFnSet, nvimFnSet);
const nvimOnlyFnSet = difference(nvimFnSet, vimFnSet);

const commonCode = format(
  vimDefs.filter((def) => commonFnSet.has(def.fn)),
);
const vimOnlyCode = format(
  vimDefs.filter((def) => vimOnlyFnSet.has(def.fn)),
);
const nvimOnlyCode = format(
  nvimDefs.filter((def) => nvimOnlyFnSet.has(def.fn)),
);

await Deno.writeTextFile(
  path.fromFileUrl(
    new URL(

/home/runner/work/deno-denops-std/deno-denops-std/scripts/gen-function/types.ts

Already latest version:
https://deno.land/x/unreachable@v0.1.0/mod.ts == v0.1.0
https://cdn.skypack.dev/encoding-japanese@2.0.0/ == 2.0.0
https://cdn.skypack.dev/encoding-japanese@2.0.0/ == 2.0.0
https://raw.githubusercontent.com/vim-denops/deno-denops-std/v1.9.1/denops_std/helper/#= == v1.9.1
https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/options.txt`,
];
for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
  console.log(`Download from ${vimHelpDownloadUrl}`);
}
const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimOptionSet = difference(
  new Set(vimDefs.map((def) => def.name)),
  manualOptionSet,
);

const nvimHelpDownloadUrls = [
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/options.txt`,
];
for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
  console.log(`Download from ${nvimHelpDownloadUrl}`);
}
const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimOptionSet = difference(
  new Set(nvimDefs.map((def) => def.name)),
  manualOptionSet,
);

const commonOptionSet = intersection(vimOptionSet, nvimOptionSet);
const vimOnlyOptionSet = difference(vimOptionSet, nvimOptionSet);
const nvimOnlyOptionSet = difference(nvimOptionSet, vimOptionSet);

const commonCode = format(
  vimDefs.filter((def) => commonOptionSet.has(def.name)),
   == v${VIM_VERSION}
https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
];
for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
  console.log(`Download from ${vimHelpDownloadUrl}`);
}
const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
const vimDefs = vimHelps.map(parse).flat();
const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);

const nvimHelpDownloadUrls = [
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
];
for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
  console.log(`Download from ${nvimHelpDownloadUrl}`);
}
const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
const nvimDefs = nvimHelps.map(parse).flat();
const nvimFnSet = difference(
  new Set(nvimDefs.map((def) => def.fn)),
  manualFnSet,
);

const commonFnSet = intersection(vimFnSet, nvimFnSet);
const vimOnlyFnSet = difference(vimFnSet, nvimFnSet);
const nvimOnlyFnSet = difference(nvimFnSet, vimFnSet);

const commonCode = format(
  vimDefs.filter((def) => commonFnSet.has(def.fn)),
);
const vimOnlyCode = format(
  vimDefs.filter((def) => vimOnlyFnSet.has(def.fn)),
);
const nvimOnlyCode = format(
  nvimDefs.filter((def) => nvimOnlyFnSet.has(def.fn)),
);

await Deno.writeTextFile(
  path.fromFileUrl(
    new URL( == v${VIM_VERSION}

Successfully updated:
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/path/mod.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/itertools@v1.0.2/mod.ts v1.0.2 -> v1.1.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts v2.0.0 -> v2.1.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/unknownutil@v2.0.0/mod.ts v2.0.0 -> v2.1.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/testing/mock.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/unknownutil@v2.0.0/mod.ts v2.0.0 -> v2.1.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/unknownutil@v2.0.0/mod.ts v2.0.0 -> v2.1.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/fs/mod.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/hash/mod.ts 0.160.0 -> 0.167.0
https://deno.land/std@0.160.0/path/mod.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/unknownutil@v2.0.0/mod.ts v2.0.0 -> v2.1.0
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/testing/asserts.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/test/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/streams/mod.ts 0.160.0 -> 0.167.0
https://deno.land/x/set_operations@v1.0.3/mod.ts v1.0.3 -> v1.1.0
https://deno.land/std@0.160.0/path/mod.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/std@0.160.0/streams/mod.ts 0.160.0 -> 0.167.0
https://deno.land/x/denops_core@v3.2.0/mod.ts v3.2.0 -> v3.2.2
https://deno.land/x/set_operations@v1.0.3/mod.ts v1.0.3 -> v1.1.0
https://deno.land/std@0.160.0/path/mod.ts 0.160.0 -> 0.167.0
make[1]: Entering directory '/home/runner/work/deno-denops-std/deno-denops-std'
make[1]: Leaving directory '/home/runner/work/deno-denops-std/deno-denops-std'

```