### PR TITLE
Generate return type

### DIFF
--- a/denops_std/function/_generated.ts
+++ b/denops_std/function/_generated.ts
@@ -27,7 +27,7 @@ import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
  *
  * *only available when compiled with the `+float` feature*
  */
-export function abs(denops: Denops, expr: unknown): Promise<unknown>;
+export function abs(denops: Denops, expr: unknown): Promise<number>;
 export function abs(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("abs", ...args);
 }
@@ -53,7 +53,7 @@ export function abs(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function acos(denops: Denops, expr: unknown): Promise<unknown>;
+export function acos(denops: Denops, expr: unknown): Promise<number>;
 export function acos(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("acos", ...args);
 }
@@ -79,7 +79,7 @@ export function add(
   denops: Denops,
   object: unknown,
   expr: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | unknown>;
 export function add(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("add", ...args);
 }
@@ -100,7 +100,7 @@ export function and(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function and(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("and", ...args);
 }
@@ -129,7 +129,7 @@ export function append(
   denops: Denops,
   lnum: unknown,
   text: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function append(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("append", ...args);
 }
@@ -165,7 +165,7 @@ export function appendbufline(
   buf: unknown,
   lnum: unknown,
   text: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function appendbufline(
   denops: Denops,
   ...args: unknown[]
@@ -183,7 +183,7 @@ export function appendbufline(
  * list is used: either the window number or the window ID.
  * Returns -1 if the **{winid}** argument is invalid.
  */
-export function argc(denops: Denops, winid?: unknown): Promise<unknown>;
+export function argc(denops: Denops, winid?: unknown): Promise<number>;
 export function argc(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("argc", ...args);
 }
@@ -192,7 +192,7 @@ export function argc(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The result is the current index in the argument list.  0 is
  * the first file.  argc() - 1 is the last one.  See `arglist`.
  */
-export function argidx(denops: Denops): Promise<unknown>;
+export function argidx(denops: Denops): Promise<number>;
 export function argidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("argidx", ...args);
 }
@@ -213,7 +213,7 @@ export function arglistid(
   denops: Denops,
   winnr?: unknown,
   tabnr?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function arglistid(
   denops: Denops,
   ...args: unknown[]
@@ -246,7 +246,7 @@ export function argv(
   denops: Denops,
   nr?: unknown,
   winid?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function argv(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("argv", ...args);
 }
@@ -274,7 +274,7 @@ export function argv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function asin(denops: Denops, expr: unknown): Promise<unknown>;
+export function asin(denops: Denops, expr: unknown): Promise<number>;
 export function asin(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("asin", ...args);
 }
@@ -300,7 +300,7 @@ export function asin(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function atan(denops: Denops, expr: unknown): Promise<unknown>;
+export function atan(denops: Denops, expr: unknown): Promise<number>;
 export function atan(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("atan", ...args);
 }
@@ -331,7 +331,7 @@ export function atan2(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function atan2(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("atan2", ...args);
 }
@@ -353,7 +353,7 @@ export function browse(
   title: unknown,
   initdir: unknown,
   defaultValue: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function browse(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("browse", ...args);
 }
@@ -374,7 +374,7 @@ export function browsedir(
   denops: Denops,
   title: unknown,
   initdir: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function browsedir(
   denops: Denops,
   ...args: unknown[]
@@ -416,7 +416,7 @@ export function byteidx(
   denops: Denops,
   expr: unknown,
   nr: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function byteidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("byteidx", ...args);
 }
@@ -444,7 +444,7 @@ export function byteidxcomp(
   denops: Denops,
   expr: unknown,
   nr: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function byteidxcomp(
   denops: Denops,
   ...args: unknown[]
@@ -501,7 +501,7 @@ export function call(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function ceil(denops: Denops, expr: unknown): Promise<unknown>;
+export function ceil(denops: Denops, expr: unknown): Promise<number>;
 export function ceil(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ceil", ...args);
 }
@@ -515,7 +515,7 @@ export function ceil(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * one less than the number of the undone change.
  * Returns 0 if the undo list is empty.
  */
-export function changenr(denops: Denops): Promise<unknown>;
+export function changenr(denops: Denops): Promise<number>;
 export function changenr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("changenr", ...args);
 }
@@ -553,7 +553,7 @@ export function char2nr(
   denops: Denops,
   string: unknown,
   utf8?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function char2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("char2nr", ...args);
 }
@@ -569,7 +569,7 @@ export function char2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The class is used in patterns and word motions.
  * Returns 0 if **{string}** is not a `String`.
  */
-export function charclass(denops: Denops, string: unknown): Promise<unknown>;
+export function charclass(denops: Denops, string: unknown): Promise<number>;
 export function charclass(
   denops: Denops,
   ...args: unknown[]
@@ -591,7 +591,7 @@ export function charclass(
  *
  *     GetPos()->col()
  */
-export function charcol(denops: Denops, expr: unknown): Promise<unknown>;
+export function charcol(denops: Denops, expr: unknown): Promise<number>;
 export function charcol(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("charcol", ...args);
 }
@@ -628,7 +628,7 @@ export function charidx(
   string: unknown,
   idx: unknown,
   countcc?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function charidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("charidx", ...args);
 }
@@ -660,7 +660,7 @@ export function charidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetDir()->chdir()
  */
-export function chdir(denops: Denops, dir: unknown): Promise<unknown>;
+export function chdir(denops: Denops, dir: unknown): Promise<string>;
 export function chdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("chdir", ...args);
 }
@@ -677,7 +677,7 @@ export function chdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetLnum()->cindent()
  */
-export function cindent(denops: Denops, lnum: unknown): Promise<unknown>;
+export function cindent(denops: Denops, lnum: unknown): Promise<number>;
 export function cindent(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("cindent", ...args);
 }
@@ -692,7 +692,7 @@ export function cindent(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetWin()->clearmatches()
  */
-export function clearmatches(denops: Denops, win?: unknown): Promise<unknown>;
+export function clearmatches(denops: Denops, win?: unknown): Promise<void>;
 export function clearmatches(
   denops: Denops,
   ...args: unknown[]
@@ -741,7 +741,7 @@ export function complete(
   denops: Denops,
   startcol: unknown,
   matches: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function complete(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("complete", ...args);
 }
@@ -759,7 +759,7 @@ export function complete(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetMoreMatches()->complete_add()
  */
-export function complete_add(denops: Denops, expr: unknown): Promise<unknown>;
+export function complete_add(denops: Denops, expr: unknown): Promise<number>;
 export function complete_add(
   denops: Denops,
   ...args: unknown[]
@@ -775,7 +775,7 @@ export function complete_add(
  * Only to be used by the function specified with the
  * 'completefunc' option.
  */
-export function complete_check(denops: Denops): Promise<unknown>;
+export function complete_check(denops: Denops): Promise<number>;
 export function complete_check(
   denops: Denops,
   ...args: unknown[]
@@ -845,7 +845,10 @@ export function complete_check(
  *
  *     GetItems()->complete_info()
  */
-export function complete_info(denops: Denops, what?: unknown): Promise<unknown>;
+export function complete_info(
+  denops: Denops,
+  what?: unknown,
+): Promise<Record<string, unknown>>;
 export function complete_info(
   denops: Denops,
   ...args: unknown[]
@@ -924,7 +927,7 @@ export function confirm(
   choices?: unknown,
   defaultValue?: unknown,
   type?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function confirm(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("confirm", ...args);
 }
@@ -967,7 +970,7 @@ export function copy(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function cos(denops: Denops, expr: unknown): Promise<unknown>;
+export function cos(denops: Denops, expr: unknown): Promise<number>;
 export function cos(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("cos", ...args);
 }
@@ -993,7 +996,7 @@ export function cos(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function cosh(denops: Denops, expr: unknown): Promise<unknown>;
+export function cosh(denops: Denops, expr: unknown): Promise<number>;
 export function cosh(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("cosh", ...args);
 }
@@ -1021,7 +1024,7 @@ export function count(
   expr: unknown,
   ic?: unknown,
   start?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function count(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("count", ...args);
 }
@@ -1072,7 +1075,7 @@ export function cscope_connection(
   num?: unknown,
   dbpath?: unknown,
   prepend?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function cscope_connection(
   denops: Denops,
   ...args: unknown[]
@@ -1093,7 +1096,7 @@ export function cscope_connection(
  *
  *     GetPid()->debugbreak()
  */
-export function debugbreak(denops: Denops, pid: unknown): Promise<unknown>;
+export function debugbreak(denops: Denops, pid: unknown): Promise<number>;
 export function debugbreak(
   denops: Denops,
   ...args: unknown[]
@@ -1167,7 +1170,7 @@ export function delete_(
   denops: Denops,
   fname: unknown,
   flags?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function delete_(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("delete_", ...args);
 }
@@ -1195,7 +1198,7 @@ export function deletebufline(
   buf: unknown,
   first: unknown,
   last?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function deletebufline(
   denops: Denops,
   ...args: unknown[]
@@ -1215,7 +1218,7 @@ export function deletebufline(
  * editing another buffer to set 'filetype' and load a syntax
  * file.
  */
-export function did_filetype(denops: Denops): Promise<unknown>;
+export function did_filetype(denops: Denops): Promise<number>;
 export function did_filetype(
   denops: Denops,
   ...args: unknown[]
@@ -1242,7 +1245,7 @@ export function diff_hlID(
   denops: Denops,
   lnum: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function diff_hlID(
   denops: Denops,
   ...args: unknown[]
@@ -1279,7 +1282,7 @@ export function diff_hlID(
  * feature.  If this feature is disabled, this function will
  * display an error message.
  */
-export function digraph_get(denops: Denops, chars: unknown): Promise<unknown>;
+export function digraph_get(denops: Denops, chars: unknown): Promise<string>;
 export function digraph_get(
   denops: Denops,
   ...args: unknown[]
@@ -1317,7 +1320,7 @@ export function digraph_get(
 export function digraph_getlist(
   denops: Denops,
   listall?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function digraph_getlist(
   denops: Denops,
   ...args: unknown[]
@@ -1355,7 +1358,7 @@ export function digraph_set(
   denops: Denops,
   chars: unknown,
   digraph: unknown,
-): Promise<unknown>;
+): Promise<boolean>;
 export function digraph_set(
   denops: Denops,
   ...args: unknown[]
@@ -1392,7 +1395,7 @@ export function digraph_set(
 export function digraph_setlist(
   denops: Denops,
   digraphlist: unknown,
-): Promise<unknown>;
+): Promise<boolean>;
 export function digraph_setlist(
   denops: Denops,
   ...args: unknown[]
@@ -1418,7 +1421,7 @@ export function digraph_setlist(
  *
  *     mylist->empty()
  */
-export function empty(denops: Denops, expr: unknown): Promise<unknown>;
+export function empty(denops: Denops, expr: unknown): Promise<number>;
 export function empty(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("empty", ...args);
 }
@@ -1434,7 +1437,7 @@ export function empty(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     :echo index(keys(environ()), 'HOME', 0, 1) != -1
  */
-export function environ(denops: Denops): Promise<unknown>;
+export function environ(denops: Denops): Promise<Record<string, unknown>>;
 export function environ(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("environ", ...args);
 }
@@ -1459,7 +1462,7 @@ export function escape(
   denops: Denops,
   string: unknown,
   chars: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function escape(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("escape", ...args);
 }
@@ -1486,7 +1489,7 @@ export function eval_(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * e.g., when dropping a file on Vim.  This means interactive
  * commands cannot be used.  Otherwise zero is returned.
  */
-export function eventhandler(denops: Denops): Promise<unknown>;
+export function eventhandler(denops: Denops): Promise<number>;
 export function eventhandler(
   denops: Denops,
   ...args: unknown[]
@@ -1524,7 +1527,7 @@ export function eventhandler(
  *
  *     GetCommand()->executable()
  */
-export function executable(denops: Denops, expr: unknown): Promise<unknown>;
+export function executable(denops: Denops, expr: unknown): Promise<number>;
 export function executable(
   denops: Denops,
   ...args: unknown[]
@@ -1571,7 +1574,7 @@ export function execute(
   denops: Denops,
   command: unknown,
   silent?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function execute(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("execute", ...args);
 }
@@ -1591,7 +1594,7 @@ export function execute(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetCommand()->exepath()
  */
-export function exepath(denops: Denops, expr: unknown): Promise<unknown>;
+export function exepath(denops: Denops, expr: unknown): Promise<string>;
 export function exepath(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("exepath", ...args);
 }
@@ -1617,7 +1620,7 @@ export function exepath(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function exp(denops: Denops, expr: unknown): Promise<unknown>;
+export function exp(denops: Denops, expr: unknown): Promise<number>;
 export function exp(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("exp", ...args);
 }
@@ -1767,7 +1770,7 @@ export function expandcmd(
   denops: Denops,
   string: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function expandcmd(
   denops: Denops,
   ...args: unknown[]
@@ -1823,7 +1826,7 @@ export function extend(
   expr1: unknown,
   expr2: unknown,
   expr3?: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | Record<string, unknown>>;
 export function extend(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("extend", ...args);
 }
@@ -1890,7 +1893,7 @@ export function feedkeys(
   denops: Denops,
   string: unknown,
   mode?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function feedkeys(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("feedkeys", ...args);
 }
@@ -1915,7 +1918,7 @@ export function feedkeys(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * Obsolete name: file_readable().
  */
-export function filereadable(denops: Denops, file: unknown): Promise<unknown>;
+export function filereadable(denops: Denops, file: unknown): Promise<number>;
 export function filereadable(
   denops: Denops,
   ...args: unknown[]
@@ -1933,7 +1936,7 @@ export function filereadable(
  *
  *     GetName()->filewritable()
  */
-export function filewritable(denops: Denops, file: unknown): Promise<unknown>;
+export function filewritable(denops: Denops, file: unknown): Promise<number>;
 export function filewritable(
   denops: Denops,
   ...args: unknown[]
@@ -2021,7 +2024,7 @@ export function filter(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | Record<string, unknown> | unknown | string>;
 export function filter(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("filter", ...args);
 }
@@ -2053,7 +2056,7 @@ export function finddir(
   name: unknown,
   path?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function finddir(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("finddir", ...args);
 }
@@ -2077,7 +2080,7 @@ export function findfile(
   name: unknown,
   path?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function findfile(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("findfile", ...args);
 }
@@ -2115,7 +2118,7 @@ export function flatten(
   denops: Denops,
   list: unknown,
   maxdepth?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function flatten(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("flatten", ...args);
 }
@@ -2158,7 +2161,7 @@ export function flatten(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function float2nr(denops: Denops, expr: unknown): Promise<unknown>;
+export function float2nr(denops: Denops, expr: unknown): Promise<number>;
 export function float2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("float2nr", ...args);
 }
@@ -2188,7 +2191,7 @@ export function float2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function floor(denops: Denops, expr: unknown): Promise<unknown>;
+export function floor(denops: Denops, expr: unknown): Promise<number>;
 export function floor(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("floor", ...args);
 }
@@ -2223,7 +2226,7 @@ export function fmod(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function fmod(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("fmod", ...args);
 }
@@ -2251,7 +2254,7 @@ export function fmod(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetName()->fnameescape()
  */
-export function fnameescape(denops: Denops, string: unknown): Promise<unknown>;
+export function fnameescape(denops: Denops, string: unknown): Promise<string>;
 export function fnameescape(
   denops: Denops,
   ...args: unknown[]
@@ -2288,7 +2291,7 @@ export function fnamemodify(
   denops: Denops,
   fname: unknown,
   mods: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function fnamemodify(
   denops: Denops,
   ...args: unknown[]
@@ -2307,7 +2310,7 @@ export function fnamemodify(
  *
  *     GetLnum()->foldclosed()
  */
-export function foldclosed(denops: Denops, lnum: unknown): Promise<unknown>;
+export function foldclosed(denops: Denops, lnum: unknown): Promise<number>;
 export function foldclosed(
   denops: Denops,
   ...args: unknown[]
@@ -2326,7 +2329,7 @@ export function foldclosed(
  *
  *     GetLnum()->foldclosedend()
  */
-export function foldclosedend(denops: Denops, lnum: unknown): Promise<unknown>;
+export function foldclosedend(denops: Denops, lnum: unknown): Promise<number>;
 export function foldclosedend(
   denops: Denops,
   ...args: unknown[]
@@ -2350,7 +2353,7 @@ export function foldclosedend(
  *
  *     GetLnum()->foldlevel()
  */
-export function foldlevel(denops: Denops, lnum: unknown): Promise<unknown>;
+export function foldlevel(denops: Denops, lnum: unknown): Promise<number>;
 export function foldlevel(
   denops: Denops,
   ...args: unknown[]
@@ -2378,7 +2381,7 @@ export function foldlevel(
  * Returns an empty string when there is no fold.
  * *not available when compiled without the `+folding` feature*
  */
-export function foldtext(denops: Denops): Promise<unknown>;
+export function foldtext(denops: Denops): Promise<string>;
 export function foldtext(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("foldtext", ...args);
 }
@@ -2397,7 +2400,7 @@ export function foldtext(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetLnum()->foldtextresult()
  */
-export function foldtextresult(denops: Denops, lnum: unknown): Promise<unknown>;
+export function foldtextresult(denops: Denops, lnum: unknown): Promise<string>;
 export function foldtextresult(
   denops: Denops,
   ...args: unknown[]
@@ -2421,7 +2424,7 @@ export function foldtextresult(
  *
  *     GetName()->fullcommand()
  */
-export function fullcommand(denops: Denops, name: unknown): Promise<unknown>;
+export function fullcommand(denops: Denops, name: unknown): Promise<string>;
 export function fullcommand(
   denops: Denops,
   ...args: unknown[]
@@ -2587,10 +2590,7 @@ export function function_(
  * type a character.  To force garbage collection immediately use
  * `test_garbagecollect_now()`.
  */
-export function garbagecollect(
-  denops: Denops,
-  atexit?: unknown,
-): Promise<unknown>;
+export function garbagecollect(denops: Denops, atexit?: unknown): Promise<void>;
 export function garbagecollect(
   denops: Denops,
   ...args: unknown[]
@@ -2691,8 +2691,8 @@ export function get(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetBufnr()->getbufinfo()
  */
-export function getbufinfo(denops: Denops, buf?: unknown): Promise<unknown>;
-export function getbufinfo(denops: Denops, dict?: unknown): Promise<unknown>;
+export function getbufinfo(denops: Denops, buf?: unknown): Promise<unknown[]>;
+export function getbufinfo(denops: Denops, dict?: unknown): Promise<unknown[]>;
 export function getbufinfo(
   denops: Denops,
   ...args: unknown[]
@@ -2759,7 +2759,10 @@ export function getbufvar(
  *
  *     GetBufnr()->getchangelist()
  */
-export function getchangelist(denops: Denops, buf?: unknown): Promise<unknown>;
+export function getchangelist(
+  denops: Denops,
+  buf?: unknown,
+): Promise<unknown[]>;
 export function getchangelist(
   denops: Denops,
   ...args: unknown[]
@@ -2852,7 +2855,10 @@ export function getchangelist(
  *     :  return c
  *     :endfunction
  */
-export function getchar(denops: Denops, expr?: unknown): Promise<unknown>;
+export function getchar(
+  denops: Denops,
+  expr?: unknown,
+): Promise<number | string>;
 export function getchar(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getchar", ...args);
 }
@@ -2873,7 +2879,7 @@ export function getchar(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * character itself are obtained.  Thus Shift-a results in "A"
  * without a modifier.  Returns 0 if no modifiers are used.
  */
-export function getcharmod(denops: Denops): Promise<unknown>;
+export function getcharmod(denops: Denops): Promise<number>;
 export function getcharmod(
   denops: Denops,
   ...args: unknown[]
@@ -2899,7 +2905,7 @@ export function getcharmod(
  *
  *     GetMark()->getcharpos()
  */
-export function getcharpos(denops: Denops, expr: unknown): Promise<unknown>;
+export function getcharpos(denops: Denops, expr: unknown): Promise<unknown[]>;
 export function getcharpos(
   denops: Denops,
   ...args: unknown[]
@@ -2929,7 +2935,7 @@ export function getcharpos(
  *
  * Also see `setcharsearch()`.
  */
-export function getcharsearch(denops: Denops): Promise<unknown>;
+export function getcharsearch(denops: Denops): Promise<Record<string, unknown>>;
 export function getcharsearch(
   denops: Denops,
   ...args: unknown[]
@@ -2949,7 +2955,7 @@ export function getcharsearch(
  * Otherwise this works like `getchar()`, except that a number
  * result is converted to a string.
  */
-export function getcharstr(denops: Denops, expr?: unknown): Promise<unknown>;
+export function getcharstr(denops: Denops, expr?: unknown): Promise<string>;
 export function getcharstr(
   denops: Denops,
   ...args: unknown[]
@@ -2966,7 +2972,7 @@ export function getcharstr(
  * `setcmdline()`.
  * Returns an empty string when completion is not defined.
  */
-export function getcmdcompltype(denops: Denops): Promise<unknown>;
+export function getcmdcompltype(denops: Denops): Promise<string>;
 export function getcmdcompltype(
   denops: Denops,
   ...args: unknown[]
@@ -2987,7 +2993,7 @@ export function getcmdcompltype(
  * Returns an empty string when entering a password or using
  * `inputsecret()`.
  */
-export function getcmdline(denops: Denops): Promise<unknown>;
+export function getcmdline(denops: Denops): Promise<string>;
 export function getcmdline(
   denops: Denops,
   ...args: unknown[]
@@ -3004,7 +3010,7 @@ export function getcmdline(
  * Also see `getcmdtype()`, `setcmdpos()`, `getcmdline()` and
  * `setcmdline()`.
  */
-export function getcmdpos(denops: Denops): Promise<unknown>;
+export function getcmdpos(denops: Denops): Promise<number>;
 export function getcmdpos(
   denops: Denops,
   ...args: unknown[]
@@ -3022,7 +3028,7 @@ export function getcmdpos(
  * Also see `getcmdpos()`, `setcmdpos()`, `getcmdline()` and
  * `setcmdline()`.
  */
-export function getcmdscreenpos(denops: Denops): Promise<unknown>;
+export function getcmdscreenpos(denops: Denops): Promise<number>;
 export function getcmdscreenpos(
   denops: Denops,
   ...args: unknown[]
@@ -3045,7 +3051,7 @@ export function getcmdscreenpos(
  * Returns an empty string otherwise.
  * Also see `getcmdpos()`, `setcmdpos()` and `getcmdline()`.
  */
-export function getcmdtype(denops: Denops): Promise<unknown>;
+export function getcmdtype(denops: Denops): Promise<string>;
 export function getcmdtype(
   denops: Denops,
   ...args: unknown[]
@@ -3058,7 +3064,7 @@ export function getcmdtype(
  * values are the same as `getcmdtype()`. Returns an empty string
  * when not in the command-line window.
  */
-export function getcmdwintype(denops: Denops): Promise<unknown>;
+export function getcmdwintype(denops: Denops): Promise<string>;
 export function getcmdwintype(
   denops: Denops,
   ...args: unknown[]
@@ -3143,7 +3149,7 @@ export function getcompletion(
   pat: unknown,
   type: unknown,
   filtered?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function getcompletion(
   denops: Denops,
   ...args: unknown[]
@@ -3168,7 +3174,7 @@ export function getcompletion(
 export function getcursorcharpos(
   denops: Denops,
   winid?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function getcursorcharpos(
   denops: Denops,
   ...args: unknown[]
@@ -3218,7 +3224,7 @@ export function getcwd(
   denops: Denops,
   winnr?: unknown,
   tabnr?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function getcwd(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getcwd", ...args);
 }
@@ -3238,7 +3244,7 @@ export function getcwd(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetVarname()->getenv()
  */
-export function getenv(denops: Denops, name: unknown): Promise<unknown>;
+export function getenv(denops: Denops, name: unknown): Promise<string>;
 export function getenv(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getenv", ...args);
 }
@@ -3257,7 +3263,7 @@ export function getenv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Note that the GTK GUI accepts any font name, thus checking for
  * a valid name does not work.
  */
-export function getfontname(denops: Denops, name?: unknown): Promise<unknown>;
+export function getfontname(denops: Denops, name?: unknown): Promise<string>;
 export function getfontname(
   denops: Denops,
   ...args: unknown[]
@@ -3288,7 +3294,7 @@ export function getfontname(
  *
  * For setting permissions use `setfperm()`.
  */
-export function getfperm(denops: Denops, fname: unknown): Promise<unknown>;
+export function getfperm(denops: Denops, fname: unknown): Promise<string>;
 export function getfperm(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getfperm", ...args);
 }
@@ -3305,7 +3311,7 @@ export function getfperm(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetFilename()->getfsize()
  */
-export function getfsize(denops: Denops, fname: unknown): Promise<unknown>;
+export function getfsize(denops: Denops, fname: unknown): Promise<number>;
 export function getfsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getfsize", ...args);
 }
@@ -3321,7 +3327,7 @@ export function getfsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetFilename()->getftime()
  */
-export function getftime(denops: Denops, fname: unknown): Promise<unknown>;
+export function getftime(denops: Denops, fname: unknown): Promise<number>;
 export function getftime(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getftime", ...args);
 }
@@ -3353,7 +3359,7 @@ export function getftime(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetFilename()->getftype()
  */
-export function getftype(denops: Denops, fname: unknown): Promise<unknown>;
+export function getftype(denops: Denops, fname: unknown): Promise<string>;
 export function getftype(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getftype", ...args);
 }
@@ -3386,7 +3392,7 @@ export function getjumplist(
   denops: Denops,
   winnr?: unknown,
   tabnr?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function getjumplist(
   denops: Denops,
   ...args: unknown[]
@@ -3430,7 +3436,7 @@ export function getloclist(
   denops: Denops,
   nr: unknown,
   what?: unknown,
-): Promise<unknown>;
+): Promise<Record<string, unknown>>;
 export function getloclist(
   denops: Denops,
   ...args: unknown[]
@@ -3461,7 +3467,7 @@ export function getloclist(
  *
  *     GetBufnr()->getmarklist()
  */
-export function getmarklist(denops: Denops, buf?: unknown): Promise<unknown>;
+export function getmarklist(denops: Denops, buf?: unknown): Promise<unknown[]>;
 export function getmarklist(
   denops: Denops,
   ...args: unknown[]
@@ -3501,7 +3507,7 @@ export function getmarklist(
  *
  *             :unlet m
  */
-export function getmatches(denops: Denops, win?: unknown): Promise<unknown>;
+export function getmatches(denops: Denops, win?: unknown): Promise<unknown[]>;
 export function getmatches(
   denops: Denops,
   ...args: unknown[]
@@ -3537,7 +3543,7 @@ export function getmatches(
  * When using `getchar()` the Vim variables `v:mouse_lnum`,
  * `v:mouse_col` and `v:mouse_winid` also provide these values.
  */
-export function getmousepos(denops: Denops): Promise<unknown>;
+export function getmousepos(denops: Denops): Promise<Record<string, unknown>>;
 export function getmousepos(
   denops: Denops,
   ...args: unknown[]
@@ -3550,7 +3556,7 @@ export function getmousepos(
  * On Unix and MS-Windows this is a unique number, until Vim
  * exits.
  */
-export function getpid(denops: Denops): Promise<unknown>;
+export function getpid(denops: Denops): Promise<number>;
 export function getpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getpid", ...args);
 }
@@ -3657,7 +3663,10 @@ export function getpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :echo getqflist({'nr': 2, 'title': 1})
  *     :echo getqflist({'lines' : ["F1:10:L10"]})
  */
-export function getqflist(denops: Denops, what?: unknown): Promise<unknown>;
+export function getqflist(
+  denops: Denops,
+  what?: unknown,
+): Promise<Record<string, unknown>>;
 export function getqflist(
   denops: Denops,
   ...args: unknown[]
@@ -3701,7 +3710,7 @@ export function getreg(
   regname?: unknown,
   v1?: unknown,
   list?: unknown,
-): Promise<unknown>;
+): Promise<string | unknown[]>;
 export function getreg(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getreg", ...args);
 }
@@ -3723,7 +3732,7 @@ export function getreg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetRegname()->getregtype()
  */
-export function getregtype(denops: Denops, regname?: unknown): Promise<unknown>;
+export function getregtype(denops: Denops, regname?: unknown): Promise<string>;
 export function getregtype(
   denops: Denops,
   ...args: unknown[]
@@ -3748,7 +3757,7 @@ export function getregtype(
  *
  *     GetTabnr()->gettabinfo()
  */
-export function gettabinfo(denops: Denops, tabnr?: unknown): Promise<unknown>;
+export function gettabinfo(denops: Denops, tabnr?: unknown): Promise<unknown[]>;
 export function gettabinfo(
   denops: Denops,
   ...args: unknown[]
@@ -3861,7 +3870,10 @@ export function gettabwinvar(
  *
  *     GetWinnr()->gettagstack()
  */
-export function gettagstack(denops: Denops, winnr?: unknown): Promise<unknown>;
+export function gettagstack(
+  denops: Denops,
+  winnr?: unknown,
+): Promise<Record<string, unknown>>;
 export function gettagstack(
   denops: Denops,
   ...args: unknown[]
@@ -3910,7 +3922,7 @@ export function gettagstack(
  *
  *     GetWinnr()->getwininfo()
  */
-export function getwininfo(denops: Denops, winid?: unknown): Promise<unknown>;
+export function getwininfo(denops: Denops, winid?: unknown): Promise<unknown[]>;
 export function getwininfo(
   denops: Denops,
   ...args: unknown[]
@@ -3942,7 +3954,10 @@ export function getwininfo(
  *
  *     GetTimeout()->getwinpos()
  */
-export function getwinpos(denops: Denops, timeout?: unknown): Promise<unknown>;
+export function getwinpos(
+  denops: Denops,
+  timeout?: unknown,
+): Promise<unknown[]>;
 export function getwinpos(
   denops: Denops,
   ...args: unknown[]
@@ -3957,7 +3972,7 @@ export function getwinpos(
  * The result will be -1 if the information is not available.
  * The value can be used with `:winpos`.
  */
-export function getwinposx(denops: Denops): Promise<unknown>;
+export function getwinposx(denops: Denops): Promise<number>;
 export function getwinposx(
   denops: Denops,
   ...args: unknown[]
@@ -3972,7 +3987,7 @@ export function getwinposx(
  * The result will be -1 if the information is not available.
  * The value can be used with `:winpos`.
  */
-export function getwinposy(denops: Denops): Promise<unknown>;
+export function getwinposy(denops: Denops): Promise<number>;
 export function getwinposy(
   denops: Denops,
   ...args: unknown[]
@@ -4077,7 +4092,7 @@ export function glob(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetExpr()->glob2regpat()
  */
-export function glob2regpat(denops: Denops, string: unknown): Promise<unknown>;
+export function glob2regpat(denops: Denops, string: unknown): Promise<string>;
 export function glob2regpat(
   denops: Denops,
   ...args: unknown[]
@@ -4136,7 +4151,7 @@ export function globpath(
   nosuf?: unknown,
   list?: unknown,
   alllinks?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function globpath(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("globpath", ...args);
 }
@@ -4157,7 +4172,7 @@ export function has_key(
   denops: Denops,
   dict: unknown,
   key: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function has_key(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("has_key", ...args);
 }
@@ -4205,7 +4220,7 @@ export function haslocaldir(
   denops: Denops,
   winnr?: unknown,
   tabnr?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function haslocaldir(
   denops: Denops,
   ...args: unknown[]
@@ -4255,7 +4270,7 @@ export function hasmapto(
   what: unknown,
   mode?: unknown,
   abbr?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function hasmapto(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("hasmapto", ...args);
 }
@@ -4292,7 +4307,7 @@ export function histadd(
   denops: Denops,
   history: unknown,
   item: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function histadd(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("histadd", ...args);
 }
@@ -4341,7 +4356,7 @@ export function histdel(
   denops: Denops,
   history: unknown,
   item?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function histdel(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("histdel", ...args);
 }
@@ -4371,7 +4386,7 @@ export function histget(
   denops: Denops,
   history: unknown,
   index?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function histget(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("histget", ...args);
 }
@@ -4389,7 +4404,7 @@ export function histget(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetHistory()->histnr()
  */
-export function histnr(denops: Denops, history: unknown): Promise<unknown>;
+export function histnr(denops: Denops, history: unknown): Promise<number>;
 export function histnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("histnr", ...args);
 }
@@ -4407,7 +4422,7 @@ export function histnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetName()->hlexists()
  */
-export function hlexists(denops: Denops, name: unknown): Promise<unknown>;
+export function hlexists(denops: Denops, name: unknown): Promise<number>;
 export function hlexists(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("hlexists", ...args);
 }
@@ -4428,7 +4443,7 @@ export function hlexists(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetName()->hlID()
  */
-export function hlID(denops: Denops, name: unknown): Promise<unknown>;
+export function hlID(denops: Denops, name: unknown): Promise<number>;
 export function hlID(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("hlID", ...args);
 }
@@ -4438,7 +4453,7 @@ export function hlID(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * which Vim is currently running.  Machine names greater than
  * 256 characters long are truncated.
  */
-export function hostname(denops: Denops): Promise<unknown>;
+export function hostname(denops: Denops): Promise<string>;
 export function hostname(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("hostname", ...args);
 }
@@ -4473,7 +4488,7 @@ export function iconv(
   string: unknown,
   from: unknown,
   to: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function iconv(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("iconv", ...args);
 }
@@ -4490,7 +4505,7 @@ export function iconv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetLnum()->indent()
  */
-export function indent(denops: Denops, lnum: unknown): Promise<unknown>;
+export function indent(denops: Denops, lnum: unknown): Promise<number>;
 export function indent(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("indent", ...args);
 }
@@ -4531,7 +4546,7 @@ export function index(
   expr: unknown,
   start?: unknown,
   ic?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function index(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("index", ...args);
 }
@@ -4564,7 +4579,7 @@ export function insert(
   object: unknown,
   item: unknown,
   idx?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function insert(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("insert", ...args);
 }
@@ -4583,7 +4598,7 @@ export function insert(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :endfunction
  *     :au BufWritePre * call s:check_typoname(expand('<amatch>'))
  */
-export function interrupt(denops: Denops): Promise<unknown>;
+export function interrupt(denops: Denops): Promise<void>;
 export function interrupt(
   denops: Denops,
   ...args: unknown[]
@@ -4601,7 +4616,7 @@ export function interrupt(
  *
  *     :let bits = bits->invert()
  */
-export function invert(denops: Denops, expr: unknown): Promise<unknown>;
+export function invert(denops: Denops, expr: unknown): Promise<number>;
 export function invert(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("invert", ...args);
 }
@@ -4619,7 +4634,7 @@ export function invert(denops: Denops, ...args: unknown[]): Promise<unknown> {
 export function isdirectory(
   denops: Denops,
   directory: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function isdirectory(
   denops: Denops,
   ...args: unknown[]
@@ -4645,7 +4660,7 @@ export function isdirectory(
  *
  * *only available when compiled with the `+float` feature*
  */
-export function isinf(denops: Denops, expr: unknown): Promise<unknown>;
+export function isinf(denops: Denops, expr: unknown): Promise<number>;
 export function isinf(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("isinf", ...args);
 }
@@ -4672,7 +4687,7 @@ export function isinf(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetName()->islocked()
  */
-export function islocked(denops: Denops, expr: unknown): Promise<unknown>;
+export function islocked(denops: Denops, expr: unknown): Promise<number>;
 export function islocked(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("islocked", ...args);
 }
@@ -4690,7 +4705,7 @@ export function islocked(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function isnan(denops: Denops, expr: unknown): Promise<unknown>;
+export function isnan(denops: Denops, expr: unknown): Promise<number>;
 export function isnan(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("isnan", ...args);
 }
@@ -4710,7 +4725,7 @@ export function isnan(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     mydict->items()
  */
-export function items(denops: Denops, dict: unknown): Promise<unknown>;
+export function items(denops: Denops, dict: unknown): Promise<unknown[]>;
 export function items(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("items", ...args);
 }
@@ -4736,7 +4751,7 @@ export function join(
   denops: Denops,
   list: unknown,
   sep?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function join(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("join", ...args);
 }
@@ -4817,7 +4832,7 @@ export function json_decode(
  *
  *     GetObject()->json_encode()
  */
-export function json_encode(denops: Denops, expr: unknown): Promise<unknown>;
+export function json_encode(denops: Denops, expr: unknown): Promise<string>;
 export function json_encode(
   denops: Denops,
   ...args: unknown[]
@@ -4833,7 +4848,7 @@ export function json_encode(
  *
  *     mydict->keys()
  */
-export function keys(denops: Denops, dict: unknown): Promise<unknown>;
+export function keys(denops: Denops, dict: unknown): Promise<unknown[]>;
 export function keys(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("keys", ...args);
 }
@@ -4851,7 +4866,7 @@ export function keys(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     "\<C-Home>"->keytrans()
  */
-export function keytrans(denops: Denops, string: unknown): Promise<unknown>;
+export function keytrans(denops: Denops, string: unknown): Promise<string>;
 export function keytrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("keytrans", ...args);
 }
@@ -4871,7 +4886,7 @@ export function keytrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     mylist->len()
  */
-export function len(denops: Denops, expr: unknown): Promise<unknown>;
+export function len(denops: Denops, expr: unknown): Promise<number>;
 export function len(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("len", ...args);
 }
@@ -4932,7 +4947,7 @@ export function libcall(
   libname: unknown,
   funcname: unknown,
   argument: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function libcall(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("libcall", ...args);
 }
@@ -4958,7 +4973,7 @@ export function libcallnr(
   libname: unknown,
   funcname: unknown,
   argument: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function libcallnr(
   denops: Denops,
   ...args: unknown[]
@@ -4978,7 +4993,7 @@ export function libcallnr(
  *
  *     GetLnum()->lispindent()
  */
-export function lispindent(denops: Denops, lnum: unknown): Promise<unknown>;
+export function lispindent(denops: Denops, lnum: unknown): Promise<number>;
 export function lispindent(
   denops: Denops,
   ...args: unknown[]
@@ -5015,7 +5030,7 @@ export function list2str(
   denops: Denops,
   list: unknown,
   utf8?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function list2str(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("list2str", ...args);
 }
@@ -5024,7 +5039,7 @@ export function list2str(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Return the current time, measured as seconds since 1st Jan
  * 1970.  See also `strftime()`, `strptime()` and `getftime()`.
  */
-export function localtime(denops: Denops): Promise<unknown>;
+export function localtime(denops: Denops): Promise<number>;
 export function localtime(
   denops: Denops,
   ...args: unknown[]
@@ -5053,7 +5068,7 @@ export function localtime(
  *
  * *only available when compiled with the `+float` feature*
  */
-export function log(denops: Denops, expr: unknown): Promise<unknown>;
+export function log(denops: Denops, expr: unknown): Promise<number>;
 export function log(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("log", ...args);
 }
@@ -5078,7 +5093,7 @@ export function log(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function log10(denops: Denops, expr: unknown): Promise<unknown>;
+export function log10(denops: Denops, expr: unknown): Promise<number>;
 export function log10(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("log10", ...args);
 }
@@ -5156,7 +5171,7 @@ export function map(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | Record<string, unknown> | unknown | string>;
 export function map(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("map", ...args);
 }
@@ -5244,7 +5259,7 @@ export function maparg(
   mode?: unknown,
   abbr?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<string | Record<string, unknown>>;
 export function maparg(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("maparg", ...args);
 }
@@ -5293,7 +5308,7 @@ export function mapcheck(
   name: unknown,
   mode?: unknown,
   abbr?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function mapcheck(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("mapcheck", ...args);
 }
@@ -5343,8 +5358,8 @@ export function mapset(
   mode: unknown,
   abbr: unknown,
   dict: unknown,
-): Promise<unknown>;
-export function mapset(denops: Denops, dict: unknown): Promise<unknown>;
+): Promise<void>;
+export function mapset(denops: Denops, dict: unknown): Promise<void>;
 export function mapset(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("mapset", ...args);
 }
@@ -5434,7 +5449,7 @@ export function match(
   pat: unknown,
   start?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function match(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("match", ...args);
 }
@@ -5511,7 +5526,7 @@ export function matchadd(
   priority?: unknown,
   id?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function matchadd(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("matchadd", ...args);
 }
@@ -5565,7 +5580,7 @@ export function matchaddpos(
   priority?: unknown,
   id?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function matchaddpos(
   denops: Denops,
   ...args: unknown[]
@@ -5589,7 +5604,7 @@ export function matchaddpos(
  *
  *     GetMatch()->matcharg()
  */
-export function matcharg(denops: Denops, nr: unknown): Promise<unknown>;
+export function matcharg(denops: Denops, nr: unknown): Promise<unknown[]>;
 export function matcharg(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("matcharg", ...args);
 }
@@ -5610,7 +5625,7 @@ export function matchdelete(
   denops: Denops,
   id: unknown,
   win?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function matchdelete(
   denops: Denops,
   ...args: unknown[]
@@ -5655,7 +5670,7 @@ export function matchend(
   pat: unknown,
   start?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function matchend(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("matchend", ...args);
 }
@@ -5744,7 +5759,7 @@ export function matchfuzzy(
   list: unknown,
   str: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function matchfuzzy(
   denops: Denops,
   ...args: unknown[]
@@ -5784,7 +5799,7 @@ export function matchfuzzypos(
   list: unknown,
   str: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function matchfuzzypos(
   denops: Denops,
   ...args: unknown[]
@@ -5816,7 +5831,7 @@ export function matchlist(
   pat: unknown,
   start?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function matchlist(
   denops: Denops,
   ...args: unknown[]
@@ -5853,7 +5868,7 @@ export function matchstr(
   pat: unknown,
   start?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function matchstr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("matchstr", ...args);
 }
@@ -5894,7 +5909,7 @@ export function matchstrpos(
   pat: unknown,
   start?: unknown,
   count?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function matchstrpos(
   denops: Denops,
   ...args: unknown[]
@@ -5917,7 +5932,7 @@ export function matchstrpos(
  *
  *     mylist->max()
  */
-export function max(denops: Denops, expr: unknown): Promise<unknown>;
+export function max(denops: Denops, expr: unknown): Promise<number>;
 export function max(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("max", ...args);
 }
@@ -6001,7 +6016,7 @@ export function menu_info(
   denops: Denops,
   name: unknown,
   mode?: unknown,
-): Promise<unknown>;
+): Promise<Record<string, unknown>>;
 export function menu_info(
   denops: Denops,
   ...args: unknown[]
@@ -6024,7 +6039,7 @@ export function menu_info(
  *
  *     mylist->min()
  */
-export function min(denops: Denops, expr: unknown): Promise<unknown>;
+export function min(denops: Denops, expr: unknown): Promise<number>;
 export function min(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("min", ...args);
 }
@@ -6093,7 +6108,7 @@ export function mkdir(
   name: unknown,
   path?: unknown,
   prot?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function mkdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("mkdir", ...args);
 }
@@ -6113,7 +6128,7 @@ export function mkdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetLnum()->nextnonblank()
  */
-export function nextnonblank(denops: Denops, lnum: unknown): Promise<unknown>;
+export function nextnonblank(denops: Denops, lnum: unknown): Promise<number>;
 export function nextnonblank(
   denops: Denops,
   ...args: unknown[]
@@ -6153,7 +6168,7 @@ export function nr2char(
   denops: Denops,
   expr: unknown,
   utf8?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function nr2char(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("nr2char", ...args);
 }
@@ -6179,7 +6194,7 @@ export function or(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function or(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("or", ...args);
 }
@@ -6209,7 +6224,7 @@ export function pathshorten(
   denops: Denops,
   path: unknown,
   len?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function pathshorten(
   denops: Denops,
   ...args: unknown[]
@@ -6267,7 +6282,7 @@ export function perleval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function pow(denops: Denops, x: unknown, y: unknown): Promise<unknown>;
+export function pow(denops: Denops, x: unknown, y: unknown): Promise<number>;
 export function pow(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("pow", ...args);
 }
@@ -6287,7 +6302,7 @@ export function pow(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetLnum()->prevnonblank()
  */
-export function prevnonblank(denops: Denops, lnum: unknown): Promise<unknown>;
+export function prevnonblank(denops: Denops, lnum: unknown): Promise<number>;
 export function prevnonblank(
   denops: Denops,
   ...args: unknown[]
@@ -6499,7 +6514,7 @@ export function printf(
   denops: Denops,
   fmt: unknown,
   expr1: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function printf(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("printf", ...args);
 }
@@ -6517,10 +6532,7 @@ export function printf(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+channel` feature*
  */
-export function prompt_getprompt(
-  denops: Denops,
-  buf: unknown,
-): Promise<unknown>;
+export function prompt_getprompt(denops: Denops, buf: unknown): Promise<string>;
 export function prompt_getprompt(
   denops: Denops,
   ...args: unknown[]
@@ -6568,7 +6580,7 @@ export function prompt_setcallback(
   denops: Denops,
   buf: unknown,
   expr: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prompt_setcallback(
   denops: Denops,
   ...args: unknown[]
@@ -6595,7 +6607,7 @@ export function prompt_setinterrupt(
   denops: Denops,
   buf: unknown,
   expr: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prompt_setinterrupt(
   denops: Denops,
   ...args: unknown[]
@@ -6621,7 +6633,7 @@ export function prompt_setprompt(
   denops: Denops,
   buf: unknown,
   text: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prompt_setprompt(
   denops: Denops,
   ...args: unknown[]
@@ -6643,7 +6655,7 @@ export function prompt_setprompt(
  * The values are the same as in `v:event` during
  * `CompleteChanged`.
  */
-export function pum_getpos(denops: Denops): Promise<unknown>;
+export function pum_getpos(denops: Denops): Promise<Record<string, unknown>>;
 export function pum_getpos(
   denops: Denops,
   ...args: unknown[]
@@ -6657,7 +6669,7 @@ export function pum_getpos(
  * This can be used to avoid some things that would remove the
  * popup menu.
  */
-export function pumvisible(denops: Denops): Promise<unknown>;
+export function pumvisible(denops: Denops): Promise<number>;
 export function pumvisible(
   denops: Denops,
   ...args: unknown[]
@@ -6744,7 +6756,7 @@ export function pyxeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :echo rand(seed)
  *     :echo rand(seed) % 16  " random number 0 - 15
  */
-export function rand(denops: Denops, expr?: unknown): Promise<unknown>;
+export function rand(denops: Denops, expr?: unknown): Promise<number>;
 export function rand(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("rand", ...args);
 }
@@ -6777,7 +6789,7 @@ export function range(
   expr: unknown,
   max?: unknown,
   stride?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function range(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("range", ...args);
 }
@@ -6850,7 +6862,7 @@ export function readdir(
   directory: unknown,
   expr?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function readdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("readdir", ...args);
 }
@@ -6900,7 +6912,7 @@ export function readfile(
   fname: unknown,
   type?: unknown,
   max?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function readfile(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("readfile", ...args);
 }
@@ -6942,7 +6954,7 @@ export function reduce(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Returns an empty string when no register is being executed.
  * See `@`.
  */
-export function reg_executing(denops: Denops): Promise<unknown>;
+export function reg_executing(denops: Denops): Promise<string>;
 export function reg_executing(
   denops: Denops,
   ...args: unknown[]
@@ -6954,7 +6966,7 @@ export function reg_executing(
  * Returns the single letter name of the register being recorded.
  * Returns an empty string when not recording.  See `q`.
  */
-export function reg_recording(denops: Denops): Promise<unknown>;
+export function reg_recording(denops: Denops): Promise<string>;
 export function reg_recording(
   denops: Denops,
   ...args: unknown[]
@@ -6991,7 +7003,7 @@ export function reltime(
   denops: Denops,
   start?: unknown,
   end?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function reltime(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("reltime", ...args);
 }
@@ -7015,7 +7027,7 @@ export function reltime(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+reltime` feature*
  */
-export function reltimefloat(denops: Denops, time: unknown): Promise<unknown>;
+export function reltimefloat(denops: Denops, time: unknown): Promise<number>;
 export function reltimefloat(
   denops: Denops,
   ...args: unknown[]
@@ -7049,7 +7061,7 @@ export function reltimefloat(
  *
  * *only available when compiled with the `+reltime` feature*
  */
-export function reltimestr(denops: Denops, time: unknown): Promise<unknown>;
+export function reltimestr(denops: Denops, time: unknown): Promise<string>;
 export function reltimestr(
   denops: Denops,
   ...args: unknown[]
@@ -7103,7 +7115,7 @@ export function rename(
   denops: Denops,
   from: unknown,
   to: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function rename(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("rename", ...args);
 }
@@ -7130,7 +7142,7 @@ export function repeat(
   denops: Denops,
   expr: unknown,
   count: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | unknown | string>;
 export function repeat(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("repeat", ...args);
 }
@@ -7155,7 +7167,7 @@ export function repeat(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetName()->resolve()
  */
-export function resolve(denops: Denops, filename: unknown): Promise<unknown>;
+export function resolve(denops: Denops, filename: unknown): Promise<string>;
 export function resolve(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("resolve", ...args);
 }
@@ -7173,7 +7185,7 @@ export function resolve(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     mylist->reverse()
  */
-export function reverse(denops: Denops, object: unknown): Promise<unknown>;
+export function reverse(denops: Denops, object: unknown): Promise<unknown[]>;
 export function reverse(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("reverse", ...args);
 }
@@ -7204,7 +7216,7 @@ export function reverse(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function round(denops: Denops, expr: unknown): Promise<unknown>;
+export function round(denops: Denops, expr: unknown): Promise<number>;
 export function round(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("round", ...args);
 }
@@ -7246,7 +7258,7 @@ export function screenattr(
   denops: Denops,
   row: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function screenattr(
   denops: Denops,
   ...args: unknown[]
@@ -7272,7 +7284,7 @@ export function screenchar(
   denops: Denops,
   row: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function screenchar(
   denops: Denops,
   ...args: unknown[]
@@ -7295,7 +7307,7 @@ export function screenchars(
   denops: Denops,
   row: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function screenchars(
   denops: Denops,
   ...args: unknown[]
@@ -7318,7 +7330,7 @@ export function screenchars(
  *     nnoremap <silent> GG :echom screencol()<CR>
  *     nnoremap GG <Cmd>echom screencol()<CR>
  */
-export function screencol(denops: Denops): Promise<unknown>;
+export function screencol(denops: Denops): Promise<number>;
 export function screencol(
   denops: Denops,
   ...args: unknown[]
@@ -7334,7 +7346,7 @@ export function screencol(
  *
  * Note: Same restrictions as with `screencol()`.
  */
-export function screenrow(denops: Denops): Promise<unknown>;
+export function screenrow(denops: Denops): Promise<number>;
 export function screenrow(
   denops: Denops,
   ...args: unknown[]
@@ -7358,7 +7370,7 @@ export function screenstring(
   denops: Denops,
   row: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function screenstring(
   denops: Denops,
   ...args: unknown[]
@@ -7484,7 +7496,7 @@ export function search(
   stopline?: unknown,
   timeout?: unknown,
   skip?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function search(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("search", ...args);
 }
@@ -7621,7 +7633,7 @@ export function search(denops: Denops, ...args: unknown[]): Promise<unknown> {
 export function searchcount(
   denops: Denops,
   options?: unknown,
-): Promise<unknown>;
+): Promise<Record<string, unknown>>;
 export function searchcount(
   denops: Denops,
   ...args: unknown[]
@@ -7657,7 +7669,7 @@ export function searchdecl(
   name: unknown,
   global?: unknown,
   thisblock?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function searchdecl(
   denops: Denops,
   ...args: unknown[]
@@ -7764,7 +7776,7 @@ export function searchpair(
   skip?: unknown,
   stopline?: unknown,
   timeout?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function searchpair(
   denops: Denops,
   ...args: unknown[]
@@ -7792,7 +7804,7 @@ export function searchpairpos(
   skip?: unknown,
   stopline?: unknown,
   timeout?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function searchpairpos(
   denops: Denops,
   ...args: unknown[]
@@ -7829,7 +7841,7 @@ export function searchpos(
   stopline?: unknown,
   timeout?: unknown,
   skip?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function searchpos(
   denops: Denops,
   ...args: unknown[]
@@ -7846,7 +7858,7 @@ export function searchpos(
  *
  *     :echo serverlist()
  */
-export function serverlist(denops: Denops): Promise<unknown>;
+export function serverlist(denops: Denops): Promise<string>;
 export function serverlist(
   denops: Denops,
   ...args: unknown[]
@@ -7880,7 +7892,7 @@ export function setbufvar(
   buf: unknown,
   varname: unknown,
   val: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function setbufvar(
   denops: Denops,
   ...args: unknown[]
@@ -7916,7 +7928,7 @@ export function setbufvar(
  * You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
  * the effect for known emoji characters.
  */
-export function setcellwidths(denops: Denops, list: unknown): Promise<unknown>;
+export function setcellwidths(denops: Denops, list: unknown): Promise<void>;
 export function setcellwidths(
   denops: Denops,
   ...args: unknown[]
@@ -7947,7 +7959,7 @@ export function setcharpos(
   denops: Denops,
   expr: unknown,
   list: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setcharpos(
   denops: Denops,
   ...args: unknown[]
@@ -7981,7 +7993,10 @@ export function setcharpos(
  *
  *     SavedSearch()->setcharsearch()
  */
-export function setcharsearch(denops: Denops, dict: unknown): Promise<unknown>;
+export function setcharsearch(
+  denops: Denops,
+  dict: unknown,
+): Promise<Record<string, unknown>>;
 export function setcharsearch(
   denops: Denops,
   ...args: unknown[]
@@ -8004,7 +8019,7 @@ export function setcmdline(
   denops: Denops,
   str: unknown,
   pos?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setcmdline(
   denops: Denops,
   ...args: unknown[]
@@ -8031,7 +8046,7 @@ export function setcmdline(
  *
  *     GetPos()->setcmdpos()
  */
-export function setcmdpos(denops: Denops, pos: unknown): Promise<unknown>;
+export function setcmdpos(denops: Denops, pos: unknown): Promise<number>;
 export function setcmdpos(
   denops: Denops,
   ...args: unknown[]
@@ -8063,11 +8078,11 @@ export function setcursorcharpos(
   lnum: unknown,
   col: unknown,
   off?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setcursorcharpos(
   denops: Denops,
   list: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setcursorcharpos(
   denops: Denops,
   ...args: unknown[]
@@ -8092,7 +8107,7 @@ export function setenv(
   denops: Denops,
   name: unknown,
   val: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function setenv(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("setenv", ...args);
 }
@@ -8122,7 +8137,7 @@ export function setfperm(
   denops: Denops,
   fname: unknown,
   mode: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setfperm(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("setfperm", ...args);
 }
@@ -8154,7 +8169,7 @@ export function setloclist(
   list: unknown,
   action?: unknown,
   what?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setloclist(
   denops: Denops,
   ...args: unknown[]
@@ -8178,7 +8193,7 @@ export function setmatches(
   denops: Denops,
   list: unknown,
   win?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setmatches(
   denops: Denops,
   ...args: unknown[]
@@ -8309,7 +8324,7 @@ export function setqflist(
   list: unknown,
   action?: unknown,
   what?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setqflist(
   denops: Denops,
   ...args: unknown[]
@@ -8387,7 +8402,7 @@ export function setreg(
   regname: unknown,
   value: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function setreg(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("setreg", ...args);
 }
@@ -8412,7 +8427,7 @@ export function settabvar(
   tabnr: unknown,
   varname: unknown,
   val: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function settabvar(
   denops: Denops,
   ...args: unknown[]
@@ -8451,7 +8466,7 @@ export function settabwinvar(
   winnr: unknown,
   varname: unknown,
   val: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function settabwinvar(
   denops: Denops,
   ...args: unknown[]
@@ -8504,7 +8519,7 @@ export function settagstack(
   nr: unknown,
   dict: unknown,
   action?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function settagstack(
   denops: Denops,
   ...args: unknown[]
@@ -8529,7 +8544,7 @@ export function setwinvar(
   winnr: unknown,
   varname: unknown,
   val: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function setwinvar(
   denops: Denops,
   ...args: unknown[]
@@ -8547,7 +8562,7 @@ export function setwinvar(
  *
  * *only available when compiled with the `+cryptv` feature*
  */
-export function sha256(denops: Denops, string: unknown): Promise<unknown>;
+export function sha256(denops: Denops, string: unknown): Promise<string>;
 export function sha256(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("sha256", ...args);
 }
@@ -8602,7 +8617,7 @@ export function shellescape(
   denops: Denops,
   string: unknown,
   special?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function shellescape(
   denops: Denops,
   ...args: unknown[]
@@ -8626,7 +8641,7 @@ export function shellescape(
  *
  *     GetColumn()->shiftwidth()
  */
-export function shiftwidth(denops: Denops, col?: unknown): Promise<unknown>;
+export function shiftwidth(denops: Denops, col?: unknown): Promise<number>;
 export function shiftwidth(
   denops: Denops,
   ...args: unknown[]
@@ -8657,7 +8672,7 @@ export function shiftwidth(
  *
  *     GetName()->simplify()
  */
-export function simplify(denops: Denops, filename: unknown): Promise<unknown>;
+export function simplify(denops: Denops, filename: unknown): Promise<string>;
 export function simplify(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("simplify", ...args);
 }
@@ -8682,7 +8697,7 @@ export function simplify(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function sin(denops: Denops, expr: unknown): Promise<unknown>;
+export function sin(denops: Denops, expr: unknown): Promise<number>;
 export function sin(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("sin", ...args);
 }
@@ -8708,7 +8723,7 @@ export function sin(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function sinh(denops: Denops, expr: unknown): Promise<unknown>;
+export function sinh(denops: Denops, expr: unknown): Promise<number>;
 export function sinh(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("sinh", ...args);
 }
@@ -8804,7 +8819,7 @@ export function sort(
   list: unknown,
   how?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function sort(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("sort", ...args);
 }
@@ -8821,7 +8836,7 @@ export function sort(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetWord()->soundfold()
  */
-export function soundfold(denops: Denops, word: unknown): Promise<unknown>;
+export function soundfold(denops: Denops, word: unknown): Promise<string>;
 export function soundfold(
   denops: Denops,
   ...args: unknown[]
@@ -8862,7 +8877,7 @@ export function soundfold(
 export function spellbadword(
   denops: Denops,
   sentence?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function spellbadword(
   denops: Denops,
   ...args: unknown[]
@@ -8900,7 +8915,7 @@ export function spellsuggest(
   word: unknown,
   max?: unknown,
   capital?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function spellsuggest(
   denops: Denops,
   ...args: unknown[]
@@ -8948,7 +8963,7 @@ export function split(
   string: unknown,
   pattern?: unknown,
   keepempty?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function split(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("split", ...args);
 }
@@ -8976,7 +8991,7 @@ export function split(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function sqrt(denops: Denops, expr: unknown): Promise<unknown>;
+export function sqrt(denops: Denops, expr: unknown): Promise<number>;
 export function sqrt(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("sqrt", ...args);
 }
@@ -8996,7 +9011,7 @@ export function sqrt(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :let seed = srand(userinput)
  *     :echo rand(seed)
  */
-export function srand(denops: Denops, expr?: unknown): Promise<unknown>;
+export function srand(denops: Denops, expr?: unknown): Promise<unknown[]>;
 export function srand(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("srand", ...args);
 }
@@ -9031,7 +9046,7 @@ export function str2float(
   denops: Denops,
   string: unknown,
   quoted?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function str2float(
   denops: Denops,
   ...args: unknown[]
@@ -9063,7 +9078,7 @@ export function str2list(
   denops: Denops,
   string: unknown,
   utf8?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function str2list(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("str2list", ...args);
 }
@@ -9097,7 +9112,7 @@ export function str2nr(
   string: unknown,
   base?: unknown,
   quoted?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function str2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("str2nr", ...args);
 }
@@ -9129,7 +9144,7 @@ export function strcharpart(
   start: unknown,
   len?: unknown,
   skipcc?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function strcharpart(
   denops: Denops,
   ...args: unknown[]
@@ -9174,7 +9189,7 @@ export function strchars(
   denops: Denops,
   string: unknown,
   skipcc?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function strchars(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strchars", ...args);
 }
@@ -9201,7 +9216,7 @@ export function strdisplaywidth(
   denops: Denops,
   string: unknown,
   col?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function strdisplaywidth(
   denops: Denops,
   ...args: unknown[]
@@ -9239,7 +9254,7 @@ export function strftime(
   denops: Denops,
   format: unknown,
   time?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function strftime(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strftime", ...args);
 }
@@ -9261,7 +9276,7 @@ export function strgetchar(
   denops: Denops,
   str: unknown,
   index: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function strgetchar(
   denops: Denops,
   ...args: unknown[]
@@ -9300,7 +9315,7 @@ export function stridx(
   haystack: unknown,
   needle: unknown,
   start?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function stridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("stridx", ...args);
 }
@@ -9328,7 +9343,7 @@ export function stridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * Also see `strtrans()`.
  */
-export function string(denops: Denops, expr: unknown): Promise<unknown>;
+export function string(denops: Denops, expr: unknown): Promise<string>;
 export function string(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("string", ...args);
 }
@@ -9346,7 +9361,7 @@ export function string(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetString()->strlen()
  */
-export function strlen(denops: Denops, string: unknown): Promise<unknown>;
+export function strlen(denops: Denops, string: unknown): Promise<number>;
 export function strlen(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strlen", ...args);
 }
@@ -9388,7 +9403,7 @@ export function strpart(
   start: unknown,
   len?: unknown,
   chars?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function strpart(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strpart", ...args);
 }
@@ -9435,7 +9450,7 @@ export function strptime(
   denops: Denops,
   format: unknown,
   timestring: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function strptime(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strptime", ...args);
 }
@@ -9470,7 +9485,7 @@ export function strridx(
   haystack: unknown,
   needle: unknown,
   start?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function strridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strridx", ...args);
 }
@@ -9491,7 +9506,7 @@ export function strridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetString()->strtrans()
  */
-export function strtrans(denops: Denops, string: unknown): Promise<unknown>;
+export function strtrans(denops: Denops, string: unknown): Promise<string>;
 export function strtrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strtrans", ...args);
 }
@@ -9509,7 +9524,7 @@ export function strtrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetString()->strwidth()
  */
-export function strwidth(denops: Denops, string: unknown): Promise<unknown>;
+export function strwidth(denops: Denops, string: unknown): Promise<number>;
 export function strwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("strwidth", ...args);
 }
@@ -9552,7 +9567,7 @@ export function submatch(
   denops: Denops,
   nr: unknown,
   list?: unknown,
-): Promise<unknown>;
+): Promise<string | unknown[]>;
 export function submatch(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("submatch", ...args);
 }
@@ -9618,7 +9633,7 @@ export function substitute(
   pat: unknown,
   sub: unknown,
   flags: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function substitute(
   denops: Denops,
   ...args: unknown[]
@@ -9649,7 +9664,10 @@ export function substitute(
  *
  *     GetFilename()->swapinfo()
  */
-export function swapinfo(denops: Denops, fname: unknown): Promise<unknown>;
+export function swapinfo(
+  denops: Denops,
+  fname: unknown,
+): Promise<Record<string, unknown>>;
 export function swapinfo(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("swapinfo", ...args);
 }
@@ -9665,7 +9683,7 @@ export function swapinfo(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetBufname()->swapname()
  */
-export function swapname(denops: Denops, buf: unknown): Promise<unknown>;
+export function swapname(denops: Denops, buf: unknown): Promise<string>;
 export function swapname(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("swapname", ...args);
 }
@@ -9701,7 +9719,7 @@ export function synID(
   lnum: unknown,
   col: unknown,
   trans: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function synID(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("synID", ...args);
 }
@@ -9756,7 +9774,7 @@ export function synIDattr(
   synID: unknown,
   what: unknown,
   mode?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function synIDattr(
   denops: Denops,
   ...args: unknown[]
@@ -9776,7 +9794,7 @@ export function synIDattr(
  *
  *     :echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
  */
-export function synIDtrans(denops: Denops, synID: unknown): Promise<unknown>;
+export function synIDtrans(denops: Denops, synID: unknown): Promise<number>;
 export function synIDtrans(
   denops: Denops,
   ...args: unknown[]
@@ -9813,7 +9831,7 @@ export function synconcealed(
   denops: Denops,
   lnum: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function synconcealed(
   denops: Denops,
   ...args: unknown[]
@@ -9846,7 +9864,7 @@ export function synstack(
   denops: Denops,
   lnum: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function synstack(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("synstack", ...args);
 }
@@ -9921,7 +9939,7 @@ export function system(
   denops: Denops,
   expr: unknown,
   input?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function system(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("system", ...args);
 }
@@ -9949,7 +9967,7 @@ export function systemlist(
   denops: Denops,
   expr: unknown,
   input?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function systemlist(
   denops: Denops,
   ...args: unknown[]
@@ -9976,7 +9994,10 @@ export function systemlist(
  *
  *     GetTabpage()->tabpagebuflist()
  */
-export function tabpagebuflist(denops: Denops, arg?: unknown): Promise<unknown>;
+export function tabpagebuflist(
+  denops: Denops,
+  arg?: unknown,
+): Promise<unknown[]>;
 export function tabpagebuflist(
   denops: Denops,
   ...args: unknown[]
@@ -9998,7 +10019,7 @@ export function tabpagebuflist(
  *
  * Returns zero on error.
  */
-export function tabpagenr(denops: Denops, arg?: unknown): Promise<unknown>;
+export function tabpagenr(denops: Denops, arg?: unknown): Promise<number>;
 export function tabpagenr(
   denops: Denops,
   ...args: unknown[]
@@ -10029,7 +10050,7 @@ export function tabpagewinnr(
   denops: Denops,
   tabarg: unknown,
   arg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function tabpagewinnr(
   denops: Denops,
   ...args: unknown[]
@@ -10041,7 +10062,7 @@ export function tabpagewinnr(
  * Returns a `List` with the file names used to search for tags
  * for the current buffer.  This is the 'tags' option expanded.
  */
-export function tagfiles(denops: Denops): Promise<unknown>;
+export function tagfiles(denops: Denops): Promise<unknown[]>;
 export function tagfiles(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("tagfiles", ...args);
 }
@@ -10097,7 +10118,7 @@ export function taglist(
   denops: Denops,
   expr: unknown,
   filename?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function taglist(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("taglist", ...args);
 }
@@ -10123,7 +10144,7 @@ export function taglist(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function tan(denops: Denops, expr: unknown): Promise<unknown>;
+export function tan(denops: Denops, expr: unknown): Promise<number>;
 export function tan(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("tan", ...args);
 }
@@ -10149,7 +10170,7 @@ export function tan(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function tanh(denops: Denops, expr: unknown): Promise<unknown>;
+export function tanh(denops: Denops, expr: unknown): Promise<number>;
 export function tanh(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("tanh", ...args);
 }
@@ -10167,7 +10188,7 @@ export function tanh(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * option is set, or when 'shellcmdflag' starts with '-' and
  * 'shell' does not contain powershell or pwsh.
  */
-export function tempname(denops: Denops): Promise<unknown>;
+export function tempname(denops: Denops): Promise<string>;
 export function tempname(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("tempname", ...args);
 }
@@ -10195,7 +10216,7 @@ export function tempname(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+timers` feature*
  */
-export function timer_info(denops: Denops, id?: unknown): Promise<unknown>;
+export function timer_info(denops: Denops, id?: unknown): Promise<unknown[]>;
 export function timer_info(
   denops: Denops,
   ...args: unknown[]
@@ -10226,7 +10247,7 @@ export function timer_pause(
   denops: Denops,
   timer: unknown,
   paused: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function timer_pause(
   denops: Denops,
   ...args: unknown[]
@@ -10282,7 +10303,7 @@ export function timer_start(
   time: unknown,
   callback: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function timer_start(
   denops: Denops,
   ...args: unknown[]
@@ -10301,7 +10322,7 @@ export function timer_start(
  *
  * *only available when compiled with the `+timers` feature*
  */
-export function timer_stop(denops: Denops, timer: unknown): Promise<unknown>;
+export function timer_stop(denops: Denops, timer: unknown): Promise<void>;
 export function timer_stop(
   denops: Denops,
   ...args: unknown[]
@@ -10316,7 +10337,7 @@ export function timer_stop(
  *
  * *only available when compiled with the `+timers` feature*
  */
-export function timer_stopall(denops: Denops): Promise<unknown>;
+export function timer_stopall(denops: Denops): Promise<void>;
 export function timer_stopall(
   denops: Denops,
   ...args: unknown[]
@@ -10333,7 +10354,7 @@ export function timer_stopall(
  *
  *     GetText()->tolower()
  */
-export function tolower(denops: Denops, expr: unknown): Promise<unknown>;
+export function tolower(denops: Denops, expr: unknown): Promise<string>;
 export function tolower(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("tolower", ...args);
 }
@@ -10347,7 +10368,7 @@ export function tolower(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetText()->toupper()
  */
-export function toupper(denops: Denops, expr: unknown): Promise<unknown>;
+export function toupper(denops: Denops, expr: unknown): Promise<string>;
 export function toupper(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("toupper", ...args);
 }
@@ -10381,7 +10402,7 @@ export function tr(
   src: unknown,
   fromstr: unknown,
   tostr: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function tr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("tr", ...args);
 }
@@ -10431,7 +10452,7 @@ export function trim(
   text: unknown,
   mask?: unknown,
   dir?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function trim(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("trim", ...args);
 }
@@ -10461,7 +10482,7 @@ export function trim(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+float` feature*
  */
-export function trunc(denops: Denops, expr: unknown): Promise<unknown>;
+export function trunc(denops: Denops, expr: unknown): Promise<number>;
 export function trunc(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("trunc", ...args);
 }
@@ -10500,7 +10521,7 @@ export function trunc(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     mylist->type()
  */
-export function type(denops: Denops, expr: unknown): Promise<unknown>;
+export function type(denops: Denops, expr: unknown): Promise<number>;
 export function type(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("type", ...args);
 }
@@ -10522,7 +10543,7 @@ export function type(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetFilename()->undofile()
  */
-export function undofile(denops: Denops, name: unknown): Promise<unknown>;
+export function undofile(denops: Denops, name: unknown): Promise<string>;
 export function undofile(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("undofile", ...args);
 }
@@ -10570,7 +10591,7 @@ export function undofile(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *                 blocks.  Each item may again have an "alt"
  *                 item.
  */
-export function undotree(denops: Denops): Promise<unknown>;
+export function undotree(denops: Denops): Promise<unknown[]>;
 export function undotree(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("undotree", ...args);
 }
@@ -10596,7 +10617,7 @@ export function uniq(
   list: unknown,
   func?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function uniq(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("uniq", ...args);
 }
@@ -10610,7 +10631,7 @@ export function uniq(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     mydict->values()
  */
-export function values(denops: Denops, dict: unknown): Promise<unknown>;
+export function values(denops: Denops, dict: unknown): Promise<unknown[]>;
 export function values(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("values", ...args);
 }
@@ -10641,7 +10662,7 @@ export function virtcol2col(
   winid: unknown,
   lnum: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function virtcol2col(
   denops: Denops,
   ...args: unknown[]
@@ -10669,7 +10690,7 @@ export function virtcol2col(
  * a non-empty String, then the Visual mode will be cleared and
  * the old value is returned.  See `non-zero-arg`.
  */
-export function visualmode(denops: Denops, expr?: unknown): Promise<unknown>;
+export function visualmode(denops: Denops, expr?: unknown): Promise<string>;
 export function visualmode(
   denops: Denops,
   ...args: unknown[]
@@ -10689,7 +10710,7 @@ export function visualmode(
  *
  * (Note, this needs the 'wildcharm' option set appropriately).
  */
-export function wildmenumode(denops: Denops): Promise<unknown>;
+export function wildmenumode(denops: Denops): Promise<number>;
 export function wildmenumode(
   denops: Denops,
   ...args: unknown[]
@@ -10724,7 +10745,7 @@ export function win_execute(
   id: unknown,
   command: unknown,
   silent?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function win_execute(
   denops: Denops,
   ...args: unknown[]
@@ -10740,7 +10761,7 @@ export function win_execute(
  *
  *     GetBufnr()->win_findbuf()
  */
-export function win_findbuf(denops: Denops, bufnr: unknown): Promise<unknown>;
+export function win_findbuf(denops: Denops, bufnr: unknown): Promise<unknown[]>;
 export function win_findbuf(
   denops: Denops,
   ...args: unknown[]
@@ -10765,7 +10786,7 @@ export function win_getid(
   denops: Denops,
   win?: unknown,
   tab?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function win_getid(
   denops: Denops,
   ...args: unknown[]
@@ -10797,7 +10818,7 @@ export function win_getid(
  *
  *     GetWinid()->win_gettype()
  */
-export function win_gettype(denops: Denops, nr?: unknown): Promise<unknown>;
+export function win_gettype(denops: Denops, nr?: unknown): Promise<string>;
 export function win_gettype(
   denops: Denops,
   ...args: unknown[]
@@ -10814,7 +10835,7 @@ export function win_gettype(
  *
  *     GetWinid()->win_gotoid()
  */
-export function win_gotoid(denops: Denops, expr: unknown): Promise<unknown>;
+export function win_gotoid(denops: Denops, expr: unknown): Promise<number>;
 export function win_gotoid(
   denops: Denops,
   ...args: unknown[]
@@ -10831,7 +10852,10 @@ export function win_gotoid(
  *
  *     GetWinid()->win_id2tabwin()
  */
-export function win_id2tabwin(denops: Denops, expr: unknown): Promise<unknown>;
+export function win_id2tabwin(
+  denops: Denops,
+  expr: unknown,
+): Promise<unknown[]>;
 export function win_id2tabwin(
   denops: Denops,
   ...args: unknown[]
@@ -10847,7 +10871,7 @@ export function win_id2tabwin(
  *
  *     GetWinid()->win_id2win()
  */
-export function win_id2win(denops: Denops, expr: unknown): Promise<unknown>;
+export function win_id2win(denops: Denops, expr: unknown): Promise<number>;
 export function win_id2win(
   denops: Denops,
   ...args: unknown[]
@@ -10877,7 +10901,7 @@ export function win_move_separator(
   denops: Denops,
   nr: unknown,
   offset: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function win_move_separator(
   denops: Denops,
   ...args: unknown[]
@@ -10904,7 +10928,7 @@ export function win_move_statusline(
   denops: Denops,
   nr: unknown,
   offset: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function win_move_statusline(
   denops: Denops,
   ...args: unknown[]
@@ -10925,7 +10949,7 @@ export function win_move_statusline(
  *
  *     GetWinid()->win_screenpos()
  */
-export function win_screenpos(denops: Denops, nr: unknown): Promise<unknown>;
+export function win_screenpos(denops: Denops, nr: unknown): Promise<unknown[]>;
 export function win_screenpos(
   denops: Denops,
   ...args: unknown[]
@@ -10962,7 +10986,7 @@ export function win_splitmove(
   nr: unknown,
   target: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function win_splitmove(
   denops: Denops,
   ...args: unknown[]
@@ -10985,7 +11009,7 @@ export function win_splitmove(
  *
  *     FindWindow()->winbufnr()->bufname()
  */
-export function winbufnr(denops: Denops, nr: unknown): Promise<unknown>;
+export function winbufnr(denops: Denops, nr: unknown): Promise<number>;
 export function winbufnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("winbufnr", ...args);
 }
@@ -10996,7 +11020,7 @@ export function winbufnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Windows XP is "5.1".  For non-MS-Windows systems the result is
  * an empty string.
  */
-export function windowsversion(denops: Denops): Promise<unknown>;
+export function windowsversion(denops: Denops): Promise<string>;
 export function windowsversion(
   denops: Denops,
   ...args: unknown[]
@@ -11019,7 +11043,7 @@ export function windowsversion(
  *
  *     GetWinid()->winheight()
  */
-export function winheight(denops: Denops, nr: unknown): Promise<unknown>;
+export function winheight(denops: Denops, nr: unknown): Promise<number>;
 export function winheight(
   denops: Denops,
   ...args: unknown[]
@@ -11062,7 +11086,7 @@ export function winheight(
  *
  *     GetTabnr()->winlayout()
  */
-export function winlayout(denops: Denops, tabnr?: unknown): Promise<unknown>;
+export function winlayout(denops: Denops, tabnr?: unknown): Promise<unknown[]>;
 export function winlayout(
   denops: Denops,
   ...args: unknown[]
@@ -11104,7 +11128,7 @@ export function winlayout(
  *
  *     GetWinval()->winnr()
  */
-export function winnr(denops: Denops, arg?: unknown): Promise<unknown>;
+export function winnr(denops: Denops, arg?: unknown): Promise<number>;
 export function winnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("winnr", ...args);
 }
@@ -11120,7 +11144,7 @@ export function winnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :call MessWithWindowSizes()
  *     :exe cmd
  */
-export function winrestcmd(denops: Denops): Promise<unknown>;
+export function winrestcmd(denops: Denops): Promise<string>;
 export function winrestcmd(
   denops: Denops,
   ...args: unknown[]
@@ -11149,7 +11173,7 @@ export function winrestcmd(
  *
  *     GetView()->winrestview()
  */
-export function winrestview(denops: Denops, dict: unknown): Promise<unknown>;
+export function winrestview(denops: Denops, dict: unknown): Promise<void>;
 export function winrestview(
   denops: Denops,
   ...args: unknown[]
@@ -11184,7 +11208,7 @@ export function winrestview(
  *         skipcol         columns skipped
  * Note that no option values are saved.
  */
-export function winsaveview(denops: Denops): Promise<unknown>;
+export function winsaveview(denops: Denops): Promise<Record<string, unknown>>;
 export function winsaveview(
   denops: Denops,
   ...args: unknown[]
@@ -11212,7 +11236,7 @@ export function winsaveview(
  *
  *     GetWinid()->winwidth()
  */
-export function winwidth(denops: Denops, nr: unknown): Promise<unknown>;
+export function winwidth(denops: Denops, nr: unknown): Promise<number>;
 export function winwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("winwidth", ...args);
 }
@@ -11238,7 +11262,7 @@ export function winwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         visual_words    Number of words visually selected
  *                         (only in Visual mode)
  */
-export function wordcount(denops: Denops): Promise<unknown>;
+export function wordcount(denops: Denops): Promise<Record<string, unknown>>;
 export function wordcount(
   denops: Denops,
   ...args: unknown[]
@@ -11305,7 +11329,7 @@ export function writefile(
   object: unknown,
   fname: unknown,
   flags?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function writefile(
   denops: Denops,
   ...args: unknown[]
@@ -11329,7 +11353,7 @@ export function xor(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function xor(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("xor", ...args);
 }

--- a/denops_std/function/nvim/_generated.ts
+++ b/denops_std/function/nvim/_generated.ts
@@ -9,7 +9,7 @@ import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
  *
  *     :lua print(vim.inspect(vim.fn.api_info()))
  */
-export function api_info(denops: Denops): Promise<unknown>;
+export function api_info(denops: Denops): Promise<Record<string, unknown>>;
 export function api_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("api_info", ...args);
 }
@@ -28,7 +28,7 @@ export function chanclose(
   denops: Denops,
   id: unknown,
   stream?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function chanclose(
   denops: Denops,
   ...args: unknown[]
@@ -60,7 +60,7 @@ export function chansend(
   denops: Denops,
   id: unknown,
   data: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function chansend(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("chansend", ...args);
 }
@@ -70,7 +70,10 @@ export function chansend(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * from the top of the `context-stack` (see `context-dict`).
  * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
  */
-export function ctxget(denops: Denops, index?: unknown): Promise<unknown>;
+export function ctxget(
+  denops: Denops,
+  index?: unknown,
+): Promise<Record<string, unknown>>;
 export function ctxget(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ctxget", ...args);
 }
@@ -79,7 +82,7 @@ export function ctxget(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Pops and restores the `context` at the top of the
  * `context-stack`.
  */
-export function ctxpop(denops: Denops): Promise<unknown>;
+export function ctxpop(denops: Denops): Promise<void>;
 export function ctxpop(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ctxpop", ...args);
 }
@@ -91,7 +94,7 @@ export function ctxpop(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * which `context-types` to include in the pushed context.
  * Otherwise, all context types are included.
  */
-export function ctxpush(denops: Denops, types?: unknown): Promise<unknown>;
+export function ctxpush(denops: Denops, types?: unknown): Promise<void>;
 export function ctxpush(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ctxpush", ...args);
 }
@@ -106,7 +109,7 @@ export function ctxset(
   denops: Denops,
   context: unknown,
   index?: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function ctxset(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ctxset", ...args);
 }
@@ -114,7 +117,7 @@ export function ctxset(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Returns the size of the `context-stack`.
  */
-export function ctxsize(denops: Denops): Promise<unknown>;
+export function ctxsize(denops: Denops): Promise<number>;
 export function ctxsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ctxsize", ...args);
 }
@@ -208,7 +211,7 @@ export function dictwatcherdel(
  * will not be equal to some other `id()`: new containers may
  * reuse identifiers of the garbage-collected ones.
  */
-export function id(denops: Denops, expr: unknown): Promise<unknown>;
+export function id(denops: Denops, expr: unknown): Promise<string>;
 export function id(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("id", ...args);
 }
@@ -216,7 +219,7 @@ export function id(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Return the PID (process id) of `job-id` **{job}**.
  */
-export function jobpid(denops: Denops, job: unknown): Promise<unknown>;
+export function jobpid(denops: Denops, job: unknown): Promise<number>;
 export function jobpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("jobpid", ...args);
 }
@@ -231,7 +234,7 @@ export function jobresize(
   job: unknown,
   width: unknown,
   height: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function jobresize(
   denops: Denops,
   ...args: unknown[]
@@ -334,7 +337,7 @@ export function jobstart(
   denops: Denops,
   cmd: unknown,
   opts?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function jobstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("jobstart", ...args);
 }
@@ -349,7 +352,7 @@ export function jobstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Returns 1 for valid job id, 0 for invalid id, including jobs have
  * exited or stopped.
  */
-export function jobstop(denops: Denops, id: unknown): Promise<unknown>;
+export function jobstop(denops: Denops, id: unknown): Promise<number>;
 export function jobstop(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("jobstop", ...args);
 }
@@ -380,7 +383,7 @@ export function jobwait(
   denops: Denops,
   jobs: unknown,
   timeout?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function jobwait(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("jobwait", ...args);
 }
@@ -436,7 +439,7 @@ export function menu_get(
   denops: Denops,
   path: unknown,
   modes?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function menu_get(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("menu_get", ...args);
 }
@@ -467,7 +470,7 @@ export function msgpackdump(
   denops: Denops,
   list: unknown,
   type?: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | unknown>;
 export function msgpackdump(
   denops: Denops,
   ...args: unknown[]
@@ -553,7 +556,7 @@ export function msgpackdump(
  *         representing extension type. Second is
  *         `readfile()`-style list of strings.
  */
-export function msgpackparse(denops: Denops, data: unknown): Promise<unknown>;
+export function msgpackparse(denops: Denops, data: unknown): Promise<unknown[]>;
 export function msgpackparse(
   denops: Denops,
   ...args: unknown[]
@@ -566,7 +569,7 @@ export function msgpackparse(
  * Returns an empty string when nothing was recorded yet.
  * See `q` and `Q`.
  */
-export function reg_recorded(denops: Denops): Promise<unknown>;
+export function reg_recorded(denops: Denops): Promise<string>;
 export function reg_recorded(
   denops: Denops,
   ...args: unknown[]
@@ -711,7 +714,7 @@ export function sockconnect(
   mode: unknown,
   address: unknown,
   opts?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function sockconnect(
   denops: Denops,
   ...args: unknown[]
@@ -740,7 +743,7 @@ export function sockconnect(
  *   - `channel-id` on success (value is always 1)
  *   - 0 on invalid arguments
  */
-export function stdioopen(denops: Denops, opts: unknown): Promise<unknown>;
+export function stdioopen(denops: Denops, opts: unknown): Promise<number>;
 export function stdioopen(
   denops: Denops,
   ...args: unknown[]
@@ -770,7 +773,10 @@ export function stdioopen(
  *
  *     :echo stdpath("config")
  */
-export function stdpath(denops: Denops, what: unknown): Promise<unknown>;
+export function stdpath(
+  denops: Denops,
+  what: unknown,
+): Promise<string | unknown[]>;
 export function stdpath(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("stdpath", ...args);
 }
@@ -817,7 +823,7 @@ export function wait(
   timeout: unknown,
   condition: unknown,
   interval?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function wait(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("wait", ...args);
 }

--- a/denops_std/function/vim/_generated.ts
+++ b/denops_std/function/vim/_generated.ts
@@ -48,7 +48,7 @@ import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
  *     Can also be used as a |method|: >
  *             GetAutocmdList()->autocmd_add()
  */
-export function autocmd_add(denops: Denops, acmds: unknown): Promise<unknown>;
+export function autocmd_add(denops: Denops, acmds: unknown): Promise<boolean>;
 export function autocmd_add(
   denops: Denops,
   ...args: unknown[]
@@ -110,7 +110,7 @@ export function autocmd_add(
 export function autocmd_delete(
   denops: Denops,
   acmds: unknown,
-): Promise<unknown>;
+): Promise<boolean>;
 export function autocmd_delete(
   denops: Denops,
   ...args: unknown[]
@@ -177,7 +177,7 @@ export function autocmd_delete(
  *
  *     Getopts()->autocmd_get()
  */
-export function autocmd_get(denops: Denops, opts?: unknown): Promise<unknown>;
+export function autocmd_get(denops: Denops, opts?: unknown): Promise<unknown[]>;
 export function autocmd_get(
   denops: Denops,
   ...args: unknown[]
@@ -190,7 +190,7 @@ export function autocmd_get(
  * not used for the List.  Returns an empty string if balloon
  * is not present.
  */
-export function balloon_gettext(denops: Denops): Promise<unknown>;
+export function balloon_gettext(denops: Denops): Promise<string>;
 export function balloon_gettext(
   denops: Denops,
   ...args: unknown[]
@@ -232,7 +232,7 @@ export function balloon_gettext(
  * *only available when compiled with the `+balloon_eval` or
  * `+balloon_eval_term` feature*
  */
-export function balloon_show(denops: Denops, expr: unknown): Promise<unknown>;
+export function balloon_show(denops: Denops, expr: unknown): Promise<void>;
 export function balloon_show(
   denops: Denops,
   ...args: unknown[]
@@ -253,7 +253,7 @@ export function balloon_show(
  * *only available when compiled with the `+balloon_eval_term`
  * feature*
  */
-export function balloon_split(denops: Denops, msg: unknown): Promise<unknown>;
+export function balloon_split(denops: Denops, msg: unknown): Promise<unknown[]>;
 export function balloon_split(
   denops: Denops,
   ...args: unknown[]
@@ -275,7 +275,7 @@ export function balloon_split(
  *
  *     GetBlob()->blob2list()
  */
-export function blob2list(denops: Denops, blob: unknown): Promise<unknown>;
+export function blob2list(denops: Denops, blob: unknown): Promise<unknown[]>;
 export function blob2list(
   denops: Denops,
   ...args: unknown[]
@@ -296,7 +296,7 @@ export function blob2list(
  *
  * Use with care, you can mess up the terminal this way.
  */
-export function echoraw(denops: Denops, string: unknown): Promise<unknown>;
+export function echoraw(denops: Denops, string: unknown): Promise<void>;
 export function echoraw(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("echoraw", ...args);
 }
@@ -317,10 +317,7 @@ export function echoraw(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can only be used in a `:def` function.
  * This does not work to check for arguments or local variables.
  */
-export function exists_compiled(
-  denops: Denops,
-  expr: unknown,
-): Promise<unknown>;
+export function exists_compiled(denops: Denops, expr: unknown): Promise<number>;
 export function exists_compiled(
   denops: Denops,
   ...args: unknown[]
@@ -339,7 +336,7 @@ export function extendnew(
   expr1: unknown,
   expr2: unknown,
   expr3?: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | Record<string, unknown>>;
 export function extendnew(
   denops: Denops,
   ...args: unknown[]
@@ -354,7 +351,7 @@ export function flattennew(
   denops: Denops,
   list: unknown,
   maxdepth?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function flattennew(
   denops: Denops,
   ...args: unknown[]
@@ -371,7 +368,7 @@ export function flattennew(
  * *only in the Win32, Motif and GTK GUI versions and the
  * Win32 console version*
  */
-export function foreground(denops: Denops): Promise<unknown>;
+export function foreground(denops: Denops): Promise<number>;
 export function foreground(
   denops: Denops,
   ...args: unknown[]
@@ -384,7 +381,7 @@ export function foreground(
  * active and `FALSE` otherwise.
  * See 'imstatusfunc'.
  */
-export function getimstatus(denops: Denops): Promise<unknown>;
+export function getimstatus(denops: Denops): Promise<number>;
 export function getimstatus(
   denops: Denops,
   ...args: unknown[]
@@ -434,7 +431,10 @@ export function getimstatus(
  *     :echo getscriptinfo({'name': 'myscript'})
  *     :echo getscriptinfo({'sid': 15}).variables
  */
-export function getscriptinfo(denops: Denops, opts?: unknown): Promise<unknown>;
+export function getscriptinfo(
+  denops: Denops,
+  opts?: unknown,
+): Promise<unknown[]>;
 export function getscriptinfo(
   denops: Denops,
   ...args: unknown[]
@@ -453,7 +453,7 @@ export function getscriptinfo(
  * xgettext does not understand escaping in single quoted
  * strings.
  */
-export function gettext(denops: Denops, text: unknown): Promise<unknown>;
+export function gettext(denops: Denops, text: unknown): Promise<string>;
 export function gettext(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("gettext", ...args);
 }
@@ -515,7 +515,7 @@ export function hlget(
   denops: Denops,
   name?: unknown,
   resolve?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function hlget(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("hlget", ...args);
 }
@@ -573,7 +573,7 @@ export function hlget(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetAttrList()->hlset()
  */
-export function hlset(denops: Denops, list: unknown): Promise<unknown>;
+export function hlset(denops: Denops, list: unknown): Promise<number>;
 export function hlset(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("hlset", ...args);
 }
@@ -626,7 +626,7 @@ export function indexof(
   object: unknown,
   expr: unknown,
   opts?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function indexof(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("indexof", ...args);
 }
@@ -656,7 +656,7 @@ export function inputdialog(
   prompt: unknown,
   text?: unknown,
   cancelreturn?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function inputdialog(
   denops: Denops,
   ...args: unknown[]
@@ -683,7 +683,7 @@ export function inputdialog(
  *
  *     GetName()->isabsolutepath()
  */
-export function isabsolutepath(denops: Denops, path: unknown): Promise<unknown>;
+export function isabsolutepath(denops: Denops, path: unknown): Promise<number>;
 export function isabsolutepath(
   denops: Denops,
   ...args: unknown[]
@@ -728,7 +728,7 @@ export function js_decode(
  *
  *     GetObject()->js_encode()
  */
-export function js_encode(denops: Denops, expr: unknown): Promise<unknown>;
+export function js_encode(denops: Denops, expr: unknown): Promise<string>;
 export function js_encode(
   denops: Denops,
   ...args: unknown[]
@@ -841,7 +841,7 @@ export function listener_add(
   denops: Denops,
   callback: unknown,
   buf?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function listener_add(
   denops: Denops,
   ...args: unknown[]
@@ -861,7 +861,7 @@ export function listener_add(
  *
  *     GetBuffer()->listener_flush()
  */
-export function listener_flush(denops: Denops, buf?: unknown): Promise<unknown>;
+export function listener_flush(denops: Denops, buf?: unknown): Promise<void>;
 export function listener_flush(
   denops: Denops,
   ...args: unknown[]
@@ -878,7 +878,7 @@ export function listener_flush(
  *
  *     GetListenerId()->listener_remove()
  */
-export function listener_remove(denops: Denops, id: unknown): Promise<unknown>;
+export function listener_remove(denops: Denops, id: unknown): Promise<void>;
 export function listener_remove(
   denops: Denops,
   ...args: unknown[]
@@ -954,7 +954,7 @@ export function luaeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     ounmap xyzzy
  *     echo printf("Operator-pending mode bit: 0x%x", op_bit)
  */
-export function maplist(denops: Denops, abbr?: unknown): Promise<unknown>;
+export function maplist(denops: Denops, abbr?: unknown): Promise<unknown[]>;
 export function maplist(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("maplist", ...args);
 }
@@ -969,7 +969,7 @@ export function mapnew(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown>;
+): Promise<unknown[] | Record<string, unknown> | unknown | string>;
 export function mapnew(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("mapnew", ...args);
 }
@@ -1082,7 +1082,7 @@ export function readdirex(
   directory: unknown,
   expr?: unknown,
   dict?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function readdirex(
   denops: Denops,
   ...args: unknown[]
@@ -1133,7 +1133,7 @@ export function remote_expr(
   string: unknown,
   idvar?: unknown,
   timeout?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function remote_expr(
   denops: Denops,
   ...args: unknown[]
@@ -1165,7 +1165,7 @@ export function remote_expr(
 export function remote_foreground(
   denops: Denops,
   server: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function remote_foreground(
   denops: Denops,
   ...args: unknown[]
@@ -1196,7 +1196,7 @@ export function remote_peek(
   denops: Denops,
   serverid: unknown,
   retvar?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function remote_peek(
   denops: Denops,
   ...args: unknown[]
@@ -1224,7 +1224,7 @@ export function remote_read(
   denops: Denops,
   serverid: unknown,
   timeout: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function remote_read(
   denops: Denops,
   ...args: unknown[]
@@ -1269,7 +1269,7 @@ export function remote_send(
   server: unknown,
   string: unknown,
   idvar?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function remote_send(
   denops: Denops,
   ...args: unknown[]
@@ -1290,7 +1290,7 @@ export function remote_send(
 export function remote_startserver(
   denops: Denops,
   name: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function remote_startserver(
   denops: Denops,
   ...args: unknown[]
@@ -1320,7 +1320,7 @@ export function server2client(
   denops: Denops,
   clientid: unknown,
   string: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function server2client(
   denops: Denops,
   ...args: unknown[]
@@ -1346,7 +1346,7 @@ export function slice(
   expr: unknown,
   start: unknown,
   end?: unknown,
-): Promise<unknown>;
+): Promise<string | unknown[] | unknown>;
 export function slice(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("slice", ...args);
 }
@@ -1359,7 +1359,7 @@ export function slice(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * *only available when compiled with the `+sound` feature*
  */
-export function sound_clear(denops: Denops): Promise<unknown>;
+export function sound_clear(denops: Denops): Promise<void>;
 export function sound_clear(
   denops: Denops,
   ...args: unknown[]
@@ -1407,7 +1407,7 @@ export function sound_playevent(
   denops: Denops,
   name: unknown,
   callback?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function sound_playevent(
   denops: Denops,
   ...args: unknown[]
@@ -1432,7 +1432,7 @@ export function sound_playfile(
   denops: Denops,
   path: unknown,
   callback?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function sound_playfile(
   denops: Denops,
   ...args: unknown[]
@@ -1456,7 +1456,7 @@ export function sound_playfile(
  *
  * *only available when compiled with the `+sound` feature*
  */
-export function sound_stop(denops: Denops, id: unknown): Promise<unknown>;
+export function sound_stop(denops: Denops, id: unknown): Promise<void>;
 export function sound_stop(
   denops: Denops,
   ...args: unknown[]
@@ -1501,7 +1501,7 @@ export function sound_stop(
  *         recursiveness up to "ccc")
  *     s   screen has scrolled for messages
  */
-export function state(denops: Denops, what?: unknown): Promise<unknown>;
+export function state(denops: Denops, what?: unknown): Promise<string>;
 export function state(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("state", ...args);
 }
@@ -1520,7 +1520,7 @@ export function state(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetText()->strcharlen()
  */
-export function strcharlen(denops: Denops, string: unknown): Promise<unknown>;
+export function strcharlen(denops: Denops, string: unknown): Promise<number>;
 export function strcharlen(
   denops: Denops,
   ...args: unknown[]
@@ -1561,7 +1561,7 @@ export function strcharlen(
  * - `v:termstyleresp` and `v:termblinkresp` for the response to
  *   `t_RS` and `t_RC`.
  */
-export function terminalprops(denops: Denops): Promise<unknown>;
+export function terminalprops(denops: Denops): Promise<Record<string, unknown>>;
 export function terminalprops(
   denops: Denops,
   ...args: unknown[]
@@ -1576,7 +1576,7 @@ export function terminalprops(
  *     echo typename([1, 2, 3])
  *     list<number>
  */
-export function typename(denops: Denops, expr: unknown): Promise<unknown>;
+export function typename(denops: Denops, expr: unknown): Promise<string>;
 export function typename(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("typename", ...args);
 }
@@ -1595,7 +1595,7 @@ export function typename(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetChannel()->ch_canread()
  */
-export function ch_canread(denops: Denops, handle: unknown): Promise<unknown>;
+export function ch_canread(denops: Denops, handle: unknown): Promise<number>;
 export function ch_canread(
   denops: Denops,
   ...args: unknown[]
@@ -1612,7 +1612,7 @@ export function ch_canread(
  *
  *     GetChannel()->ch_close()
  */
-export function ch_close(denops: Denops, handle: unknown): Promise<unknown>;
+export function ch_close(denops: Denops, handle: unknown): Promise<void>;
 export function ch_close(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ch_close", ...args);
 }
@@ -1626,7 +1626,7 @@ export function ch_close(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetChannel()->ch_close_in()
  */
-export function ch_close_in(denops: Denops, handle: unknown): Promise<unknown>;
+export function ch_close_in(denops: Denops, handle: unknown): Promise<void>;
 export function ch_close_in(
   denops: Denops,
   ...args: unknown[]
@@ -1716,7 +1716,7 @@ export function ch_getbufnr(
   denops: Denops,
   handle: unknown,
   what: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function ch_getbufnr(
   denops: Denops,
   ...args: unknown[]
@@ -1777,7 +1777,7 @@ export function ch_getjob(
  *
  *     GetChannel()->ch_info()
  */
-export function ch_info(denops: Denops, handle: unknown): Promise<unknown>;
+export function ch_info(denops: Denops, handle: unknown): Promise<string>;
 export function ch_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ch_info", ...args);
 }
@@ -1798,7 +1798,7 @@ export function ch_log(
   denops: Denops,
   msg: unknown,
   handle?: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function ch_log(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ch_log", ...args);
 }
@@ -1835,7 +1835,7 @@ export function ch_logfile(
   denops: Denops,
   fname: unknown,
   mode?: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function ch_logfile(
   denops: Denops,
   ...args: unknown[]
@@ -1881,7 +1881,7 @@ export function ch_read(
   denops: Denops,
   handle: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function ch_read(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("ch_read", ...args);
 }
@@ -1920,7 +1920,7 @@ export function ch_readraw(
   denops: Denops,
   handle: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function ch_readraw(
   denops: Denops,
   ...args: unknown[]
@@ -2011,7 +2011,7 @@ export function ch_setoptions(
   denops: Denops,
   handle: unknown,
   options: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function ch_setoptions(
   denops: Denops,
   ...args: unknown[]
@@ -2043,7 +2043,7 @@ export function ch_status(
   denops: Denops,
   handle: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function ch_status(
   denops: Denops,
   ...args: unknown[]
@@ -2097,7 +2097,10 @@ export function job_getchannel(
  *
  *     GetJob()->job_info()
  */
-export function job_info(denops: Denops, job?: unknown): Promise<unknown>;
+export function job_info(
+  denops: Denops,
+  job?: unknown,
+): Promise<Record<string, unknown>>;
 export function job_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("job_info", ...args);
 }
@@ -2115,7 +2118,7 @@ export function job_setoptions(
   denops: Denops,
   job: unknown,
   options: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function job_setoptions(
   denops: Denops,
   ...args: unknown[]
@@ -2229,7 +2232,7 @@ export function job_start(
  *
  *     GetJob()->job_status()
  */
-export function job_status(denops: Denops, job: unknown): Promise<unknown>;
+export function job_status(denops: Denops, job: unknown): Promise<string>;
 export function job_status(
   denops: Denops,
   ...args: unknown[]
@@ -2287,7 +2290,7 @@ export function job_stop(
   denops: Denops,
   job: unknown,
   how?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function job_stop(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("job_stop", ...args);
 }
@@ -2352,7 +2355,7 @@ export function term_dumpdiff(
   filename1: unknown,
   filename2: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function term_dumpdiff(
   denops: Denops,
   ...args: unknown[]
@@ -2376,7 +2379,7 @@ export function term_dumpload(
   denops: Denops,
   filename: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function term_dumpload(
   denops: Denops,
   ...args: unknown[]
@@ -2407,7 +2410,7 @@ export function term_dumpwrite(
   buf: unknown,
   filename: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_dumpwrite(
   denops: Denops,
   ...args: unknown[]
@@ -2427,7 +2430,7 @@ export function term_dumpwrite(
 export function term_getaltscreen(
   denops: Denops,
   buf: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function term_getaltscreen(
   denops: Denops,
   ...args: unknown[]
@@ -2455,7 +2458,7 @@ export function term_getaltscreen(
 export function term_getansicolors(
   denops: Denops,
   buf: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function term_getansicolors(
   denops: Denops,
   ...args: unknown[]
@@ -2480,7 +2483,7 @@ export function term_getattr(
   denops: Denops,
   attr: unknown,
   what: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function term_getattr(
   denops: Denops,
   ...args: unknown[]
@@ -2513,7 +2516,10 @@ export function term_getattr(
  *
  *     GetBufnr()->term_getcursor()
  */
-export function term_getcursor(denops: Denops, buf: unknown): Promise<unknown>;
+export function term_getcursor(
+  denops: Denops,
+  buf: unknown,
+): Promise<unknown[]>;
 export function term_getcursor(
   denops: Denops,
   ...args: unknown[]
@@ -2556,7 +2562,7 @@ export function term_getline(
   denops: Denops,
   buf: unknown,
   row: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function term_getline(
   denops: Denops,
   ...args: unknown[]
@@ -2583,10 +2589,7 @@ export function term_getline(
  *
  *     GetBufnr()->term_getscrolled()
  */
-export function term_getscrolled(
-  denops: Denops,
-  buf: unknown,
-): Promise<unknown>;
+export function term_getscrolled(denops: Denops, buf: unknown): Promise<number>;
 export function term_getscrolled(
   denops: Denops,
   ...args: unknown[]
@@ -2607,7 +2610,7 @@ export function term_getscrolled(
  *
  *     GetBufnr()->term_getsize()
  */
-export function term_getsize(denops: Denops, buf: unknown): Promise<unknown>;
+export function term_getsize(denops: Denops, buf: unknown): Promise<unknown[]>;
 export function term_getsize(
   denops: Denops,
   ...args: unknown[]
@@ -2631,7 +2634,7 @@ export function term_getsize(
  *
  *     GetBufnr()->term_getstatus()
  */
-export function term_getstatus(denops: Denops, buf: unknown): Promise<unknown>;
+export function term_getstatus(denops: Denops, buf: unknown): Promise<string>;
 export function term_getstatus(
   denops: Denops,
   ...args: unknown[]
@@ -2651,7 +2654,7 @@ export function term_getstatus(
  *
  *     GetBufnr()->term_gettitle()
  */
-export function term_gettitle(denops: Denops, buf: unknown): Promise<unknown>;
+export function term_gettitle(denops: Denops, buf: unknown): Promise<string>;
 export function term_gettitle(
   denops: Denops,
   ...args: unknown[]
@@ -2675,7 +2678,7 @@ export function term_gettty(
   denops: Denops,
   buf: unknown,
   input?: unknown,
-): Promise<unknown>;
+): Promise<string>;
 export function term_gettty(
   denops: Denops,
   ...args: unknown[]
@@ -2687,7 +2690,7 @@ export function term_gettty(
  * Return a list with the buffer numbers of all buffers for
  * terminal windows.
  */
-export function term_list(denops: Denops): Promise<unknown>;
+export function term_list(denops: Denops): Promise<unknown[]>;
 export function term_list(
   denops: Denops,
   ...args: unknown[]
@@ -2721,7 +2724,7 @@ export function term_scrape(
   denops: Denops,
   buf: unknown,
   row: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function term_scrape(
   denops: Denops,
   ...args: unknown[]
@@ -2744,7 +2747,7 @@ export function term_sendkeys(
   denops: Denops,
   buf: unknown,
   keys: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_sendkeys(
   denops: Denops,
   ...args: unknown[]
@@ -2792,7 +2795,7 @@ export function term_setansicolors(
   denops: Denops,
   buf: unknown,
   colors: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_setansicolors(
   denops: Denops,
   ...args: unknown[]
@@ -2818,7 +2821,7 @@ export function term_setapi(
   denops: Denops,
   buf: unknown,
   expr: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_setapi(
   denops: Denops,
   ...args: unknown[]
@@ -2846,7 +2849,7 @@ export function term_setkill(
   denops: Denops,
   buf: unknown,
   how: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_setkill(
   denops: Denops,
   ...args: unknown[]
@@ -2873,7 +2876,7 @@ export function term_setrestore(
   denops: Denops,
   buf: unknown,
   command: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_setrestore(
   denops: Denops,
   ...args: unknown[]
@@ -2900,7 +2903,7 @@ export function term_setsize(
   buf: unknown,
   rows: unknown,
   cols: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function term_setsize(
   denops: Denops,
   ...args: unknown[]
@@ -2987,7 +2990,7 @@ export function term_start(
   denops: Denops,
   cmd: unknown,
   options?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function term_start(
   denops: Denops,
   ...args: unknown[]
@@ -3009,7 +3012,7 @@ export function term_wait(
   denops: Denops,
   buf: unknown,
   time?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function term_wait(
   denops: Denops,
   ...args: unknown[]
@@ -3032,7 +3035,7 @@ export function test_alloc_fail(
   id: unknown,
   countdown: unknown,
   repeat: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function test_alloc_fail(
   denops: Denops,
   ...args: unknown[]
@@ -3044,7 +3047,7 @@ export function test_alloc_fail(
  * Set a flag to enable the effect of 'autochdir' before Vim
  * startup has finished.
  */
-export function test_autochdir(denops: Denops): Promise<unknown>;
+export function test_autochdir(denops: Denops): Promise<void>;
 export function test_autochdir(
   denops: Denops,
   ...args: unknown[]
@@ -3061,10 +3064,7 @@ export function test_autochdir(
  *
  *     GetText()->test_feedinput()
  */
-export function test_feedinput(
-  denops: Denops,
-  string: unknown,
-): Promise<unknown>;
+export function test_feedinput(denops: Denops, string: unknown): Promise<void>;
 export function test_feedinput(
   denops: Denops,
   ...args: unknown[]
@@ -3080,7 +3080,7 @@ export function test_feedinput(
  * This will not work when called from a :def function, because
  * variables on the stack will be freed.
  */
-export function test_garbagecollect_now(denops: Denops): Promise<unknown>;
+export function test_garbagecollect_now(denops: Denops): Promise<void>;
 export function test_garbagecollect_now(
   denops: Denops,
   ...args: unknown[]
@@ -3092,7 +3092,7 @@ export function test_garbagecollect_now(
  * Set the flag to call the garbagecollector as if in the main
  * loop.  Only to be used in tests.
  */
-export function test_garbagecollect_soon(denops: Denops): Promise<unknown>;
+export function test_garbagecollect_soon(denops: Denops): Promise<void>;
 export function test_garbagecollect_soon(
   denops: Denops,
   ...args: unknown[]
@@ -3248,7 +3248,7 @@ export function test_gui_event(
   denops: Denops,
   event: unknown,
   args: unknown,
-): Promise<unknown>;
+): Promise<boolean>;
 export function test_gui_event(
   denops: Denops,
   ...args: unknown[]
@@ -3270,10 +3270,7 @@ export function test_gui_event(
  *
  *     GetErrorText()->test_ignore_error()
  */
-export function test_ignore_error(
-  denops: Denops,
-  expr: unknown,
-): Promise<unknown>;
+export function test_ignore_error(denops: Denops, expr: unknown): Promise<void>;
 export function test_ignore_error(
   denops: Denops,
   ...args: unknown[]
@@ -3307,7 +3304,9 @@ export function test_null_channel(
 /**
  * Return a `Dict` that is null. Only useful for testing.
  */
-export function test_null_dict(denops: Denops): Promise<unknown>;
+export function test_null_dict(
+  denops: Denops,
+): Promise<Record<string, unknown>>;
 export function test_null_dict(
   denops: Denops,
   ...args: unknown[]
@@ -3341,7 +3340,7 @@ export function test_null_job(
 /**
  * Return a `List` that is null. Only useful for testing.
  */
-export function test_null_list(denops: Denops): Promise<unknown>;
+export function test_null_list(denops: Denops): Promise<unknown[]>;
 export function test_null_list(
   denops: Denops,
   ...args: unknown[]
@@ -3363,7 +3362,7 @@ export function test_null_partial(
 /**
  * Return a `String` that is null. Only useful for testing.
  */
-export function test_null_string(denops: Denops): Promise<unknown>;
+export function test_null_string(denops: Denops): Promise<string>;
 export function test_null_string(
   denops: Denops,
   ...args: unknown[]
@@ -3389,7 +3388,7 @@ export function test_null_string(
 export function test_option_not_set(
   denops: Denops,
   name: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function test_option_not_set(
   denops: Denops,
   ...args: unknown[]
@@ -3451,7 +3450,7 @@ export function test_override(
   denops: Denops,
   name: unknown,
   val: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function test_override(
   denops: Denops,
   ...args: unknown[]
@@ -3468,7 +3467,7 @@ export function test_override(
  *
  *     GetVarname()->test_refcount()
  */
-export function test_refcount(denops: Denops, expr: unknown): Promise<unknown>;
+export function test_refcount(denops: Denops, expr: unknown): Promise<number>;
 export function test_refcount(
   denops: Denops,
   ...args: unknown[]
@@ -3488,7 +3487,7 @@ export function test_setmouse(
   denops: Denops,
   row: unknown,
   col: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function test_setmouse(
   denops: Denops,
   ...args: unknown[]
@@ -3509,7 +3508,7 @@ export function test_setmouse(
  *
  *     GetTime()->test_settime()
  */
-export function test_settime(denops: Denops, expr: unknown): Promise<unknown>;
+export function test_settime(denops: Denops, expr: unknown): Promise<void>;
 export function test_settime(
   denops: Denops,
   ...args: unknown[]
@@ -3521,10 +3520,7 @@ export function test_settime(
  * When [seed] is given this sets the seed value used by
  * `srand()`.  When omitted the test seed is removed.
  */
-export function test_srand_seed(
-  denops: Denops,
-  seed?: unknown,
-): Promise<unknown>;
+export function test_srand_seed(denops: Denops, seed?: unknown): Promise<void>;
 export function test_srand_seed(
   denops: Denops,
   ...args: unknown[]
@@ -3564,7 +3560,7 @@ export function test_void(
  *
  *     GetCmd()->assert_beeps()
  */
-export function assert_beeps(denops: Denops, cmd: unknown): Promise<unknown>;
+export function assert_beeps(denops: Denops, cmd: unknown): Promise<number>;
 export function assert_beeps(
   denops: Denops,
   ...args: unknown[]
@@ -3599,7 +3595,7 @@ export function assert_equal(
   expected: unknown,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_equal(
   denops: Denops,
   ...args: unknown[]
@@ -3624,7 +3620,7 @@ export function assert_equalfile(
   fname_one: unknown,
   fname_two: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_equalfile(
   denops: Denops,
   ...args: unknown[]
@@ -3650,7 +3646,7 @@ export function assert_exception(
   denops: Denops,
   error: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_exception(
   denops: Denops,
   ...args: unknown[]
@@ -3710,7 +3706,7 @@ export function assert_fails(
   msg?: unknown,
   lnum?: unknown,
   context?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_fails(
   denops: Denops,
   ...args: unknown[]
@@ -3735,7 +3731,7 @@ export function assert_false(
   denops: Denops,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_false(
   denops: Denops,
   ...args: unknown[]
@@ -3757,7 +3753,7 @@ export function assert_inrange(
   upper: unknown,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_inrange(
   denops: Denops,
   ...args: unknown[]
@@ -3795,7 +3791,7 @@ export function assert_match(
   pattern: unknown,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_match(
   denops: Denops,
   ...args: unknown[]
@@ -3812,7 +3808,7 @@ export function assert_match(
  *
  *     GetCmd()->assert_nobeep()
  */
-export function assert_nobeep(denops: Denops, cmd: unknown): Promise<unknown>;
+export function assert_nobeep(denops: Denops, cmd: unknown): Promise<number>;
 export function assert_nobeep(
   denops: Denops,
   ...args: unknown[]
@@ -3834,7 +3830,7 @@ export function assert_notequal(
   expected: unknown,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_notequal(
   denops: Denops,
   ...args: unknown[]
@@ -3856,7 +3852,7 @@ export function assert_notmatch(
   pattern: unknown,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_notmatch(
   denops: Denops,
   ...args: unknown[]
@@ -3872,7 +3868,7 @@ export function assert_notmatch(
  *
  *     GetMessage()->assert_report()
  */
-export function assert_report(denops: Denops, msg: unknown): Promise<unknown>;
+export function assert_report(denops: Denops, msg: unknown): Promise<number>;
 export function assert_report(
   denops: Denops,
   ...args: unknown[]
@@ -3897,7 +3893,7 @@ export function assert_true(
   denops: Denops,
   actual: unknown,
   msg?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function assert_true(
   denops: Denops,
   ...args: unknown[]
@@ -4007,7 +4003,7 @@ export function prop_add(
   lnum: unknown,
   col: unknown,
   props: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prop_add(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("prop_add", ...args);
 }
@@ -4029,7 +4025,7 @@ export function prop_clear(
   lnum: unknown,
   lnum_end?: unknown,
   props?: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prop_clear(
   denops: Denops,
   ...args: unknown[]
@@ -4066,7 +4062,7 @@ export function prop_find(
   denops: Denops,
   props: unknown,
   direction?: unknown,
-): Promise<unknown>;
+): Promise<Record<string, unknown>>;
 export function prop_find(
   denops: Denops,
   ...args: unknown[]
@@ -4142,7 +4138,7 @@ export function prop_list(
   denops: Denops,
   lnum: unknown,
   props?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function prop_list(
   denops: Denops,
   ...args: unknown[]
@@ -4185,7 +4181,7 @@ export function prop_remove(
   props: unknown,
   lnum?: unknown,
   lnum_end?: unknown,
-): Promise<unknown>;
+): Promise<number>;
 export function prop_remove(
   denops: Denops,
   ...args: unknown[]
@@ -4224,7 +4220,7 @@ export function prop_type_add(
   denops: Denops,
   name: unknown,
   props: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prop_type_add(
   denops: Denops,
   ...args: unknown[]
@@ -4245,7 +4241,7 @@ export function prop_type_change(
   denops: Denops,
   name: unknown,
   props: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prop_type_change(
   denops: Denops,
   ...args: unknown[]
@@ -4272,7 +4268,7 @@ export function prop_type_delete(
   denops: Denops,
   name: unknown,
   props?: unknown,
-): Promise<unknown>;
+): Promise<void>;
 export function prop_type_delete(
   denops: Denops,
   ...args: unknown[]
@@ -4298,7 +4294,7 @@ export function prop_type_get(
   denops: Denops,
   name: unknown,
   props?: unknown,
-): Promise<unknown>;
+): Promise<Record<string, unknown>>;
 export function prop_type_get(
   denops: Denops,
   ...args: unknown[]
@@ -4315,7 +4311,7 @@ export function prop_type_get(
 export function prop_type_list(
   denops: Denops,
   props?: unknown,
-): Promise<unknown>;
+): Promise<unknown[]>;
 export function prop_type_list(
   denops: Denops,
   ...args: unknown[]

--- a/scripts/gen-function/format.ts
+++ b/scripts/gen-function/format.ts
@@ -26,16 +26,16 @@ export function formatDocs(docs: string): string[] {
 
 function formatVariants(fn: string, vars: Variant[]): string[] {
   if (vars.length === 0) {
-    return formatVariants(fn, [[]]);
+    return formatVariants(fn, [{ args: [], restype: "unknown" }]);
   }
-  const lines = vars.map((variant) => {
-    const args = variant.map(({ name, optional }) => {
+  const lines = vars.map(({ args, restype }) => {
+    const argTypes = args.map(({ name, optional }) => {
       name = translate[name] ?? name;
       return `${name}${optional ? "?" : ""}: unknown`;
     });
     return `export function ${fn}(denops: Denops, ${
-      args.join(", ")
-    }): Promise<unknown>;`;
+      argTypes.join(", ")
+    }): Promise<${restype}>;`;
   });
   return lines;
 }

--- a/scripts/gen-function/gen-function.ts
+++ b/scripts/gen-function/gen-function.ts
@@ -45,7 +45,7 @@ for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
   console.log(`Download from ${vimHelpDownloadUrl}`);
 }
 const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
-const vimDefs = vimHelps.map(parse).flat();
+const vimDefs = parse(vimHelps.join("\n"));
 const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);
 
 const nvimHelpDownloadUrls = [
@@ -57,7 +57,7 @@ for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
   console.log(`Download from ${nvimHelpDownloadUrl}`);
 }
 const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
-const nvimDefs = nvimHelps.map(parse).flat();
+const nvimDefs = parse(nvimHelps.join("\n"));
 const nvimFnSet = difference(
   new Set(nvimDefs.map((def) => def.fn)),
   manualFnSet,

--- a/scripts/gen-function/types.ts
+++ b/scripts/gen-function/types.ts
@@ -4,7 +4,10 @@ export type Arg = {
   optional: boolean;
 };
 
-export type Variant = Arg[];
+export type Variant = {
+  args: Arg[];
+  restype: string;
+};
 
 export type Definition = {
   fn: string;


### PR DESCRIPTION
Generate return types by parsing `builtin-function-list`.

I have not checked the correctness of each of the generated types.
But feel LGTM.