### PR TITLE
:+1: Add expr-string helper

### DIFF
--- a/denops_std/helper/expr_string.ts
+++ b/denops_std/helper/expr_string.ts
@@ -1,0 +1,224 @@
+import type {
+  Context,
+  Denops,
+  Dispatcher,
+  Meta,
+} from "https://deno.land/x/denops_core@v5.0.0/mod.ts";
+import { execute } from "./execute.ts";
+import { generateUniqueString } from "../util.ts";
+
+const EXPR_STRING_MARK = "__denops_expr_string";
+
+/**
+ * String that marked as Vim's string constant format.
+ */
+export type ExprString = string & {
+  /**
+   * @internal
+   */
+  readonly [EXPR_STRING_MARK]: 1;
+};
+
+type Jsonable = {
+  toJSON(key: string | number | undefined): string;
+};
+
+// deno-lint-ignore no-explicit-any
+type TemplateSubstitutions = any[];
+
+const cacheKey = "denops_std/helper/exprStr@1";
+
+async function ensurePrerequisites(denops: Denops): Promise<string> {
+  if (typeof denops.context[cacheKey] === "string") {
+    return denops.context[cacheKey];
+  }
+  const suffix = generateUniqueString();
+  denops.context[cacheKey] = suffix;
+  const script = `
+  let g:loaded_denops_std_helper_exprStr_${suffix} = 1
+
+  function DenopsStdHelperExprStringCall_${suffix}(fn, args) abort
+    return call(a:fn, eval(a:args))
+  endfunction
+  `;
+  await execute(denops, script);
+  return suffix;
+}
+
+/**
+ * Tagged template function that marks a string as Vim's string constant format.
+ * Returns a `String` wrapper object instead of a primitive string.
+ *
+ * ```typescript
+ * import { exprQuote } from "./expr_string.ts";
+ *
+ * console.log(exprQuote`foo` == "foo"); // outputs: true
+ * console.log(exprQuote`foo` === "foo"); // outputs: false
+ * console.log(exprQuote`foo,${40 + 2}` == "foo,42"); // outputs: true
+ * ```
+ *
+ * @see useExprString for usage
+ */
+export function exprQuote(
+  template: TemplateStringsArray,
+  ...substitutions: TemplateSubstitutions
+): ExprString {
+  const raw = String.raw(template, ...substitutions);
+  return Object.assign(raw, {
+    [EXPR_STRING_MARK]: 1 as const,
+  });
+}
+
+/**
+ * Returns `true` if the value is a string marked as Vim's string constant format.
+ *
+ * ```typescript
+ * import { exprQuote, isExprString } from "./expr_string.ts";
+ *
+ * console.log(isExprString(exprQuote`foo`)); // outputs: true
+ * console.log(isExprString("foo")); // outputs: false
+ * ```
+ */
+export function isExprString(x: unknown): x is ExprString {
+  return x instanceof String && (x as ExprString)[EXPR_STRING_MARK] === 1;
+}
+
+function isJsonable(x: unknown): x is Jsonable {
+  return x != null && typeof (x as Jsonable).toJSON === "function";
+}
+
+/**
+ * @internal
+ */
+export function vimStringify(value: unknown, key?: string | number): string {
+  if (isJsonable(value)) {
+    return vimStringify(JSON.parse(value.toJSON(key)));
+  }
+  if (isExprString(value)) {
+    return `"${value.replaceAll('"', '\\"')}"`;
+  }
+  if (value == null || ["function", "symbol"].includes(typeof value)) {
+    return "v:null";
+  }
+  if (typeof value === "boolean" || value instanceof Boolean) {
+    return value == true ? "v:true" : "v:false";
+  }
+  if (typeof value === "number" || value instanceof Number) {
+    // Replace `5e-10` to `5.0e-10`
+    return `${value}`.replace(/^(\d+)e/, "$1.0e");
+  }
+  if (typeof value === "string" || value instanceof String) {
+    return `'${value.replaceAll("'", "''")}'`;
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(vimStringify).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    return `{${
+      Object.entries(value)
+        .filter(([, value]) =>
+          !["undefined", "function", "symbol"].includes(typeof value)
+        )
+        .map(([key, value]) =>
+          `'${key.replaceAll("'", "''")}':${vimStringify(value, key)}`
+        )
+        .join(",")
+    }}`;
+  }
+  const type = Object.prototype.toString.call(value).slice(8, -1);
+  throw new TypeError(`${type} value can't be serialized`);
+}
+
+function trimEndOfArgs(args: unknown[]): unknown[] {
+  const last = args.findIndex((v) => v === undefined);
+  return last < 0 ? args : args.slice(0, last);
+}
+
+class ExprStringHelper implements Denops {
+  #denops: Denops;
+
+  constructor(denops: Denops) {
+    this.#denops = denops;
+  }
+
+  get name(): string {
+    return this.#denops.name;
+  }
+
+  get meta(): Meta {
+    return this.#denops.meta;
+  }
+
+  get context(): Record<string | number | symbol, unknown> {
+    return this.#denops.context;
+  }
+
+  get dispatcher(): Dispatcher {
+    return this.#denops.dispatcher;
+  }
+
+  set dispatcher(dispatcher: Dispatcher) {
+    this.#denops.dispatcher = dispatcher;
+  }
+
+  redraw(force?: boolean): Promise<void> {
+    return this.#denops.redraw(force);
+  }
+
+  async call(fn: string, ...args: unknown[]): Promise<unknown> {
+    const suffix = await ensurePrerequisites(this.#denops);
+    return this.#denops.call(
+      `DenopsStdHelperExprStringCall_${suffix}`,
+      fn,
+      vimStringify(trimEndOfArgs(args)),
+    );
+  }
+
+  async batch(...calls: [string, ...unknown[]][]): Promise<unknown[]> {
+    const suffix = await ensurePrerequisites(this.#denops);
+    const callHelper = `DenopsStdHelperExprStringCall_${suffix}`;
+    return this.#denops.batch(
+      ...calls.map(([fn, ...args]): [string, ...unknown[]] => [
+        callHelper,
+        fn,
+        vimStringify(trimEndOfArgs(args)),
+      ]),
+    );
+  }
+
+  async cmd(cmd: string, ctx: Context = {}): Promise<void> {
+    await this.call("denops#api#cmd", cmd, ctx);
+  }
+
+  eval(expr: string, ctx: Context = {}): Promise<unknown> {
+    return this.call("denops#api#eval", expr, ctx);
+  }
+
+  dispatch(name: string, fn: string, ...args: unknown[]): Promise<unknown> {
+    return this.#denops.dispatch(name, fn, ...args);
+  }
+}
+
+/**
+ * Call the denops function using Vim's string constant format.
+ *
+ * ```typescript
+ * import { Denops } from "../mod.ts";
+ * import { exprQuote as q, useExprString } from "./expr_string.ts";
+ * import * as fn from "../function/mod.ts";
+ *
+ * export async function main(denops: Denops): Promise<void> {
+ *   await useExprString(denops, async (denops) => {
+ *     await fn.feedkeys(denops, q`\<Cmd>echo 'foo'\<CR>`)
+ *     await denops.cmd('echo value', { value: q`\U0001F680` })
+ *   });
+ * }
+ * ```
+ */
+export function useExprString<T extends unknown>(
+  denops: Denops,
+  executor: (helper: ExprStringHelper) => Promise<T>,
+): Promise<T> {
+  const helper = new ExprStringHelper(denops);
+  return executor(helper);
+}

