### PR TITLE
☕ Generate manual docs

### DIFF
--- a/denops_std/function/buffer.ts
+++ b/denops_std/function/buffer.ts
@@ -1,20 +1,23 @@
 import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
 
 /**
- * Add a buffer to the buffer list with name {name} (must be a
+ * Add a buffer to the buffer list with name **{name}** (must be a
  * String).
- * If a buffer for file {name} already exists, return that buffer
+ * If a buffer for file **{name}** already exists, return that buffer
  * number.  Otherwise return the buffer number of the newly
- * created buffer.  When {name} is an empty string then a new
+ * created buffer.  When **{name}** is an empty string then a new
  * buffer is always created.
  * The buffer will not have 'buflisted' set and not be loaded
  * yet.  To add some text to the buffer use this:
- * 	let bufnr = bufadd('someName')
- * 	call bufload(bufnr)
- * 	call setbufline(bufnr, 1, ['some', 'text'])
+ *
+ *     let bufnr = bufadd('someName')
+ *     call bufload(bufnr)
+ *     call setbufline(bufnr, 1, ['some', 'text'])
+ *
  * Returns 0 on error.
- * Can also be used as a |method|:
- * 	let bufnr = 'somename'->bufadd()
+ * Can also be used as a `method`:
+ *
+ *     let bufnr = 'somename'->bufadd()
  */
 export async function bufadd(
   denops: Denops,
@@ -25,12 +28,12 @@ export async function bufadd(
 }
 
 /**
- * The result is a Number, which is |TRUE| if a buffer called
- * {buf} exists.
- * If the {buf} argument is a number, buffer numbers are used.
- *
+ * The result is a Number, which is `TRUE` if a buffer called
+ * **{buf}** exists.
+ * If the **{buf}** argument is a number, buffer numbers are used.
  * Number zero is the alternate buffer for the current window.
- * If the {buf} argument is a string it must match a buffer name
+ *
+ * If the **{buf}** argument is a string it must match a buffer name
  * exactly.  The name can be:
  * - Relative to the current directory.
  * - A full path.
@@ -38,16 +41,17 @@ export async function bufadd(
  * - A URL name.
  * Unlisted buffers will be found.
  * Note that help files are listed by their short name in the
- * output of |:buffers|, but bufexists() requires using their
+ * output of `:buffers`, but bufexists() requires using their
  * long name to be able to find them.
  * bufexists() may report a buffer exists, but to use the name
- * with a |:buffer| command you may need to use |expand()|.  Esp
- * for MS-Windows 8.3 names in the form "c:\DOCUME~1"
+ * with a `:buffer` command you may need to use `expand()`.  Esp
+ * for MS-Windows 8.3 names in the form `"c:\DOCUME~1"`
  * Use "bufexists(0)" to test for the existence of an alternate
  * file name.
  *
- * Can also be used as a |method|:
- * 	let exists = 'somename'->bufexists()
+ * Can also be used as a `method`:
+ *
+ *     let exists = 'somename'->bufexists()
  *
  * Obsolete name: buffer_exists().
  */
@@ -60,12 +64,13 @@ export async function bufexists(
 }
 
 /**
- * The result is a Number, which is |TRUE| if a buffer called
- * {buf} exists and is listed (has the 'buflisted' option set).
- * The {buf} argument is used like with |bufexists()|.
+ * The result is a Number, which is `TRUE` if a buffer called
+ * **{buf}** exists and is listed (has the 'buflisted' option set).
+ * The **{buf}** argument is used like with `bufexists()`.
  *
- * Can also be used as a |method|:
- * 	let listed = 'somename'->buflisted()
+ * Can also be used as a `method`:
+ *
+ *     let listed = 'somename'->buflisted()
  */
 export async function buflisted(
   denops: Denops,
@@ -76,17 +81,18 @@ export async function buflisted(
 }
 
 /**
- * Ensure the buffer {buf} is loaded.  When the buffer name
+ * Ensure the buffer **{buf}** is loaded.  When the buffer name
  * refers to an existing file then the file is read.  Otherwise
  * the buffer will be empty.  If the buffer was already loaded
  * then there is no change.  If the buffer is not related to a
  * file the no file is read (e.g., when 'buftype' is "nofile").
  * If there is an existing swap file for the file of the buffer,
  * there will be no dialog, the buffer will be loaded anyway.
- * The {buf} argument is used like with |bufexists()|.
+ * The **{buf}** argument is used like with `bufexists()`.
  *
- * Can also be used as a |method|:
- * 	eval 'somename'->bufload()
+ * Can also be used as a `method`:
+ *
+ *     eval 'somename'->bufload()
  */
 export async function bufload(
   denops: Denops,
@@ -96,12 +102,13 @@ export async function bufload(
 }
 
 /**
- * The result is a Number, which is |TRUE| if a buffer called
- * {buf} exists and is loaded (shown in a window or hidden).
- * The {buf} argument is used like with |bufexists()|.
+ * The result is a Number, which is `TRUE` if a buffer called
+ * **{buf}** exists and is loaded (shown in a window or hidden).
+ * The **{buf}** argument is used like with `bufexists()`.
  *
- * Can also be used as a |method|:
- * 	let loaded = 'somename'->bufloaded()
+ * Can also be used as a `method`:
+ *
+ *     let loaded = 'somename'->bufloaded()
  */
 export async function bufloaded(
   denops: Denops,
@@ -115,10 +122,10 @@ export async function bufloaded(
  * The result is the name of a buffer.  Mostly as it is displayed
  * by the `:ls` command, but not using special names such as
  * "[No Name]".
- * If {buf} is omitted the current buffer is used.
- * If {buf} is a Number, that buffer number's name is given.
+ * If **{buf}** is omitted the current buffer is used.
+ * If **{buf}** is a Number, that buffer number's name is given.
  * Number zero is the alternate buffer for the current window.
- * If {buf} is a String, it is used as a |file-pattern| to match
+ * If **{buf}** is a String, it is used as a `file-pattern` to match
  * with the buffer names.  This is always done like 'magic' is
  * set and 'cpoptions' is empty.  When there is more than one
  * match an empty string is returned.
@@ -131,18 +138,22 @@ export async function bufloaded(
  * Listed buffers are found first.  If there is a single match
  * with a listed buffer, that one is returned.  Next unlisted
  * buffers are searched for.
- * If the {buf} is a String, but you want to use it as a buffer
+ * If the **{buf}** is a String, but you want to use it as a buffer
  * number, force it to be a Number by adding zero to it:
- * 	:echo bufname("3" + 0)
- * Can also be used as a |method|:
- * 	echo bufnr->bufname()
+ *
+ *     :echo bufname("3" + 0)
+ *
+ * Can also be used as a `method`:
+ *
+ *     echo bufnr->bufname()
  *
  * If the buffer doesn't exist, or doesn't have a name, an empty
  * string is returned.
- * 	bufname("#")		alternate buffer name
- * 	bufname(3)		name of buffer 3
- * 	bufname("%")		name of current buffer
- * 	bufname("file2")	name of buffer where "file2" matches.
+ *
+ *     bufname("#")            alternate buffer name
+ *     bufname(3)              name of buffer 3
+ *     bufname("%")            name of current buffer
+ *     bufname("file2")        name of buffer where "file2" matches.
  *
  * Obsolete name: buffer_name().
  */
@@ -155,25 +166,33 @@ export async function bufname(
 
 /**
  * The result is the number of a buffer, as it is displayed by
- * the `:ls` command.  For the use of {buf}, see |bufname()|
+ * the `:ls` command.  For the use of **{buf}**, see `bufname()`
  * above.
+ *
  * If the buffer doesn't exist, -1 is returned.  Or, if the
- * {create} argument is present and TRUE, a new, unlisted,
+ * **{create}** argument is present and TRUE, a new, unlisted,
  * buffer is created and its number is returned.  Example:
- * 	let newbuf = bufnr('Scratch001', 1)
+ *
+ *     let newbuf = bufnr('Scratch001', 1)
+ *
  * Using an empty name uses the current buffer. To create a new
- * buffer with an empty name use |bufadd()|.
+ * buffer with an empty name use `bufadd()`.
+ *
  * bufnr("$") is the last buffer:
- * 	:let last_buffer = bufnr("$")
+ *
+ *     :let last_buffer = bufnr("$")
+ *
  * The result is a Number, which is the highest buffer number
  * of existing buffers.  Note that not all buffers with a smaller
  * number necessarily exist, because ":bwipeout" may have removed
  * them.  Use bufexists() to test for the existence of a buffer.
  *
- * Can also be used as a |method|:
- * 	echo bufref->bufnr()
+ * Can also be used as a `method`:
+ *
+ *     echo bufref->bufnr()
  *
  * Obsolete name: buffer_number().
+ *
  * Obsolete name for bufnr("$"): last_buffer_nr().
  */
 export async function bufnr(
@@ -185,17 +204,18 @@ export async function bufnr(
 }
 
 /**
- * The result is a Number, which is the |window-ID| of the first
- * window associated with buffer {buf}.  For the use of {buf},
- * see |bufname()| above.  If buffer {buf} doesn't exist or
+ * The result is a Number, which is the `window-ID` of the first
+ * window associated with buffer **{buf}**.  For the use of **{buf}**,
+ * see `bufname()` above.  If buffer **{buf}** doesn't exist or
  * there is no such window, -1 is returned.  Example:
  *
- * 	echo "A window containing buffer 1 is " .. (bufwinid(1))
+ *     echo "A window containing buffer 1 is " .. (bufwinid(1))
  *
  * Only deals with the current tab page.
  *
- * Can also be used as a |method|:
- * 	FindBuffer()->bufwinid()
+ * Can also be used as a `method`:
+ *
+ *     FindBuffer()->bufwinid()
  */
 export async function bufwinid(
   denops: Denops,
@@ -205,18 +225,19 @@ export async function bufwinid(
 }
 
 /**
- * Like |bufwinid()| but return the window number instead of the
- * |window-ID|.
- * If buffer {buf} doesn't exist or there is no such window, -1
+ * Like `bufwinid()` but return the window number instead of the
+ * `window-ID`.
+ * If buffer **{buf}** doesn't exist or there is no such window, -1
  * is returned.  Example:
  *
- * 	echo "A window containing buffer 1 is " .. (bufwinnr(1))
+ *     echo "A window containing buffer 1 is " .. (bufwinnr(1))
  *
- * The number can be used with |CTRL-W_w| and ":wincmd w"
- * |:wincmd|.
+ * The number can be used with `CTRL-W_w` and ":wincmd w"
+ * `:wincmd`.
  *
- * Can also be used as a |method|:
- * 	FindBuffer()->bufwinnr()
+ * Can also be used as a `method`:
+ *
+ *     FindBuffer()->bufwinnr()
  */
 export async function bufwinnr(
   denops: Denops,
@@ -226,31 +247,33 @@ export async function bufwinnr(
 }
 
 /**
- * Return a |List| with the lines starting from {lnum} to {end}
- * (inclusive) in the buffer {buf}.  If {end} is omitted, a
- * |List| with only the line {lnum} is returned.
+ * Return a `List` with the lines starting from **{lnum}** to **{end}**
+ * (inclusive) in the buffer **{buf}**.  If **{end}** is omitted, a
+ * `List` with only the line **{lnum}** is returned.
  *
- * For the use of {buf}, see |bufname()| above.
+ * For the use of **{buf}**, see `bufname()` above.
  *
- * For {lnum} and {end} "$" can be used for the last line of the
+ * For **{lnum}** and **{end}** "$" can be used for the last line of the
  * buffer.  Otherwise a number must be used.
  *
- * When {lnum} is smaller than 1 or bigger than the number of
- * lines in the buffer, an empty |List| is returned.
+ * When **{lnum}** is smaller than 1 or bigger than the number of
+ * lines in the buffer, an empty `List` is returned.
  *
- * When {end} is greater than the number of lines in the buffer,
- * it is treated as {end} is set to the number of lines in the
- * buffer.  When {end} is before {lnum} an empty |List| is
+ * When **{end}** is greater than the number of lines in the buffer,
+ * it is treated as **{end}** is set to the number of lines in the
+ * buffer.  When **{end}** is before **{lnum}** an empty `List` is
  * returned.
  *
  * This function works only for loaded buffers.  For unloaded and
- * non-existing buffers, an empty |List| is returned.
+ * non-existing buffers, an empty `List` is returned.
  *
  * Example:
- * 	:let lines = getbufline(bufnr("myfile"), 1, "$")
  *
- * Can also be used as a |method|:
- * 	GetBufnr()->getbufline(lnum)
+ *     :let lines = getbufline(bufnr("myfile"), 1, "$")
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetBufnr()->getbufline(lnum)
  */
 export async function getbufline(
   denops: Denops,
@@ -262,33 +285,35 @@ export async function getbufline(
 }
 
 /**
- * Set line {lnum} to {text} in buffer {buf}.  This works like
- * |setline()| for the specified buffer.
+ * Set line **{lnum}** to **{text}** in buffer **{buf}**.  This works like
+ * `setline()` for the specified buffer.
  *
  * This function works only for loaded buffers. First call
- * |bufload()| if needed.
+ * `bufload()` if needed.
  *
- * To insert lines use |appendbufline()|.
- * Any text properties in {lnum} are cleared.
- * {text} can be a string to set one line, or a list of strings
+ * To insert lines use `appendbufline()`.
+ * Any text properties in **{lnum}** are cleared.
+ *
+ * **{text}** can be a string to set one line, or a list of strings
  * to set multiple lines.  If the list extends below the last
  * line then those lines are added.
  *
- * For the use of {buf}, see |bufname()| above.
+ * For the use of **{buf}**, see `bufname()` above.
  *
- * {lnum} is used like with |setline()|.
- * Use "$" to refer to the last line in buffer {buf}.
- * When {lnum} is just below the last line the {text} will be
+ * **{lnum}** is used like with `setline()`.
+ * Use "$" to refer to the last line in buffer **{buf}**.
+ * When **{lnum}** is just below the last line the **{text}** will be
  * added below the last line.
  *
- * When {buf} is not a valid buffer, the buffer is not loaded or
- * {lnum} is not valid then 1 is returned.  In |Vim9| script an
+ * When **{buf}** is not a valid buffer, the buffer is not loaded or
+ * **{lnum}** is not valid then 1 is returned.  In `Vim9` script an
  * error is given.
  * On success 0 is returned.
  *
- * Can also be used as a |method|, the base is passed as the
+ * Can also be used as a `method`, the base is passed as the
  * third argument:
- * 	GetText()->setbufline(buf, lnum)
+ *
+ *     GetText()->setbufline(buf, lnum)
  */
 export async function setbufline(
   denops: Denops,

--- a/denops_std/function/common.ts
+++ b/denops_std/function/common.ts
@@ -1,109 +1,121 @@
 import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
 
 /**
- * The result is a Number, which is |TRUE| if {expr} is defined,
+ * The result is a Number, which is `TRUE` if **{expr}** is defined,
  * zero otherwise.
  *
- * Note: In a compiled |:def| function the evaluation is done at
+ * Note: In a compiled `:def` function the evaluation is done at
  * runtime.  Use `exists_compiled()` to evaluate the expression
  * at compile time.
  *
- * For checking for a supported feature use |has()|.
- * For checking if a file exists use |filereadable()|.
+ * For checking for a supported feature use `has()`.
+ * For checking if a file exists use `filereadable()`.
  *
- * The {expr} argument is a string, which contains one of these:
- * 	varname		internal variable (see
- * 	dict.key	|internal-variables|).  Also works
- * 	list[i]		for |curly-braces-names|, |Dictionary|
- * 	import.Func	entries, |List| items, imported
- * 			items, etc.
- * 			Does not work for local variables in a
- * 			compiled `:def` function.
- * 			Also works for a function in |Vim9|
- * 			script, since it can be used as a
- * 			function reference.
- * 			Beware that evaluating an index may
- * 			cause an error message for an invalid
- * 			expression.  E.g.:
- * 			   :let l = [1, 2, 3]
- * 			   :echo exists("l[5]")
- * 			   0
- * 			   :echo exists("l[xx]")
- * 			   E121: Undefined variable: xx
- * 			   0
- * 	&option-name	Vim option (only checks if it exists,
- * 			not if it really works)
- * 	+option-name	Vim option that works.
- * 	$ENVNAME	environment variable (could also be
- * 			done by comparing with an empty
- * 			string)
- * 	*funcname	built-in function (see |functions|)
- * 			or user defined function (see
- * 			|user-functions|) that is implemented.
- * 			Also works for a variable that is a
- * 			Funcref.
- * 	?funcname	built-in function that could be
- * 			implemented; to be used to check if
- * 			"funcname" is valid
- * 	:cmdname	Ex command: built-in command, user
- * 			command or command modifier |:command|.
- * 			Returns:
- * 			1  for match with start of a command
- * 			2  full match with a command
- * 			3  matches several user commands
- * 			To check for a supported command
- * 			always check the return value to be 2.
- * 	:2match		The |:2match| command.
- * 	:3match		The |:3match| command (but you
- * 			probably should not use it, it is
- * 			reserved for internal usage)
- * 	#event		autocommand defined for this event
- * 	#event#pattern	autocommand defined for this event and
- * 			pattern (the pattern is taken
- * 			literally and compared to the
- * 			autocommand patterns character by
- * 			character)
- * 	#group		autocommand group exists
- * 	#group#event	autocommand defined for this group and
- * 			event.
- * 	#group#event#pattern
- * 			autocommand defined for this group,
- * 			event and pattern.
- * 	##event		autocommand for this event is
- * 			supported.
+ * The **{expr}** argument is a string, which contains one of these:
+ *         varname         internal variable (see
+ *         dict.key        `internal-variables`).  Also works
+ *         list[i]         for `curly-braces-names`, `Dictionary`
+ *         import.Func     entries, `List` items, imported
+ *                         items, etc.
+ *                         Does not work for local variables in a
+ *                         compiled `:def` function.
+ *                         Also works for a function in `Vim9`
+ *                         script, since it can be used as a
+ *                         function reference.
+ *                         Beware that evaluating an index may
+ *                         cause an error message for an invalid
+ *                         expression.  E.g.:
+ *
+ *                             :let l = [1, 2, 3]
+ *                             :echo exists("l[5]")
+ *
+ *                            0
+ *
+ *                             :echo exists("l[xx]")
+ *
+ *                            E121: Undefined variable: xx
+ *                            0
+ *         &option-name    Vim option (only checks if it exists,
+ *                         not if it really works)
+ *         +option-name    Vim option that works.
+ *         $ENVNAME        environment variable (could also be
+ *                         done by comparing with an empty
+ *                         string)
+ *         *funcname       built-in function (see `functions`)
+ *                         or user defined function (see
+ *                         `user-functions`) that is implemented.
+ *                         Also works for a variable that is a
+ *                         Funcref.
+ *         ?funcname       built-in function that could be
+ *                         implemented; to be used to check if
+ *                         "funcname" is valid
+ *         :cmdname        Ex command: built-in command, user
+ *                         command or command modifier `:command`.
+ *                         Returns:
+ *                         1  for match with start of a command
+ *                         2  full match with a command
+ *                         3  matches several user commands
+ *                         To check for a supported command
+ *                         always check the return value to be 2.
+ *         :2match         The `:2match` command.
+ *         :3match         The `:3match` command (but you
+ *                         probably should not use it, it is
+ *                         reserved for internal usage)
+ *         `#event`          autocommand defined for this event
+ *         `#event#pattern`  autocommand defined for this event and
+ *                         pattern (the pattern is taken
+ *                         literally and compared to the
+ *                         autocommand patterns character by
+ *                         character)
+ *         `#group`          autocommand group exists
+ *         `#group#event`    autocommand defined for this group and
+ *                         event.
+ *         `#group#event#pattern`
+ *                         autocommand defined for this group,
+ *                         event and pattern.
+ *         `##event`         autocommand for this event is
+ *                         supported.
  *
  * Examples:
- * 	exists("&shortname")
- * 	exists("$HOSTNAME")
- * 	exists("*strftime")
- * 	exists("*s:MyFunc")	" only for legacy script
- * 	exists("*MyFunc")
- * 	exists("bufcount")
- * 	exists(":Make")
- * 	exists("#CursorHold")
- * 	exists("#BufReadPre#*.gz")
- * 	exists("#filetypeindent")
- * 	exists("#filetypeindent#FileType")
- * 	exists("#filetypeindent#FileType#*")
- * 	exists("##ColorScheme")
+ *
+ *     exists("&shortname")
+ *     exists("$HOSTNAME")
+ *     exists("*strftime")
+ *     exists("*s:MyFunc")     " only for legacy script
+ *     exists("*MyFunc")
+ *     exists("bufcount")
+ *     exists(":Make")
+ *     exists("#CursorHold")
+ *     exists("#BufReadPre#*.gz")
+ *     exists("#filetypeindent")
+ *     exists("#filetypeindent#FileType")
+ *     exists("#filetypeindent#FileType#*")
+ *     exists("##ColorScheme")
+ *
  * There must be no space between the symbol (&/$/* /#) and the
  * name.
  * There must be no extra characters after the name, although in
  * a few cases this is ignored.  That may become stricter in the
  * future, thus don't count on it!
  * Working example:
- * 	exists(":make")
+ *
+ *     exists(":make")
+ *
  * NOT working example:
- * 	exists(":make install")
+ *
+ *     exists(":make install")
  *
  * Note that the argument must be a string, not the name of the
  * variable itself.  For example:
- * 	exists(bufcount)
+ *
+ *     exists(bufcount)
+ *
  * This doesn't check for existence of the "bufcount" variable,
  * but gets the value of "bufcount", and checks if that exists.
  *
- * Can also be used as a |method|:
- * 	Varname()->exists()
+ * Can also be used as a `method`:
+ *
+ *     Varname()->exists()
  */
 export async function exists(
   denops: Denops,
@@ -114,62 +126,67 @@ export async function exists(
 }
 
 /**
- * Returns 1 if {feature} is supported, 0 otherwise.  The
- * {feature} argument is a feature name like "nvim-0.2.1" or
- * "win32", see below.  See also |exists()|.
+ * Returns 1 if **{feature}** is supported, 0 otherwise.  The
+ * **{feature}** argument is a feature name like "nvim-0.2.1" or
+ * "win32", see below.  See also `exists()`.
  *
  * If the code has a syntax error, then Nvim may skip the rest
- * of the line and miss |:endif|.
- * 	if has('feature') | let x = this->breaks->without->the->feature | endif
+ * of the line and miss `:endif`.
  *
- * Put |:if| and |:endif| on separate lines to avoid the
+ *     if has('feature') | let x = this->breaks->without->the->feature | endif
+ *
+ * Put `:if` and `:endif` on separate lines to avoid the
  * syntax error.
- * 	if has('feature')
- * 	  let x = this->breaks->without->the->feature
- * 	endif
+ *
+ *     if has('feature')
+ *       let x = this->breaks->without->the->feature
+ *     endif
  *
  * Vim's compile-time feature-names (prefixed with "+") are not
  * recognized because Nvim is always compiled with all possible
- * features. |feature-compile|
+ * features. `feature-compile`
  *
  * Feature names can be:
  * 1.  Nvim version. For example the "nvim-0.2.1" feature means
  *     that Nvim is version 0.2.1 or later:
- * 	:if has("nvim-0.2.1")
+ *
+ *         :if has("nvim-0.2.1")
  *
  * 2.  Runtime condition or other pseudo-feature. For example the
  *     "win32" feature checks if the current system is Windows:
- * 	:if has("win32")
- * 							*feature-list*
- *     List of supported pseudo-feature names:
- * 	acl		|ACL| support.
- * 	bsd		BSD system (not macOS, use "mac" for that).
- * 	clipboard	|clipboard| provider is available.
- * 	fname_case	Case in file names matters (for Darwin and MS-Windows
- * 			this is not present).
- * 	iconv		Can use |iconv()| for conversion.
- * 	linux		Linux system.
- * 	mac		MacOS system.
- * 	nvim		This is Nvim.
- * 	python3		Legacy Vim |python3| interface. |has-python|
- * 	pythonx		Legacy Vim |python_x| interface. |has-pythonx|
- * 	sun		SunOS system.
- * 	ttyin		input is a terminal (tty).
- * 	ttyout		output is a terminal (tty).
- * 	unix		Unix system.
- * 	*vim_starting*	True during |startup|.
- * 	win32		Windows system (32 or 64 bit).
- * 	win64		Windows system (64 bit).
- * 	wsl		WSL (Windows Subsystem for Linux) system.
  *
- * 							*has-patch*
+ *         :if has("win32")
+ *
+ *     List of supported pseudo-feature names:
+ *         acl             `ACL` support.
+ *         bsd             BSD system (not macOS, use "mac" for that).
+ *         clipboard       `clipboard` provider is available.
+ *         fname_case      Case in file names matters (for Darwin and MS-Windows
+ *                         this is not present).
+ *         iconv           Can use `iconv()` for conversion.
+ *         linux           Linux system.
+ *         mac             MacOS system.
+ *         nvim            This is Nvim.
+ *         python3         Legacy Vim `python3` interface. `has-python`
+ *         pythonx         Legacy Vim `python_x` interface. `has-pythonx`
+ *         sun             SunOS system.
+ *         ttyin           input is a terminal (tty).
+ *         ttyout          output is a terminal (tty).
+ *         unix            Unix system.
+ *         *vim_starting*  True during `startup`.
+ *         win32           Windows system (32 or 64 bit).
+ *         win64           Windows system (64 bit).
+ *         wsl             WSL (Windows Subsystem for Linux) system.
+ *
  * 3.  Vim patch. For example the "patch123" feature means that
- *     Vim patch 123 at the current |v:version| was included:
- * 	:if v:version > 602 || v:version == 602 && has("patch148")
+ *     Vim patch 123 at the current `v:version` was included:
+ *
+ *         :if v:version > 602 || v:version == 602 && has("patch148")
  *
  * 4.  Vim version. For example the "patch-7.4.237" feature means
  *     that Nvim is Vim-compatible to version 7.4.237 or later.
- * 	:if has("patch-7.4.237")
+ *
+ *         :if has("patch-7.4.237")
  */
 export async function has(
   denops: Denops,
@@ -181,31 +198,37 @@ export async function has(
 }
 
 /**
- * Without {end} the result is a String, which is line {lnum}
+ * Without **{end}** the result is a String, which is line **{lnum}**
  * from the current buffer.  Example:
- * 	getline(1)
- * When {lnum} is a String that doesn't start with a
- * digit, |line()| is called to translate the String into a Number.
+ *
+ *     getline(1)
+ *
+ * When **{lnum}** is a String that doesn't start with a
+ * digit, `line()` is called to translate the String into a Number.
  * To get the line under the cursor:
- * 	getline(".")
- * When {lnum} is a number smaller than 1 or bigger than the
+ *
+ *     getline(".")
+ *
+ * When **{lnum}** is a number smaller than 1 or bigger than the
  * number of lines in the buffer, an empty string is returned.
  *
- * When {end} is given the result is a |List| where each item is
- * a line from the current buffer in the range {lnum} to {end},
- * including line {end}.
- * {end} is used in the same way as {lnum}.
+ * When **{end}** is given the result is a `List` where each item is
+ * a line from the current buffer in the range **{lnum}** to **{end}**,
+ * including line **{end}**.
+ * **{end}** is used in the same way as **{lnum}**.
  * Non-existing lines are silently omitted.
- * When {end} is before {lnum} an empty |List| is returned.
+ * When **{end}** is before **{lnum}** an empty `List` is returned.
  * Example:
- * 	:let start = line('.')
- * 	:let end = search("^$") - 1
- * 	:let lines = getline(start, end)
  *
- * Can also be used as a |method|:
- * 	ComputeLnum()->getline()
+ *     :let start = line('.')
+ *     :let end = search("^$") - 1
+ *     :let lines = getline(start, end)
  *
- * To get lines from another buffer see |getbufline()|
+ * Can also be used as a `method`:
+ *
+ *     ComputeLnum()->getline()
+ *
+ * To get lines from another buffer see `getbufline()`
  */
 export async function getline(
   denops: Denops,
@@ -225,36 +248,41 @@ export async function getline(
 }
 
 /**
- * Set line {lnum} of the current buffer to {text}.  To insert
- * lines use |append()|. To set lines in another buffer use
- * |setbufline()|.  Any text properties in {lnum} are cleared.
+ * Set line **{lnum}** of the current buffer to **{text}**.  To insert
+ * lines use `append()`. To set lines in another buffer use
+ * `setbufline()`.  Any text properties in **{lnum}** are cleared.
  *
- * {lnum} is used like with |getline()|.
- * When {lnum} is just below the last line the {text} will be
+ * **{lnum}** is used like with `getline()`.
+ * When **{lnum}** is just below the last line the **{text}** will be
  * added below the last line.
- * {text} can be any type or a List of any type, each item is
+ * **{text}** can be any type or a List of any type, each item is
  * converted to a String.
  *
  * If this succeeds, FALSE is returned.  If this fails (most likely
- * because {lnum} is invalid) TRUE is returned.
- * In |Vim9| script an error is given if {lnum} is invalid.
+ * because **{lnum}** is invalid) TRUE is returned.
+ * In `Vim9` script an error is given if **{lnum}** is invalid.
  *
  * Example:
- * 	:call setline(5, strftime("%c"))
  *
- * When {text} is a |List| then line {lnum} and following lines
+ *     :call setline(5, strftime("%c"))
+ *
+ * When **{text}** is a `List` then line **{lnum}** and following lines
  * will be set to the items in the list.  Example:
- * 	:call setline(5, ['aaa', 'bbb', 'ccc'])
+ *
+ *     :call setline(5, ['aaa', 'bbb', 'ccc'])
+ *
  * This is equivalent to:
- * 	:for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
- * 	:  call setline(n, l)
- * 	:endfor
+ *
+ *     :for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
+ *     :  call setline(n, l)
+ *     :endfor
  *
  * Note: The '[ and '] marks are not set.
  *
- * Can also be used as a |method|, the base is passed as the
+ * Can also be used as a `method`, the base is passed as the
  * second argument:
- * 	GetText()->setline(lnum)
+ *
+ *     GetText()->setline(lnum)
  */
 export async function setline(
   denops: Denops,

--- a/denops_std/function/cursor.ts
+++ b/denops_std/function/cursor.ts
@@ -3,41 +3,47 @@ import type { Position, ScreenPos } from "./types.ts";
 
 /**
  * The result is a Number, which is the byte index of the column
- * position given with {expr}.  The accepted positions are:
- *     .	    the cursor position
- *     $	    the end of the cursor line (the result is the
- * 	    number of bytes in the cursor line plus one)
- *     'x	    position of mark x (if the mark is not set, 0 is
- * 	    returned)
+ * position given with **{expr}**.  The accepted positions are:
+ *     .       the cursor position
+ *     $       the end of the cursor line (the result is the
+ *             number of bytes in the cursor line plus one)
+ *     'x      position of mark x (if the mark is not set, 0 is
+ *             returned)
  *     v       In Visual mode: the start of the Visual area (the
- * 	    cursor is the end).  When not in Visual mode
- * 	    returns the cursor position.  Differs from |'<| in
- * 	    that it's updated right away.
- * Additionally {expr} can be [lnum, col]: a |List| with the line
+ *             cursor is the end).  When not in Visual mode
+ *             returns the cursor position.  Differs from `'<` in
+ *             that it's updated right away.
+ * Additionally **{expr}** can be [lnum, col]: a `List` with the line
  * and column number. Most useful when the column is "$", to get
  * the last column of a specific line.  When "lnum" or "col" is
  * out of range then col() returns zero.
- * To get the line number use |line()|.  To get both use
- * |getpos()|.
- * For the screen column position use |virtcol()|.  For the
- * character position use |charcol()|.
+ * To get the line number use `line()`.  To get both use
+ * `getpos()`.
+ * For the screen column position use `virtcol()`.  For the
+ * character position use `charcol()`.
  * Note that only marks in the current file can be used.
  * Examples:
- * 	col(".")		column of cursor
- * 	col("$")		length of cursor line plus one
- * 	col("'t")		column of mark t
- * 	col("'" .. markname)	column of mark markname
- * The first column is 1.  Returns 0 if {expr} is invalid.
+ *
+ *     col(".")                column of cursor
+ *     col("$")                length of cursor line plus one
+ *     col("'t")               column of mark t
+ *     col("'" .. markname)    column of mark markname
+ *
+ * The first column is 1.  Returns 0 if **{expr}** is invalid.
  * For an uppercase mark the column may actually be in another
  * buffer.
  * For the cursor position, when 'virtualedit' is active, the
  * column is one higher if the cursor is after the end of the
  * line.  This can be used to obtain the column in Insert mode:
- * 	:imap <F2> <C-O>:let save_ve = &ve<CR>
- * 		\<C-O>:set ve=all<CR>
- * 		\<C-O>:echo col(".") .. "\n" <Bar>
- * 		\let &ve = save_ve<CR>
- * 	GetPos()->col()
+ *
+ *     :imap <F2> <C-O>:let save_ve = &ve<CR>
+ *             \<C-O>:set ve=all<CR>
+ *             \<C-O>:echo col(".") .. "\n" <Bar>
+ *             \let &ve = save_ve<CR>
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPos()->col()
  */
 export async function col(
   denops: Denops,
@@ -50,43 +56,62 @@ export async function col(
 
 /**
  * The result is a Number, which is the screen column of the file
- * position given with {expr}.  That is, the last screen position
+ * position given with **{expr}**.  That is, the last screen position
  * occupied by the character at that position, when the screen
- * would be of unlimited width.  When there is a <Tab> at the
+ * would be of unlimited width.  When there is a `<Tab>` at the
  * position, the returned Number will be the column at the end of
- * the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
- * set to 8, it returns 8. |conceal| is ignored.
- * For the byte position use |col()|.
- * For the use of {expr} see |col()|.
- * When 'virtualedit' is used {expr} can be [lnum, col, off],
+ * the `<Tab>`.  For example, for a `<Tab>` in column 1, with 'ts'
+ * set to 8, it returns 8. `conceal` is ignored.
+ * For the byte position use `col()`.
+ *
+ * For the use of **{expr}** see `col()`.
+ *
+ * When 'virtualedit' is used **{expr}** can be [lnum, col, off],
  * where "off" is the offset in screen columns from the start of
- * the character.  E.g., a position within a <Tab> or after the
+ * the character.  E.g., a position within a `<Tab>` or after the
  * last character.  When "off" is omitted zero is used.  When
  * Virtual editing is active in the current mode, a position
  * beyond the end of the line can be returned.  Also see
- * |'virtualedit'|
+ * `'virtualedit'`
+ *
  * The accepted positions are:
- *     .	    the cursor position
- *     $	    the end of the cursor line (the result is the
- * 	    number of displayed characters in the cursor line
- * 	    plus one)
- *     'x	    position of mark x (if the mark is not set, 0 is
- * 	    returned)
+ *     .       the cursor position
+ *     $       the end of the cursor line (the result is the
+ *             number of displayed characters in the cursor line
+ *             plus one)
+ *     'x      position of mark x (if the mark is not set, 0 is
+ *             returned)
  *     v       In Visual mode: the start of the Visual area (the
- * 	    cursor is the end).  When not in Visual mode
- * 	    returns the cursor position.  Differs from |'<| in
- * 	    that it's updated right away.
+ *             cursor is the end).  When not in Visual mode
+ *             returns the cursor position.  Differs from `'<` in
+ *             that it's updated right away.
+ *
+ * If **{list}** is present and non-zero then virtcol() returns a List
+ * with the first and last screen position occupied by the
+ * character.
+ *
  * Note that only marks in the current file can be used.
  * Examples:
- *   virtcol(".")	   with text "foo^Lbar", with cursor on the "^L", returns 5
- *   virtcol("$")	   with text "foo^Lbar", returns 9
- *   virtcol("'t")    with text "	  there", with 't at 'h', returns 6
+ *
+ *     " With text "foo^Lbar" and cursor on the "^L":
+ *
+ *     virtcol(".")    " returns 5
+ *     virtcol(".", 1) " returns [4, 5]
+ *     virtcol("$")    " returns 9
+ *
+ *     " With text "     there", with 't at 'h':
+ *
+ *     virtcol("'t")   " returns 6
+ *
  * The first column is 1.  0 is returned for an error.
  * A more advanced example that echoes the maximum length of
  * all lines:
+ *
  *     echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
- * Can also be used as a |method|:
- * 	GetPos()->virtcol()
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPos()->virtcol()
  */
 export async function virtcol(
   denops: Denops,
@@ -103,38 +128,40 @@ export async function virtcol(
 
 /**
  * The result is a Number, which is the line number of the file
- * position given with {expr}.  The {expr} argument is a string.
+ * position given with **{expr}**.  The **{expr}** argument is a string.
  * The accepted positions are:
- *     .	    the cursor position
- *     $	    the last line in the current buffer
- *     'x	    position of mark x (if the mark is not set, 0 is
- * 	    returned)
- *     w0	    first line visible in current window (one if the
- * 	    display isn't updated, e.g. in silent Ex mode)
- *     w$	    last line visible in current window (this is one
- * 	    less than "w0" if no lines are visible)
- *     v	    In Visual mode: the start of the Visual area (the
- * 	    cursor is the end).  When not in Visual mode
- * 	    returns the cursor position.  Differs from |'<| in
- * 	    that it's updated right away.
+ *     .       the cursor position
+ *     $       the last line in the current buffer
+ *     'x      position of mark x (if the mark is not set, 0 is
+ *             returned)
+ *     w0      first line visible in current window (one if the
+ *             display isn't updated, e.g. in silent Ex mode)
+ *     w$      last line visible in current window (this is one
+ *             less than "w0" if no lines are visible)
+ *     v       In Visual mode: the start of the Visual area (the
+ *             cursor is the end).  When not in Visual mode
+ *             returns the cursor position.  Differs from `'<` in
+ *             that it's updated right away.
  * Note that a mark in another file can be used.  The line number
  * then applies to another buffer.
- * To get the column number use |col()|.  To get both use
- * |getpos()|.
- * With the optional {winid} argument the values are obtained for
+ * To get the column number use `col()`.  To get both use
+ * `getpos()`.
+ * With the optional **{winid}** argument the values are obtained for
  * that window instead of the current window.
- * Returns 0 for invalid values of {expr} and {winid}.
+ * Returns 0 for invalid values of **{expr}** and **{winid}**.
  * Examples:
- * 	line(".")		line number of the cursor
- * 	line(".", winid)	idem, in window "winid"
- * 	line("'t")		line number of mark t
- * 	line("'" .. marker)	line number of mark marker
+ *
+ *     line(".")               line number of the cursor
+ *     line(".", winid)        idem, in window "winid"
+ *     line("'t")              line number of mark t
+ *     line("'" .. marker)     line number of mark marker
  *
  * To jump to the last known position when opening a file see
- * |last-position-jump|.
+ * `last-position-jump`.
  *
- * Can also be used as a |method|:
- * 	GetValue()->line()
+ * Can also be used as a `method`:
+ *
+ *     GetValue()->line()
  */
 export async function line(
   denops: Denops,
@@ -165,39 +192,40 @@ export async function winline(denops: Denops): Promise<number> {
 }
 
 /**
- * Positions the cursor at the column (byte count) {col} in the
- * line {lnum}.  The first column is one.
+ * Positions the cursor at the column (byte count) **{col}** in the
+ * line **{lnum}**.  The first column is one.
  *
- * When there is one argument {list} this is used as a |List|
+ * When there is one argument **{list}** this is used as a `List`
  * with two, three or four item:
- * 	[{lnum}, {col}]
- * 	[{lnum}, {col}, {off}]
- * 	[{lnum}, {col}, {off}, {curswant}]
- * This is like the return value of |getpos()| or |getcurpos()|,
+ *         [**{lnum}**, **{col}**]
+ *         [**{lnum}**, **{col}**, **{off}**]
+ *         [**{lnum}**, **{col}**, **{off}**, **{curswant}**]
+ * This is like the return value of `getpos()` or `getcurpos()`,
  * but without the first item.
  *
  * To position the cursor using the character count, use
- * |setcursorcharpos()|.
+ * `setcursorcharpos()`.
  *
  * Does not change the jumplist.
- * {lnum} is used like with |getline()|.
- * If {lnum} is greater than the number of lines in the buffer,
+ * **{lnum}** is used like with `getline()`.
+ * If **{lnum}** is greater than the number of lines in the buffer,
  * the cursor will be positioned at the last line in the buffer.
- * If {lnum} is zero, the cursor will stay in the current line.
- * If {col} is greater than the number of bytes in the line,
+ * If **{lnum}** is zero, the cursor will stay in the current line.
+ * If **{col}** is greater than the number of bytes in the line,
  * the cursor will be positioned at the last character in the
  * line.
- * If {col} is zero, the cursor will stay in the current column.
- * If {curswant} is given it is used to set the preferred column
- * for vertical movement.  Otherwise {col} is used.
+ * If **{col}** is zero, the cursor will stay in the current column.
+ * If **{curswant}** is given it is used to set the preferred column
+ * for vertical movement.  Otherwise **{col}** is used.
  *
- * When 'virtualedit' is used {off} specifies the offset in
+ * When 'virtualedit' is used **{off}** specifies the offset in
  * screen columns from the start of the character.  E.g., a
- * position within a <Tab> or after the last character.
+ * position within a `<Tab>` or after the last character.
  * Returns 0 when the position could be set, -1 otherwise.
  *
- * Can also be used as a |method|:
- * 	GetCursorPos()->cursor()
+ * Can also be used as a `method`:
+ *
+ *     GetCursorPos()->cursor()
  */
 export async function cursor(
   denops: Denops,
@@ -225,13 +253,13 @@ export async function cursor(
 
 /**
  * The result is a Dict with the screen position of the text
- * character in window {winid} at buffer line {lnum} and column
- * {col}.  {col} is a one-based byte index.
+ * character in window **{winid}** at buffer line **{lnum}** and column
+ * **{col}**.  **{col}** is a one-based byte index.
  * The Dict has these members:
- * 	row	screen row
- * 	col	first screen column
- * 	endcol	last screen column
- * 	curscol	cursor screen column
+ *         row     screen row
+ *         col     first screen column
+ *         endcol  last screen column
+ *         curscol cursor screen column
  * If the specified position is not visible, all values are zero.
  * The "endcol" value differs from "col" when the character
  * occupies more than one screen cell.  E.g. for a Tab "col" can
@@ -239,16 +267,17 @@ export async function cursor(
  * The "curscol" value is where the cursor would be placed.  For
  * a Tab it would be the same as "endcol", while for a double
  * width character it would be the same as "col".
- * The |conceal| feature is ignored here, the column numbers are
+ * The `conceal` feature is ignored here, the column numbers are
  * as if 'conceallevel' is zero.  You can set the cursor to the
- * right position and use |screencol()| to get the value with
- * |conceal| taken into account.
+ * right position and use `screencol()` to get the value with
+ * `conceal` taken into account.
  * If the position is in a closed fold the screen position of the
- * first character is returned, {col} is not used.
- * Returns an empty Dict if {winid} is invalid.
+ * first character is returned, **{col}** is not used.
+ * Returns an empty Dict if **{winid}** is invalid.
  *
- * Can also be used as a |method|:
- * 	GetWinid()->screenpos(lnum, col)
+ * Can also be used as a `method`:
+ *
+ *     GetWinid()->screenpos(lnum, col)
  */
 export async function screenpos(
   denops: Denops,
@@ -262,30 +291,33 @@ export async function screenpos(
 /**
  * Get the position of the cursor.  This is like getpos('.'), but
  * includes an extra "curswant" item in the list:
- *     [0, lnum, col, off, curswant] ~
+ *     [0, lnum, col, off, curswant]
  * The "curswant" number is the preferred column when moving the
- * cursor vertically.  After |$| command it will be a very large
- * number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
- * |getpos()|.
+ * cursor vertically.  After `$` command it will be a very large
+ * number equal to `v:maxcol`.  Also see `getcursorcharpos()` and
+ * `getpos()`.
  * The first "bufnum" item is always zero. The byte position of
  * the cursor is returned in 'col'. To get the character
- * position, use |getcursorcharpos()|.
+ * position, use `getcursorcharpos()`.
  *
- * The optional {winid} argument can specify the window.  It can
- * be the window number or the |window-ID|.  The last known
+ * The optional **{winid}** argument can specify the window.  It can
+ * be the window number or the `window-ID`.  The last known
  * cursor position is returned, this may be invalid for the
  * current value of the buffer if it is not the current window.
- * If {winid} is invalid a list with zeroes is returned.
+ * If **{winid}** is invalid a list with zeroes is returned.
  *
  * This can be used to save and restore the cursor position:
- * 	let save_cursor = getcurpos()
- * 	MoveTheCursorAround
- * 	call setpos('.', save_cursor)
- * Note that this only works within the window.  See
- * |winrestview()| for restoring more state.
  *
- * Can also be used as a |method|:
- * 	GetWinid()->getcurpos()
+ *     let save_cursor = getcurpos()
+ *     MoveTheCursorAround
+ *     call setpos('.', save_cursor)
+ *
+ * Note that this only works within the window.  See
+ * `winrestview()` for restoring more state.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetWinid()->getcurpos()
  */
 export async function getcurpos(
   denops: Denops,
@@ -295,10 +327,10 @@ export async function getcurpos(
 }
 
 /**
- * Get the position for String {expr}.  For possible values of
- * {expr} see |line()|.  For getting the cursor position see
- * |getcurpos()|.
- * The result is a |List| with four numbers:
+ * Get the position for String **{expr}**.  For possible values of
+ * **{expr}** see `line()`.  For getting the cursor position see
+ * `getcurpos()`.
+ * The result is a `List` with four numbers:
  *     [bufnum, lnum, col, off]
  * "bufnum" is zero, unless a mark like '0 or 'A is used, then it
  * is the buffer number of the mark.
@@ -306,42 +338,46 @@ export async function getcurpos(
  * column is 1.
  * The "off" number is zero, unless 'virtualedit' is used.  Then
  * it is the offset in screen columns from the start of the
- * character.  E.g., a position within a <Tab> or after the last
+ * character.  E.g., a position within a `<Tab>` or after the last
  * character.
  * Note that for '< and '> Visual mode matters: when it is "V"
  * (visual line mode) the column of '< is zero and the column of
- * '> is a large number equal to |v:maxcol|.
+ * '> is a large number equal to `v:maxcol`.
  * The column number in the returned List is the byte position
  * within the line. To get the character position in the line,
- * use |getcharpos()|.
- * A very large column number equal to |v:maxcol| can be returned,
+ * use `getcharpos()`.
+ * A very large column number equal to `v:maxcol` can be returned,
  * in which case it means "after the end of the line".
- * If {expr} is invalid, returns a list with all zeros.
+ * If **{expr}** is invalid, returns a list with all zeros.
  * This can be used to save and restore the position of a mark:
- * 	let save_a_mark = getpos("'a")
- * 	...
- * 	call setpos("'a", save_a_mark)
- * Also see |getcharpos()|, |getcurpos()| and |setpos()|.
  *
- * Can also be used as a |method|:
- * 	GetMark()->getpos()
+ *     let save_a_mark = getpos("'a")
+ *     ...
+ *     call setpos("'a", save_a_mark)
+ *
+ * Also see `getcharpos()`, `getcurpos()` and `setpos()`.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetMark()->getpos()
  */
 export async function getpos(denops: Denops, expr: string): Promise<Position> {
   return await denops.call("getpos", expr) as Position;
 }
 
 /**
- * Set the position for String {expr}.  Possible values:
- * 	.	the cursor
- * 	'x	mark x
- * {list} must be a |List| with four or five numbers:
+ * Set the position for String **{expr}**.  Possible values:
+ *         .       the cursor
+ *         'x      mark x
+ *
+ * **{list}** must be a `List` with four or five numbers:
  *     [bufnum, lnum, col, off]
  *     [bufnum, lnum, col, off, curswant]
  *
  * "bufnum" is the buffer number.  Zero can be used for the
  * current buffer.  When setting an uppercase mark "bufnum" is
  * used for the mark position.  For other marks it specifies the
- * buffer to set the mark in.  You can use the |bufnr()| function
+ * buffer to set the mark in.  You can use the `bufnr()` function
  * to turn a file name into a buffer number.
  * For setting the cursor and the ' mark "bufnum" is ignored,
  * since these are associated with a window, not a buffer.
@@ -350,11 +386,11 @@ export async function getpos(denops: Denops, expr: string): Promise<Position> {
  * "lnum" and "col" are the position in the buffer.  The first
  * column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
  * smaller than 1 then 1 is used. To use the character count
- * instead of the byte count, use |setcharpos()|.
+ * instead of the byte count, use `setcharpos()`.
  *
  * The "off" number is only used when 'virtualedit' is set. Then
  * it is the offset in screen columns from the start of the
- * character.  E.g., a position within a <Tab> or after the last
+ * character.  E.g., a position within a `<Tab>` or after the last
  * character.
  *
  * The "curswant" number is only used when setting the cursor
@@ -368,18 +404,19 @@ export async function getpos(denops: Denops, expr: string): Promise<Position> {
  * before '>.
  *
  * Returns 0 when the position could be set, -1 otherwise.
- * An error message is given if {expr} is invalid.
+ * An error message is given if **{expr}** is invalid.
  *
- * Also see |setcharpos()|, |getpos()| and |getcurpos()|.
+ * Also see `setcharpos()`, `getpos()` and `getcurpos()`.
  *
  * This does not restore the preferred column for moving
- * vertically; if you set the cursor position with this, |j| and
- * |k| motions will jump to previous columns!  Use |cursor()| to
+ * vertically; if you set the cursor position with this, `j` and
+ * `k` motions will jump to previous columns!  Use `cursor()` to
  * also set the preferred column.  Also see the "curswant" key in
- * |winrestview()|.
+ * `winrestview()`.
  *
- * Can also be used as a |method|:
- * 	GetPosition()->setpos('.')
+ * Can also be used as a `method`:
+ *
+ *     GetPosition()->setpos('.')
  */
 export async function setpos(
   denops: Denops,
@@ -391,18 +428,20 @@ export async function setpos(
 
 /**
  * Return the line number that contains the character at byte
- * count {byte} in the current buffer.  This includes the
+ * count **{byte}** in the current buffer.  This includes the
  * end-of-line character, depending on the 'fileformat' option
  * for the current buffer.  The first character has byte count
  * one.
- * Also see |line2byte()|, |go| and |:goto|.
+ * Also see `line2byte()`, `go` and `:goto`.
  *
- * Returns -1 if the {byte} value is invalid.
+ * Returns -1 if the **{byte}** value is invalid.
  *
- * Can also be used as a |method|:
- * 	GetOffset()->byte2line()
- * {not available when compiled without the |+byte_offset|
- * feature}
+ * Can also be used as a `method`:
+ *
+ *     GetOffset()->byte2line()
+ *
+ * *not available when compiled without the `+byte_offset`
+ * feature*
  */
 export async function byte2line(denops: Denops, byte: number): Promise<number> {
   return await denops.call("byte2line", byte) as number;
@@ -410,36 +449,40 @@ export async function byte2line(denops: Denops, byte: number): Promise<number> {
 
 /**
  * Return the byte count from the start of the buffer for line
- * {lnum}.  This includes the end-of-line character, depending on
+ * **{lnum}**.  This includes the end-of-line character, depending on
  * the 'fileformat' option for the current buffer.  The first
  * line returns 1. 'encoding' matters, 'fileencoding' is ignored.
  * This can also be used to get the byte count for the line just
  * below the last line:
- * 	line2byte(line("$") + 1)
- * This is the buffer size plus one.  If 'fileencoding' is empty
- * it is the file size plus one.  {lnum} is used like with
- * |getline()|.  When {lnum} is invalid, or the |+byte_offset|
- * feature has been disabled at compile time, -1 is returned.
- * Also see |byte2line()|, |go| and |:goto|.
  *
- * Can also be used as a |method|:
- * 	GetLnum()->line2byte()
+ *     line2byte(line("$") + 1)
+ *
+ * This is the buffer size plus one.  If 'fileencoding' is empty
+ * it is the file size plus one.  **{lnum}** is used like with
+ * `getline()`.  When **{lnum}** is invalid, or the `+byte_offset`
+ * feature has been disabled at compile time, -1 is returned.
+ * Also see `byte2line()`, `go` and `:goto`.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetLnum()->line2byte()
  */
 export async function line2byte(denops: Denops, lnum: number): Promise<number> {
   return await denops.call("line2byte", lnum) as number;
 }
 
 /**
- * Returns the number of filler lines above line {lnum}.
+ * Returns the number of filler lines above line **{lnum}**.
  * These are the lines that were inserted at this point in
  * another diff'ed window.  These filler lines are shown in the
  * display but don't exist in the buffer.
- * {lnum} is used like with |getline()|.  Thus "." is the current
+ * **{lnum}** is used like with `getline()`.  Thus "." is the current
  * line, "'m" mark m, etc.
  * Returns 0 if the current window is not in diff mode.
  *
- * Can also be used as a |method|:
- * 	GetLnum()->diff_filler()
+ * Can also be used as a `method`:
+ *
+ *     GetLnum()->diff_filler()
  */
 // deno-lint-ignore camelcase
 export async function diff_filler(

--- a/denops_std/function/getreginfo.ts
+++ b/denops_std/function/getreginfo.ts
@@ -32,31 +32,34 @@ export type GetreginfoResult = {
 } | Record<string, never>;
 
 /**
- * Returns detailed information about register {regname} as a
+ * Returns detailed information about register **{regname}** as a
  * Dictionary with the following entries:
- * 	regcontents	List of lines contained in register
- * 			{regname}, like
- * 			|getreg|({regname}, 1, 1).
- * 	regtype		the type of register {regname}, as in
- * 			|getregtype()|.
- * 	isunnamed	Boolean flag, v:true if this register
- * 			is currently pointed to by the unnamed
- * 			register.
- * 	points_to	for the unnamed register, gives the
- * 			single letter name of the register
- * 			currently pointed to (see |quotequote|).
- * 			For example, after deleting a line
- * 			with `dd`, this field will be "1",
- * 			which is the register that got the
- * 			deleted text.
- * The {regname} argument is a string.  If {regname} is invalid
+ *         regcontents     List of lines contained in register
+ *                         **{regname}**, like
+ *                         `getreg`(**{regname}**, 1, 1).
+ *         regtype         the type of register **{regname}**, as in
+ *                         `getregtype()`.
+ *         isunnamed       Boolean flag, v:true if this register
+ *                         is currently pointed to by the unnamed
+ *                         register.
+ *         points_to       for the unnamed register, gives the
+ *                         single letter name of the register
+ *                         currently pointed to (see `quotequote`).
+ *                         For example, after deleting a line
+ *                         with `dd`, this field will be "1",
+ *                         which is the register that got the
+ *                         deleted text.
+ *
+ * The **{regname}** argument is a string.  If **{regname}** is invalid
  * or not set, an empty Dictionary will be returned.
- * If {regname} is "" or "@", the unnamed register '"' is used.
- * If {regname} is not specified, |v:register| is used.
- * The returned Dictionary can be passed to |setreg()|.
- * In |Vim9-script| {regname} must be one character.
- * Can also be used as a |method|:
- * 	GetRegname()->getreginfo()
+ * If **{regname}** is "" or "@", the unnamed register '"' is used.
+ * If **{regname}** is not specified, `v:register` is used.
+ * The returned Dictionary can be passed to `setreg()`.
+ * In `Vim9-script` **{regname}** must be one character.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetRegname()->getreginfo()
  */
 export function getreginfo(
   denops: Denops,

--- a/denops_std/function/input.ts
+++ b/denops_std/function/input.ts
@@ -3,51 +3,56 @@ import { BuiltinCompletion, isValidBuiltinCompletion } from "./types.ts";
 
 /**
  * The result is a String, which is whatever the user typed on
- * the command-line.  The {prompt} argument is either a prompt
+ * the command-line.  The **{prompt}** argument is either a prompt
  * string, or a blank string (for no prompt).  A '\n' can be used
  * in the prompt to start a new line.
- * The highlighting set with |:echohl| is used for the prompt.
+ * The highlighting set with `:echohl` is used for the prompt.
  * The input is entered just like a command-line, with the same
  * editing commands and mappings.  There is a separate history
  * for lines typed for input().
  * Example:
- * 	:if input("Coffee or beer? ") == "beer"
- * 	:  echo "Cheers!"
- * 	:endif
  *
- * If the optional {text} argument is present and not empty, this
+ *     :if input("Coffee or beer? ") == "beer"
+ *     :  echo "Cheers!"
+ *     :endif
+ *
+ * If the optional **{text}** argument is present and not empty, this
  * is used for the default reply, as if the user typed this.
  * Example:
- * 	:let color = input("Color? ", "white")
  *
- * The optional {completion} argument specifies the type of
+ *     :let color = input("Color? ", "white")
+ *
+ * The optional **{completion}** argument specifies the type of
  * completion supported for the input.  Without it completion is
  * not performed.  The supported completion types are the same as
  * that can be supplied to a user-defined command using the
- * "-complete=" argument.  Refer to |:command-completion| for
+ * "-complete=" argument.  Refer to `:command-completion` for
  * more information.  Example:
- * 	let fname = input("File: ", "", "file")
+ *
+ *     let fname = input("File: ", "", "file")
  *
  * NOTE: This function must not be used in a startup file, for
  * the versions that only run in GUI mode (e.g., the Win32 GUI).
  * Note: When input() is called from within a mapping it will
  * consume remaining characters from that mapping, because a
  * mapping is handled like the characters were typed.
- * Use |inputsave()| before input() and |inputrestore()|
+ * Use `inputsave()` before input() and `inputrestore()`
  * after input() to avoid that.  Another solution is to avoid
  * that further characters follow in the mapping, e.g., by using
- * |:execute| or |:normal|.
+ * `:execute` or `:normal`.
  *
  * Example with a mapping:
- * 	:nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
- * 	:function GetFoo()
- * 	:  call inputsave()
- * 	:  let g:Foo = input("enter search pattern: ")
- * 	:  call inputrestore()
- * 	:endfunction
  *
- * Can also be used as a |method|:
- * 	GetPrompt()->input()
+ *     :nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
+ *     :function GetFoo()
+ *     :  call inputsave()
+ *     :  let g:Foo = input("enter search pattern: ")
+ *     :  call inputrestore()
+ *     :endfunction
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPrompt()->input()
  */
 export function input(
   denops: Denops,
@@ -66,7 +71,7 @@ export function input(
 }
 
 /**
- * {textlist} must be a |List| of strings.  This |List| is
+ * **{textlist}** must be a `List` of strings.  This `List` is
  * displayed, one string per line.  The user will be prompted to
  * enter a number, which is returned.
  * The user can also select an item by clicking on it with the
@@ -74,23 +79,25 @@ export function input(
  * "a" or includes "c").  For the first string 0 is returned.
  * When clicking above the first item a negative number is
  * returned.  When clicking on the prompt one more than the
- * length of {textlist} is returned.
- * Make sure {textlist} has less than 'lines' entries, otherwise
+ * length of **{textlist}** is returned.
+ * Make sure **{textlist}** has less than 'lines' entries, otherwise
  * it won't work.  It's a good idea to put the entry number at
  * the start of the string.  And put a prompt in the first item.
  * Example:
- * 	let color = inputlist(['Select color:', '1. red',
- * 		\ '2. green', '3. blue'])
  *
- * Can also be used as a |method|:
- * 	GetChoices()->inputlist()
+ *     let color = inputlist(['Select color:', '1. red',
+ *             \ '2. green', '3. blue'])
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetChoices()->inputlist()
  */
 export function inputlist(denops: Denops, textlist: string[]): Promise<number> {
   return denops.call("inputlist", textlist) as Promise<number>;
 }
 
 /**
- * Restore typeahead that was saved with a previous |inputsave()|.
+ * Restore typeahead that was saved with a previous `inputsave()`.
  * Should be called the same number of times inputsave() is
  * called.  Calling it more often is harmless though.
  * Returns TRUE when there is nothing to restore, FALSE otherwise.
@@ -114,18 +121,19 @@ export async function inputsave(denops: Denops): Promise<boolean> {
 }
 
 /**
- * This function acts much like the |input()| function with but
+ * This function acts much like the `input()` function with but
  * two exceptions:
  * a) the user's response will be displayed as a sequence of
  * asterisks ("*") thereby keeping the entry secret, and
  * b) the user's response will not be recorded on the input
- * |history| stack.
+ * `history` stack.
  * The result is a String, which is whatever the user actually
  * typed on the command-line in response to the issued prompt.
  * NOTE: Command-line completion is not supported.
  *
- * Can also be used as a |method|:
- * 	GetPrompt()->inputsecret()
+ * Can also be used as a `method`:
+ *
+ *     GetPrompt()->inputsecret()
  */
 export function inputsecret(
   denops: Denops,

--- a/denops_std/function/various.ts
+++ b/denops_std/function/various.ts
@@ -3,57 +3,58 @@ import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
 /**
  * Return a string that indicates the current mode.
  * If [expr] is supplied and it evaluates to a non-zero Number or
- * a non-empty String (|non-zero-arg|), then the full mode is
+ * a non-empty String (`non-zero-arg`), then the full mode is
  * returned, otherwise only the first letter is returned.
- * Also see |state()|.
+ * Also see `state()`.
  *
- *    n	    Normal
- *    no	    Operator-pending
- *    nov	    Operator-pending (forced characterwise |o_v|)
- *    noV	    Operator-pending (forced linewise |o_V|)
- *    noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|);
- * 		CTRL-V is one character
- *    niI	    Normal using |i_CTRL-O| in |Insert-mode|
- *    niR	    Normal using |i_CTRL-O| in |Replace-mode|
- *    niV	    Normal using |i_CTRL-O| in |Virtual-Replace-mode|
- *    nt	    Terminal-Normal (insert goes to Terminal-Job mode)
- *    v	    Visual by character
- *    vs	    Visual by character using |v_CTRL-O| in Select mode
- *    V	    Visual by line
- *    Vs	    Visual by line using |v_CTRL-O| in Select mode
+ *    n        Normal
+ *    no       Operator-pending
+ *    nov      Operator-pending (forced characterwise `o_v`)
+ *    noV      Operator-pending (forced linewise `o_V`)
+ *    noCTRL-V Operator-pending (forced blockwise `o_CTRL-V`);
+ *                 CTRL-V is one character
+ *    niI      Normal using `i_CTRL-O` in `Insert-mode`
+ *    niR      Normal using `i_CTRL-O` in `Replace-mode`
+ *    niV      Normal using `i_CTRL-O` in `Virtual-Replace-mode`
+ *    nt       Terminal-Normal (insert goes to Terminal-Job mode)
+ *    v        Visual by character
+ *    vs       Visual by character using `v_CTRL-O` in Select mode
+ *    V        Visual by line
+ *    Vs       Visual by line using `v_CTRL-O` in Select mode
  *    CTRL-V   Visual blockwise
- *    CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
- *    s	    Select by character
- *    S	    Select by line
+ *    CTRL-Vs  Visual blockwise using `v_CTRL-O` in Select mode
+ *    s        Select by character
+ *    S        Select by line
  *    CTRL-S   Select blockwise
- *    i	    Insert
- *    ic	    Insert mode completion |compl-generic|
- *    ix	    Insert mode |i_CTRL-X| completion
- *    R	    Replace |R|
- *    Rc	    Replace mode completion |compl-generic|
- *    Rx	    Replace mode |i_CTRL-X| completion
- *    Rv	    Virtual Replace |gR|
- *    Rvc	    Virtual Replace mode completion |compl-generic|
- *    Rvx	    Virtual Replace mode |i_CTRL-X| completion
- *    c	    Command-line editing
- *    cv	    Vim Ex mode |gQ|
- *    ce	    Normal Ex mode |Q|
- *    r	    Hit-enter prompt
- *    rm	    The -- more -- prompt
- *    r?	    A |:confirm| query of some sort
- *    !	    Shell or external command is executing
- *    t	    Terminal-Job mode: keys go to the job
+ *    i        Insert
+ *    ic       Insert mode completion `compl-generic`
+ *    ix       Insert mode `i_CTRL-X` completion
+ *    R        Replace `R`
+ *    Rc       Replace mode completion `compl-generic`
+ *    Rx       Replace mode `i_CTRL-X` completion
+ *    Rv       Virtual Replace `gR`
+ *    Rvc      Virtual Replace mode completion `compl-generic`
+ *    Rvx      Virtual Replace mode `i_CTRL-X` completion
+ *    c        Command-line editing
+ *    cv       Vim Ex mode `gQ`
+ *    ce       Normal Ex mode `Q`
+ *    r        Hit-enter prompt
+ *    rm       The -- more -- prompt
+ *    r?       A `:confirm` query of some sort
+ *    !        Shell or external command is executing
+ *    t        Terminal-Job mode: keys go to the job
  *
  * This is useful in the 'statusline' option or when used
- * with |remote_expr()| In most other places it always returns
+ * with `remote_expr()` In most other places it always returns
  * "c" or "n".
  * Note that in the future more modes and more specific modes may
  * be added. It's better not to compare the whole string but only
  * the leading character(s).
+ * Also see `visualmode()`.
  *
- * Also see |visualmode()|.
- * Can also be used as a |method|:
- * 	DoFull()->mode()
+ * Can also be used as a `method`:
+ *
+ *     DoFull()->mode()
  */
 export function mode(denops: Denops, expr?: number | string): Promise<string> {
   return denops.call("mode", expr) as Promise<string>;

--- a/denops_std/function/vim/prop_add_list.ts
+++ b/denops_std/function/vim/prop_add_list.ts
@@ -17,32 +17,33 @@ export type PropAddListItem = [
  * Similar to prop_add(), but attaches a text property at
  * multiple positions in a buffer.
  *
- * {props} is a dictionary with these fields:
- *    bufnr	buffer to add the property to; when omitted
- * 		the current buffer is used
- *    id		user defined ID for the property; must be a
- * 		number; when omitted zero is used
- *    type		name of the text property type
+ * **{props}** is a dictionary with these fields:
+ *    bufnr        buffer to add the property to; when omitted
+ *                 the current buffer is used
+ *    id           user defined ID for the property; must be a
+ *                 number; when omitted zero is used
+ *    type         name of the text property type
  * All fields except "type" are optional.
  *
  * The second argument is a List of Lists where each list
  * specifies the starting and ending position of the text.  The
- * first two items {lnum} and {col} specify the starting position
+ * first two items **{lnum}** and **{col}** specify the starting position
  * of the text where the property will be attached and the last
- * two items {end-lnum} and {end-col} specify the position just
+ * two items **{end-lnum}** and **{end-col}** specify the position just
  * after the text.
  *
  * It is not possible to add a text property with a "text" field
  * here.
  *
  * Example:
- * 	call prop_add_list(#{type: 'MyProp', id: 2},
- * 			\ [[1, 4, 1, 7],
- * 			\  [1, 15, 1, 20],
- * 			\  [2, 30, 3, 30]]
+ *         call prop_add_list(#{type: 'MyProp', id: 2},
+ *                         \ [[1, 4, 1, 7],
+ *                         \  [1, 15, 1, 20],
+ *                         \  [2, 30, 3, 30]]
  *
- * Can also be used as a |method|:
- * 	GetProp()->prop_add_list([[1, 1, 1, 2], [1, 4, 1, 8]])
+ * Can also be used as a `method`:
+ *
+ *     GetProp()->prop_add_list([[1, 1, 1, 2], [1, 4, 1, 8]])
  */
 export function prop_add_list(
   denops: Denops,

--- a/scripts/gen-function/format.ts
+++ b/scripts/gen-function/format.ts
@@ -18,7 +18,7 @@ const translate: Record<string, string> = {
   "lnum-end": "lnum_end",
 };
 
-function formatDocs(docs: string): string[] {
+export function formatDocs(docs: string): string[] {
   const lines = docs.replaceAll(/\*\//g, "* /").split("\n");
   const normalizedLines = lines.map((v) => ` * ${v}`.trimEnd());
   return ["/**", ...normalizedLines, " */"];

--- a/scripts/gen-function/gen-function.ts
+++ b/scripts/gen-function/gen-function.ts
@@ -3,21 +3,34 @@ import {
   intersection,
 } from "https://deno.land/x/set_operations@v1.1.0/mod.ts";
 import * as path from "https://deno.land/std@0.183.0/path/mod.ts";
-import * as commonManual from "../../denops_std/function/_manual.ts";
-import * as vimManual from "../../denops_std/function/vim/_manual.ts";
-import * as nvimManual from "../../denops_std/function/nvim/_manual.ts";
 import { parse } from "./parse.ts";
 import { format } from "./format.ts";
+import { transform } from "./transform.ts";
 import { downloadString } from "../utils.ts";
 
 const VIM_VERSION = "9.0.0472";
 const NVIM_VERSION = "0.8.0";
 
-const manualFnSet = new Set([
-  ...Object.keys(commonManual),
-  ...Object.keys(vimManual),
-  ...Object.keys(nvimManual),
-]);
+const commonGenerateModule = "../../denops_std/function/_generated.ts";
+const vimGenerateModule = "../../denops_std/function/vim/_generated.ts";
+const nvimGenerateModule = "../../denops_std/function/nvim/_generated.ts";
+
+const commonManualModule = "../../denops_std/function/_manual.ts";
+const vimManualModule = "../../denops_std/function/vim/_manual.ts";
+const nvimManualModule = "../../denops_std/function/nvim/_manual.ts";
+
+const manualModules = [
+  commonManualModule,
+  vimManualModule,
+  nvimManualModule,
+];
+const manualFnSet = new Set(
+  (await Promise.all(
+    manualModules.map(async (moduleName) =>
+      Object.keys(await import(moduleName))
+    ),
+  )).flat(),
+);
 
 const vimHelpDownloadUrls = [
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/builtin.txt`,
@@ -64,20 +77,22 @@ const nvimOnlyCode = format(
 );
 
 await Deno.writeTextFile(
-  path.fromFileUrl(
-    new URL("../../denops_std/function/_generated.ts", import.meta.url),
-  ),
+  resolvePath(commonGenerateModule),
   commonCode.join("\n"),
 );
 await Deno.writeTextFile(
-  path.fromFileUrl(
-    new URL("../../denops_std/function/vim/_generated.ts", import.meta.url),
-  ),
+  resolvePath(vimGenerateModule),
   vimOnlyCode.join("\n"),
 );
 await Deno.writeTextFile(
-  path.fromFileUrl(
-    new URL("../../denops_std/function/nvim/_generated.ts", import.meta.url),
-  ),
+  resolvePath(nvimGenerateModule),
   nvimOnlyCode.join("\n"),
 );
+
+await transform(resolvePath(commonManualModule), vimDefs);
+await transform(resolvePath(vimManualModule), vimDefs);
+await transform(resolvePath(nvimManualModule), nvimDefs);
+
+function resolvePath(p: string): string {
+  return path.fromFileUrl(new URL(p, import.meta.url));
+}

--- a/scripts/gen-function/override.ts
+++ b/scripts/gen-function/override.ts
@@ -1,0 +1,8 @@
+import { DocsType } from "./types.ts";
+
+/**
+ * Mapping between function name to `DocsType`.
+ */
+export const DOCS_OVERRIDES: Readonly<Record<string, DocsType>> = {
+  has: "nvim",
+};

--- a/scripts/gen-function/transform.ts
+++ b/scripts/gen-function/transform.ts
@@ -1,0 +1,13 @@
+import { transform as transformSource } from "../transform.ts";
+import { formatDocs } from "./format.ts";
+import type { Definition } from "./types.ts";
+
+export function transform(
+  rootSourcePath: string,
+  definitions: Definition[],
+): Promise<void> {
+  const fnJSDocs = new Map(
+    definitions.map(({ fn, docs }) => [fn, formatDocs(docs).join("\n")]),
+  );
+  return transformSource(rootSourcePath, fnJSDocs);
+}

--- a/scripts/gen-function/types.ts
+++ b/scripts/gen-function/types.ts
@@ -11,3 +11,5 @@ export type Definition = {
   docs: string;
   vars: Variant[];
 };
+
+export type DocsType = "vim" | "nvim";

--- a/scripts/gen-option/format.ts
+++ b/scripts/gen-option/format.ts
@@ -24,7 +24,7 @@ function defaultValue(type: OptionType): string {
   }
 }
 
-function formatDocs(docs: string): string[] {
+export function formatDocs(docs: string): string[] {
   const lines = docs.replaceAll(/\*\//g, "* /").split("\n");
   const normalizedLines = lines.map((v) => ` * ${v}`.trimEnd());
   return ["/**", ...normalizedLines, " */"];

--- a/scripts/gen-option/override.ts
+++ b/scripts/gen-option/override.ts
@@ -1,0 +1,6 @@
+import { DocsType } from "./types.ts";
+
+/**
+ * Mapping between function name to `DocsType`.
+ */
+export const DOCS_OVERRIDES: Readonly<Record<string, DocsType>> = {};

--- a/scripts/gen-option/transform.ts
+++ b/scripts/gen-option/transform.ts
@@ -1,0 +1,13 @@
+import { transform as transformSource } from "../transform.ts";
+import { formatDocs } from "./format.ts";
+import type { Option } from "./types.ts";
+
+export function transform(
+  rootSourcePath: string,
+  options: Option[],
+): Promise<void> {
+  const fnJSDocs = new Map(
+    options.map(({ name, docs }) => [name, formatDocs(docs).join("\n")]),
+  );
+  return transformSource(rootSourcePath, fnJSDocs);
+}

--- a/scripts/gen-option/types.ts
+++ b/scripts/gen-option/types.ts
@@ -20,3 +20,5 @@ export type OptionScope = typeof OPTION_SCOPES[number];
 export function isOptionScope(x: unknown): x is OptionScope {
   return OPTION_SCOPES.includes(x as OptionScope);
 }
+
+export type DocsType = "vim" | "nvim";

--- a/scripts/transform.ts
+++ b/scripts/transform.ts
@@ -1,0 +1,87 @@
+import {
+  fromFileUrl,
+  toFileUrl,
+} from "https://deno.land/std@0.183.0/path/mod.ts";
+import { intersection } from "https://deno.land/x/set_operations@v1.1.0/mod.ts";
+
+interface ModuleInformation {
+  sourcePath: string;
+  sourceText: string;
+  functions: Set<string>;
+}
+
+function extractExportModulePaths(
+  sourcePath: string,
+  sourceText: string,
+): string[] {
+  const baseUrl = new URL("./", toFileUrl(sourcePath));
+  return [...sourceText.matchAll(/^export \* from "(?<url>.*)"/gm)].map((
+    [, url]: string[],
+  ) => fromFileUrl(new URL(url, baseUrl)));
+}
+
+function extractExportFunctions(sourceText: string): Set<string> {
+  return new Set(
+    [...sourceText.matchAll(
+      /^export\s+(?:async\s+)?function\s+(?:\*\s*)?(?<name>\w+)/gms,
+    )].map(([, name]: string[]) => name),
+  );
+}
+
+async function findExportModules(
+  sourcePath: string,
+): Promise<ModuleInformation[]> {
+  const sourceText = await Deno.readTextFile(sourcePath);
+  const modules = extractExportModulePaths(sourcePath, sourceText);
+  const descendants = await Promise.all(modules.map(findExportModules));
+  const functions = extractExportFunctions(sourceText);
+  return [
+    { sourcePath, sourceText, functions },
+    ...descendants.flat(),
+  ].filter(({ functions }) => functions.size > 0);
+}
+
+function replaceFunctionDocs(
+  sourceText: string,
+  fnJSDocs: Map<string, string>,
+): string {
+  const reLeading = /(?<leading>\s*)/.source;
+  const reJSDoc = /(?:\/\*\*[^/](?:[^*]|\*[^/])*\*\/)?/.source;
+  const reLineComments = /(?:\s|\/\/[^\n]*\n)*/.source;
+  const reFunction =
+    /^export\s+(?:async\s+)?function\s+(?:\*\s*)?(?<name>\w+)/.source;
+  const reDef = `(?<def>${reLineComments}${reFunction})`;
+  const reFunctions = new RegExp(`${reLeading}${reJSDoc}${reDef}`, "gms");
+  const fnReplaced = new Set<string>();
+  return sourceText.replaceAll(reFunctions, (prev, ...args) => {
+    const { leading, def, name } = args.at(-1) as Record<string, string>;
+    const jsdoc = fnJSDocs.get(name);
+    if (jsdoc && !fnReplaced.has(name)) {
+      fnReplaced.add(name);
+      return `${leading}${jsdoc}${def}`;
+    }
+    return prev;
+  });
+}
+
+/**
+ * Overwrite the source file by replacing the JSDoc in the export functions.
+ * Everything except JSDoc is kept.
+ * Files referenced by `export * from "..."` are replaced recursively.
+ *
+ * @param rootSourcePath - origin source file path
+ * @param fnJSDocs - Map of function names to JSDoc
+ */
+export async function transform(
+  rootSourcePath: string,
+  fnJSDocs: Map<string, string>,
+): Promise<void> {
+  const fnNames = new Set(fnJSDocs.keys());
+  const informations = await findExportModules(rootSourcePath);
+  for (const { sourcePath, sourceText, functions } of informations) {
+    if (intersection(functions, fnNames).size > 0) {
+      const transformed = replaceFunctionDocs(sourceText, fnJSDocs);
+      await Deno.writeTextFile(sourcePath, transformed);
+    }
+  }
+}


### PR DESCRIPTION
Closes #187

Generate JSDoc for functions exported in `_manual.ts`.

💪 Since `has()` referred to nvim help, so now possible to define refer to which help in common functions.

😢 Note that I tried replacing with AST parsing, but gave up because it doesn't preserve formatting.
😄 However, the source files should be `fmt`'d, so there shouldn't be any problems with RegExp parsing.