### PR TITLE
:memo: Add JSDoc to variable

### DIFF
--- a/denops_std/variable/environment.ts
+++ b/denops_std/variable/environment.ts
@@ -63,4 +63,5 @@ export const environment: Getter & Setter & Remover = {
     await denops.cmd(`unlet ${name}`);
   },
 };
+/** Shorthand for {@linkcode environment} */
 export const e = environment;

--- a/denops_std/variable/option.ts
+++ b/denops_std/variable/option.ts
@@ -87,6 +87,7 @@ export const options: Getter & Setter & Remover = {
     return removeOption(denops, "", prop);
   },
 };
+/** Shorthand for {@linkcode options} */
 export const o = options;
 
 /**
@@ -140,6 +141,7 @@ export const localOptions: Getter & Setter & Remover = {
     return removeOption(denops, "l", prop);
   },
 };
+/** Shorthand for {@linkcode localOptions} */
 export const lo = localOptions;
 
 /**
@@ -193,4 +195,5 @@ export const globalOptions: Getter & Setter & Remover = {
     return removeOption(denops, "g", prop);
   },
 };
+/** Shorthand for {@linkcode globalOptions} */
 export const go = globalOptions;

--- a/denops_std/variable/register.ts
+++ b/denops_std/variable/register.ts
@@ -58,4 +58,5 @@ export const register: Getter & Setter = {
     });
   },
 };
+/** Shorthand for {@linkcode register} */
 export const r = register;

--- a/denops_std/variable/types.ts
+++ b/denops_std/variable/types.ts
@@ -1,21 +1,46 @@
 import type { Denops } from "https://deno.land/x/denops_core@v4.0.0/mod.ts";
 
+/**
+ * Represents a getter method for retrieving property value.
+ */
 export type Getter = {
-  get<T = unknown>(
-    denops: Denops,
-    prop: string,
-    defaultValue: T,
-  ): Promise<T>;
-  get<T = unknown>(
-    denops: Denops,
-    prop: string,
-  ): Promise<T | null>;
+  /**
+   * Gets the value of the specified property, or default value if it doesn't exist.
+   * @param prop - The name of the property.
+   * @param defaultValue - The default value to be returned if the property doesn't exist.
+   * @returns A promise that resolves to the value of the property.
+   */
+  get<T = unknown>(denops: Denops, prop: string, defaultValue?: T): Promise<T>;
+
+  /**
+   * Gets the value of the specified property, or null if it doesn't exist.
+   * @param prop - The name of the property.
+   * @returns A promise that resolves to the value of the property.
+   */
+  get<T = unknown>(denops: Denops, prop: string): Promise<T | null>;
 };
 
+/**
+ * Represents a setter method for setting property value.
+ */
 export type Setter = {
+  /**
+   * Sets the value of the specified property.
+   * @param prop - The name of the property.
+   * @param value - The value to be set.
+   * @returns A promise that resolves when the value has been set.
+   */
   set<T = unknown>(denops: Denops, prop: string, value: T): Promise<void>;
 };
 
+/**
+ * Represents a remover method for removing property value.
+ */
 export type Remover = {
+  /**
+   * Removes the value of the specified property or resets to its default value.
+   * @param prop - The name of the property.
+   * @returns A promise that resolves when the value has been removed or reset.
+   */
   remove(denops: Denops, prop: string): Promise<void>;
 };

--- a/denops_std/variable/variable.ts
+++ b/denops_std/variable/variable.ts
@@ -84,6 +84,7 @@ export const globals: Getter & Setter & Remover = {
     return removeVar(denops, "g", prop);
   },
 };
+/** Shorthand for {@linkcode globals} */
 export const g = globals;
 
 /**
@@ -131,6 +132,7 @@ export const buffers: Getter & Setter & Remover = {
     return removeVar(denops, "b", prop);
   },
 };
+/** Shorthand for {@linkcode buffers} */
 export const b = buffers;
 
 /**
@@ -178,6 +180,7 @@ export const windows: Getter & Setter & Remover = {
     return removeVar(denops, "w", prop);
   },
 };
+/** Shorthand for {@linkcode windows} */
 export const w = windows;
 
 /**
@@ -225,6 +228,7 @@ export const tabpages: Getter & Setter & Remover = {
     return removeVar(denops, "t", prop);
   },
 };
+/** Shorthand for {@linkcode tabpages} */
 export const t = tabpages;
 
 /**
@@ -262,4 +266,5 @@ export const vim: Getter & Setter = {
     return setVar(denops, "v", prop, value);
   },
 };
+/** Shorthand for {@linkcode vim} */
 export const v = vim;


### PR DESCRIPTION
- Add JSDoc to variable interfaces.
  - JSDoc written in the implementation is not referenced from LSP etc.
- Add JSDoc to shorthand properties.