### PR TITLE
:bug: Fix trailing spaces capable in `execute()`

### DIFF
--- a/denops_std/helper/execute.ts
+++ b/denops_std/helper/execute.ts
@@ -6,21 +6,21 @@ import type {
 /**
  * Execute Vim script directly
  */
-export async function execute(
+export function execute(
   denops: Denops,
   script: string | string[],
   ctx: Context = {},
 ): Promise<void> {
-  if (Array.isArray(script)) {
-    ctx = {
-      ...ctx,
-      __denops_internal_command: script
-        .map((x) => x.replace(/^\s+|\s+$/g, ""))
-        .filter((x) => !!x),
-    };
-    await denops.cmd("call execute(l:__denops_internal_command, '')", ctx);
-    return;
+  if (!Array.isArray(script)) {
+    // join line-continuation
+    script = script.replace(/\r?\n\s*\\/g, "");
+    // convert to array
+    script = script.split(/\r?\n/g);
   }
-  script = script.replace(/\r?\n\s*\\/g, "");
-  await execute(denops, script.split(/\r?\n/g), ctx);
+  script = script.map((x) => x.trimStart()).filter((x) => !!x);
+  ctx = {
+    ...ctx,
+    __denops_internal_command: script,
+  };
+  return denops.cmd("call execute(l:__denops_internal_command, '')", ctx);
 }

--- a/denops_std/helper/execute_test.ts
+++ b/denops_std/helper/execute_test.ts
@@ -1,5 +1,6 @@
 import {
   assertEquals,
+  assertInstanceOf,
   assertRejects,
 } from "https://deno.land/std@0.167.0/testing/asserts.ts";
 import { test } from "https://deno.land/x/denops_core@v3.2.2/test/mod.ts";
@@ -73,5 +74,43 @@ test({
       },
     );
     assertEquals(await denops.eval("g:denops_std_execute_test") as number, 25);
+  },
+});
+
+test({
+  mode: "any",
+  name: "execute() executes Vim script with line-continuation",
+  fn: async (denops) => {
+    await execute(
+      denops,
+      `
+      let g:denops_std_execute_test = 1
+            \\ + 1
+      `,
+    );
+    assertEquals(await denops.eval("g:denops_std_execute_test") as number, 2);
+  },
+});
+
+test({
+  mode: "any",
+  name: "execute() executes Vim script with trailing spaces",
+  fn: async (denops) => {
+    try {
+      await execute(denops, "setlocal path=foo\\\\\\ ");
+      assertEquals(await denops.eval("&l:path") as string, "foo\\ ");
+    } finally {
+      await denops.cmd("setlocal path&");
+    }
+  },
+});
+
+test({
+  mode: "any",
+  name: "execute() returns Promise<void>",
+  fn: async (denops) => {
+    const actual = execute(denops, "let g:denops_std_execute_test = 1");
+    assertInstanceOf(actual, Promise);
+    assertEquals(await actual, undefined);
   },
 });


### PR DESCRIPTION
- Bug fix:
  - Only trim start of line, because trailing space is necessary in some cases.
- Improve:
  - Do not call self recursively.
  - Returns a `Promise` directly instead using await.