--- a/denops_std/helper/expr_string.ts
+++ b/denops_std/helper/expr_string.ts
@@ -27,7 +27,7 @@ type Jsonable = {
 // deno-lint-ignore no-explicit-any
 type TemplateSubstitutions = any[];
 
-const cacheKey = "denops_std/helper/exprStr@1";
+const cacheKey = "denops_std/helper/expr_string@1";
 
 async function ensurePrerequisites(denops: Denops): Promise<string> {
   if (is.String(denops.context[cacheKey])) {

--- a/denops_std/helper/expr_string_test.ts
+++ b/denops_std/helper/expr_string_test.ts
@@ -1,0 +1,482 @@
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertObjectMatch,
+  assertRejects,
+  assertThrows,
+} from "https://deno.land/std@0.205.0/assert/mod.ts";
+import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
+import {
+  exprQuote,
+  isExprString,
+  useExprString,
+  vimStringify,
+} from "./expr_string.ts";
+
+Deno.test({
+  name: "@internal vimStringify()",
+  fn: async (t) => {
+    await t.step({
+      name: "stringify undefined to `v:null`.",
+      fn: () => {
+        const actual = vimStringify(undefined);
+        assertEquals(actual, "v:null");
+      },
+    });
+    await t.step({
+      name: "stringify null to `v:null`.",
+      fn: () => {
+        const actual = vimStringify(null);
+        assertEquals(actual, "v:null");
+      },
+    });
+    await t.step({
+      name: "stringify Function to `v:null`.",
+      fn: () => {
+        const actual = vimStringify(() => {});
+        assertEquals(actual, "v:null");
+      },
+    });
+    await t.step({
+      name: "stringify Symbol to `v:null`.",
+      fn: () => {
+        const actual = vimStringify(Symbol("foo"));
+        assertEquals(actual, "v:null");
+      },
+    });
+    await t.step({
+      name: "stringify true to `v:true`.",
+      fn: () => {
+        const actual = vimStringify(true);
+        assertEquals(actual, "v:true");
+      },
+    });
+    await t.step({
+      name: "stringify false to `v:false`.",
+      fn: () => {
+        const actual = vimStringify(false);
+        assertEquals(actual, "v:false");
+      },
+    });
+    await t.step({
+      name: "stringify Boolean object to `v:true` or `v:false`.",
+      fn: () => {
+        const actualTrue = vimStringify(new Boolean(true));
+        assertEquals(actualTrue, "v:true");
+        const actualFalse = vimStringify(new Boolean(false));
+        assertEquals(actualFalse, "v:false");
+      },
+    });
+    await t.step({
+      name: "stringify integer number to integer number.",
+      fn: () => {
+        const actual = vimStringify(42);
+        assertEquals(actual, "42");
+      },
+    });
+    await t.step({
+      name: "stringify float number to float number.",
+      fn: () => {
+        const actual = vimStringify(21.948);
+        assertEquals(actual, "21.948");
+      },
+    });
+    await t.step({
+      name: "stringify exponential number to Vim's exponential number.",
+      fn: () => {
+        const actual = vimStringify(5e-10);
+        assertEquals(
+          actual,
+          "5.0e-10",
+          "Vim's exponential number requires `.0`.",
+        );
+      },
+    });
+    await t.step({
+      name: "stringify Number object to number.",
+      fn: () => {
+        const actualInteger = vimStringify(new Number(42));
+        assertEquals(actualInteger, "42");
+        const actualFloat = vimStringify(new Number(21.948));
+        assertEquals(actualFloat, "21.948");
+        const actualExponential = vimStringify(new Number(5e-10));
+        assertEquals(
+          actualExponential,
+          "5.0e-10",
+          "Vim's exponential number requires `.0`.",
+        );
+      },
+    });
+    await t.step({
+      name: "stringify string to `'...'`.",
+      fn: () => {
+        const actual = vimStringify("foo's bar");
+        assertEquals(actual, "'foo''s bar'");
+      },
+    });
+    await t.step({
+      name: "stringify String object to `'...'`.",
+      fn: () => {
+        const actual = vimStringify(new String("foo's bar"));
+        assertEquals(actual, "'foo''s bar'");
+      },
+    });
+    await t.step({
+      name: 'stringify ExprString to `"..."`.',
+      fn: () => {
+        const actual = vimStringify(exprQuote`\<Cmd>call Foo("bar")\<CR>`);
+        assertEquals(actual, '"\\<Cmd>call Foo(\\"bar\\")\\<CR>"');
+      },
+    });
+    await t.step({
+      name: "stringify array to `[value0,value1,...]`.",
+      fn: () => {
+        const actual = vimStringify(["foo", 42, null, undefined]);
+        assertEquals(actual, "['foo',42,v:null,v:null]");
+      },
+    });
+    await t.step({
+      name: "stringify object to `{'key0':value0,'key1':value1,...}`.",
+      fn: () => {
+        const actual = vimStringify({
+          foo: "foo",
+          bar: 42,
+          // undefined value is omitted.
+          undefinedValue: undefined,
+          // null value is keeped.
+          nullValue: null,
+          // Function value is omitted.
+          functionValue: () => {},
+          // Symbol key is omitted.
+          [Symbol("foo")]: "symbol key",
+          // Symbol value is omitted.
+          symbolValue: Symbol("foo"),
+        });
+        assertEquals(actual, "{'foo':'foo','bar':42,'nullValue':v:null}");
+      },
+    });
+    await t.step({
+      name: "stringify object that has `toJSON()` method.",
+      fn: () => {
+        const actual = vimStringify({
+          foo: 42,
+          toJSON: () => JSON.stringify([123, "bar"]),
+        });
+        assertEquals(actual, "[123,'bar']");
+      },
+    });
+    await t.step({
+      name: "stringify function that has `toJSON()` method.",
+      fn: () => {
+        const actual = vimStringify(Object.assign(
+          () => {},
+          {
+            toJSON: () => JSON.stringify([123, "bar"]),
+          },
+        ));
+        assertEquals(actual, "[123,'bar']");
+      },
+    });
+    await t.step({
+      name: "raises TypeError if specified BigInt.",
+      fn: () => {
+        assertThrows(
+          () => vimStringify(92382417n),
+          TypeError,
+          "BigInt value can't be serialized",
+        );
+      },
+    });
+    await t.step({
+      name: "stringify BigInt that has `toJSON()` method.",
+      fn: () => {
+        Object.assign(BigInt.prototype, {
+          toJSON(): string {
+            return this.toString();
+          },
+        });
+        try {
+          const actual = vimStringify(92382417n);
+          assertEquals(actual, "92382417");
+        } finally {
+          // deno-lint-ignore no-explicit-any
+          delete (BigInt.prototype as any).toJSON;
+        }
+      },
+    });
+    await t.step({
+      name: "stringify complex object.",
+      fn: () => {
+        const actual = vimStringify([
+          null,
+          undefined,
+          42,
+          true,
+          () => {},
+          Symbol("foo"),
+          "bar",
+          {
+            toJSON: () => JSON.stringify([123, "baz"]),
+          },
+          {
+            k0: null,
+            k1: undefined,
+            k2: [
+              {
+                [Symbol("foo")]: 123,
+                key: 234,
+                expr: exprQuote`\U0001F680`,
+              },
+            ],
+          },
+        ]);
+        assertEquals(
+          actual,
+          `[v:null,v:null,42,v:true,v:null,v:null,'bar',[123,'baz'],{'k0':v:null,'k2':[{'key':234,'expr':"\\U0001F680"}]}]`,
+        );
+      },
+    });
+  },
+});
+
+Deno.test({
+  name: "exprQuote()",
+  fn: async (t) => {
+    await t.step({
+      name: "returns a string marked as ExprString.",
+      fn: () => {
+        const actual = exprQuote`foo`;
+        assertInstanceOf(actual, String);
+        assertEquals(`${actual}`, "foo");
+        assertObjectMatch(actual, { __denops_expr_string: 1 });
+      },
+    });
+    await t.step({
+      name: "converts a template string to a string.",
+      fn: () => {
+        const actual = exprQuote`number:${40 + 2},string:${"foo"},null:${null}`;
+        assertEquals(`${actual}`, "number:42,string:foo,null:null");
+      },
+    });
+  },
+});
+
+Deno.test({
+  name: "isExprString()",
+  fn: async (t) => {
+    await t.step({
+      name: "returns true if the value is ExprString.",
+      fn: () => {
+        const actual = isExprString(exprQuote`foo`);
+        assertEquals(actual, true);
+      },
+    });
+    await t.step({
+      name: "returns false if the value is not ExprString.",
+      fn: () => {
+        const actual = isExprString("foo");
+        assertEquals(actual, false);
+      },
+    });
+  },
+});
+
+test({
+  mode: "all",
+  name: "useExprString()",
+  fn: async (denops, t) => {
+    await t.step({
+      name:
+        "sequentially execute 'denops.call()', 'denops.cmd()' or 'denops.eval()'.",
+      fn: async () => {
+        await denops.cmd("let g:denops_expr_string_test = 10");
+        const result = await useExprString(denops, async (denops) => {
+          await denops.call("execute", "let g:denops_expr_string_test *= 2");
+          await denops.cmd("let g:denops_expr_string_test += 2");
+          return await denops.eval("g:denops_expr_string_test - 1");
+        });
+        assertEquals(result, 21);
+      },
+    });
+    await t.step({
+      name: "sequentially execute calls of 'denops.batch()'.",
+      fn: async () => {
+        const result = await useExprString(denops, async (denops) => {
+          return await denops.batch(
+            ["range", 0],
+            ["range", 1],
+            ["range", 2],
+          );
+        });
+        assertEquals(result, [[], [0], [0, 1]]);
+      },
+    });
+    await t.step({
+      name: "omit undefined and after it args in 'denops.call()'.",
+      fn: async () => {
+        const result = await useExprString(denops, async (denops) => {
+          return await denops.call("abs", 12.34, undefined, 3);
+        });
+        assertEquals(result, 12.34);
+      },
+    });
+    await t.step({
+      name: "omit undefined and after it args in 'denops.batch()'.",
+      fn: async () => {
+        const result = await useExprString(denops, async (denops) => {
+          return await denops.batch(
+            ["abs", 12.34, undefined, 3],
+          );
+        });
+        assertEquals(result, [12.34]);
+      },
+    });
+    await t.step({
+      name: "execute 'denops.call()' with ExprString.",
+      fn: async () => {
+        await denops.cmd("let g:denops_expr_string_test = 10");
+        await useExprString(denops, async (denops) => {
+          await denops.call(
+            "feedkeys",
+            exprQuote`\<Cmd>let g:denops_expr_string_test += 2\<CR>`,
+            "x",
+          );
+        });
+        assertEquals(await denops.eval("g:denops_expr_string_test"), 12);
+      },
+    });
+    await t.step({
+      name: "execute 'denops.cmd()' with ExprString.",
+      fn: async () => {
+        await denops.cmd("let g:denops_expr_string_test = 10");
+        await useExprString(denops, async (denops) => {
+          await denops.cmd(
+            "call feedkeys(keys, flags)",
+            {
+              keys: exprQuote`\<Cmd>let g:denops_expr_string_test *= 2\<CR>`,
+              flags: "x",
+            },
+          );
+        });
+        assertEquals(await denops.eval("g:denops_expr_string_test"), 20);
+      },
+    });
+    await t.step({
+      name: "execute 'denops.eval()' with ExprString.",
+      fn: async () => {
+        await denops.cmd("let g:denops_expr_string_test = 10");
+        await useExprString(denops, async (denops) => {
+          await denops.eval(
+            "feedkeys(keys, flags)",
+            {
+              keys: exprQuote`\<Cmd>let g:denops_expr_string_test -= 2\<CR>`,
+              flags: "x",
+            },
+          );
+        });
+        assertEquals(await denops.eval("g:denops_expr_string_test"), 8);
+      },
+    });
+    await t.step({
+      name: "execute 'denops.batch()' with ExprString.",
+      fn: async () => {
+        await denops.cmd("let g:denops_expr_string_test = 10");
+        await useExprString(denops, async (denops) => {
+          await denops.batch(
+            [
+              "feedkeys",
+              exprQuote`\<Cmd>let g:denops_expr_string_test += 2\<CR>`,
+            ],
+            [
+              "feedkeys",
+              exprQuote`\<Cmd>let g:denops_expr_string_test *= 2\<CR>`,
+            ],
+            [
+              "feedkeys",
+              exprQuote`\<Cmd>let g:denops_expr_string_test -= 1\<CR>`,
+              "x",
+            ],
+          );
+        });
+        assertEquals(await denops.eval("g:denops_expr_string_test"), 23);
+      },
+    });
+    await t.step({
+      name: "execute 'denops.call()' with complex args.",
+      fn: async () => {
+        const savedEncoding = await denops.eval("&encoding");
+        await denops.cmd("set encoding=utf-8");
+        try {
+          const result = await useExprString(denops, async (denops) => {
+            return await denops.call(
+              "map",
+              [
+                null,
+                undefined,
+                42,
+                true,
+                () => {},
+                Symbol("foo"),
+                "bar",
+                {
+                  toJSON: () => JSON.stringify([123, "baz"]),
+                },
+                {
+                  k0: null,
+                  k1: undefined,
+                  k2: [
+                    {
+                      [Symbol("foo")]: 123,
+                      key: 234,
+                      expr: exprQuote`\U0001F680`,
+                    },
+                  ],
+                },
+              ],
+              "v:val",
+            );
+          });
+          assertEquals(result, [
+            null,
+            null,
+            42,
+            true,
+            null,
+            null,
+            "bar",
+            [
+              123,
+              "baz",
+            ],
+            {
+              k0: null,
+              k2: [
+                {
+                  key: 234,
+                  expr: `\uD83D\uDE80`, // u1F680 is surrogate pair
+                },
+              ],
+            },
+          ]);
+        } finally {
+          await denops.cmd(`set encoding=${savedEncoding}`);
+        }
+      },
+    });
+    await t.step({
+      name:
+        "throws an error if BigInt is specified in args of 'denops.call()'.",
+      fn: async () => {
+        await assertRejects(
+          async () => {
+            await useExprString(denops, async (denops) => {
+              await denops.call("range", 10n);
+            });
+          },
+          TypeError,
+          "BigInt value can't be serialized",
+        );
+      },
+    });
+  },
+});


### PR DESCRIPTION
**expr-string** is a helper that allows we to use Vim's [expr-quote](https://vim-jp.org/vimdoc-en/eval.html#expr-quote) format.

Example:
```typescript
import { Denops } from ".../denops_std/mod.ts";
import { exprQuote as q, useExprString } from ".../denops_std/helper/expr_string.ts";
import * as fn from ".../denops_std/function/mod.ts";
                                                                      
export async function main(denops: Denops): Promise<void> {
  const denopsWithExprString = useExprString (denops);
  await fn.feedkeys(denopsWithExprString, q`\<Cmd>echo 'foo'\<CR>`)
  await denopsWithExprString.cmd('echo value', { value: q`\U0001F680` })
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new way to handle and serialize strings for Vim script compatibility.
  - Added utility methods for working with Vim string constants within the Denops framework.

- **Enhancements**
  - Improved the `exprQuote` function to support advanced string handling in Vim scripts.

- **Tests**
  - Implemented new test cases to ensure the reliability of Vim script string conversion and utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->