### PR TITLE
:+1: Add send keys helper

### DIFF
--- a/denops_std/helper/keymap.ts
+++ b/denops_std/helper/keymap.ts
@@ -1,0 +1,92 @@
+import { deferred } from "https://deno.land/std@0.208.0/async/deferred.ts#=";
+import { type Denops } from "https://deno.land/x/denops_core@v5.0.0/mod.ts";
+import {
+  exprQuote as q,
+  ExprString,
+  isExprString,
+  useExprString,
+} from "./expr_string.ts";
+import { batch } from "../batch/mod.ts";
+import { register } from "../lambda/mod.ts";
+import { feedkeys } from "../function/mod.ts";
+import is from "https://deno.land/x/unknownutil@v3.10.0/is.ts";
+
+export type Keys = {
+  keys: string | ExprString;
+  remap: boolean;
+};
+
+export type KeysSpecifier = Keys | Keys["keys"];
+
+function toArray<T>(x: T | T[]): T[] {
+  return is.Array(x) ? x : [x];
+}
+
+function toKeys(keys: KeysSpecifier): Keys {
+  if (is.String(keys) || isExprString(keys)) {
+    return { keys, remap: false };
+  }
+  return keys;
+}
+
+/**
+ * Send key sequences synchronously.
+ * `denops#request` blocks, so note that it can only be used within `denops#notify`.
+ *
+ * ```typescript
+ * import { Denops } from "../mod.ts";
+ * import * as fn from "../function/mod.ts";
+ * import { send } from "./keymap.ts";
+ * import { exprQuote as q } from "./expr_string.ts";
+ *
+ * export async function main(denops: Denops): Promise<void> {
+ *   denops.dispatcher = {
+ *     send: async (): Promise<void> => {
+ *       // Let's say the current buffer is "foo".
+ *       await send(denops, "bar");
+ *       // The buffer has been changed!
+ *       // "foobar"
+ *       console.log(await fn.getline(denops, "."));
+ *
+ *       // Send special keys.
+ *       await send(denops, [
+ *         q`${"\\<BS>".repeat(6)}`,
+ *         "baz",
+ *       ]);
+ *       // "baz"
+ *       console.log(await fn.getline(denops, "."));
+ *
+ *       // Send remaped keys.
+ *       await send(denops, { keys: q`\<C-l>`, remap: true });
+ *       // "bazsend"
+ *       console.log(await fn.getline(denops, "."));
+ *     },
+ *   };
+ *   await denops.cmd(`inoremap <C-k> <Cmd>call denops#notify('${denops.name}', 'send', [])<CR>`);
+ *   await denops.cmd(`inoremap <C-l> send`);
+ * }
+ * ```
+ */
+export async function send(
+  denops: Denops,
+  keys: KeysSpecifier | KeysSpecifier[],
+): Promise<void> {
+  const waiter = deferred<void>();
+  const id = register(denops, () => waiter.resolve(), { once: true });
+  await Promise.all([
+    useExprString(denops, async (denops) => {
+      await batch(denops, async (denops) => {
+        const normKeys = toArray(keys).map(toKeys);
+        for (const key of normKeys) {
+          await feedkeys(denops, key.keys, key.remap ? "m" : "n");
+        }
+        await feedkeys(
+          denops,
+          q`\<Cmd>call denops#notify('${denops.name}', '${id}', [])\<CR>`,
+          "n",
+        );
+      });
+    }),
+    waiter,
+  ]);
+}

--- a/denops_std/helper/keymap_test.ts
+++ b/denops_std/helper/keymap_test.ts
@@ -1,0 +1,57 @@
+import { assertEquals } from "https://deno.land/std@0.205.0/assert/mod.ts";
+import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
+import { is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts";
+import * as fn from "../function/mod.ts";
+import { exprQuote as q } from "./expr_string.ts";
+import { KeysSpecifier, send } from "./keymap.ts";
+
+function toArray<T>(x: T | T[]): T[] {
+  return is.Array(x) ? x : [x];
+}
+
+type Spec = {
+  name: string;
+  keys: KeysSpecifier | KeysSpecifier[];
+  expect: string;
+};
+
+test({
+  mode: "nvim",
+  name: "send()",
+  fn: async (denops, t) => {
+    const specs: Spec[] = [
+      {
+        name: "normal key",
+        keys: "foo",
+        expect: "foo",
+      },
+      {
+        name: "special key",
+        keys: q`foo\<BS>bar\<Left>\<Del>`,
+        expect: "foba",
+      },
+      {
+        name: "remapped key",
+        keys: { keys: q`\<C-l>`, remap: true },
+        expect: "foo",
+      },
+    ];
+    await denops.cmd("inoremap <C-l> foo");
+
+    for (const spec of specs) {
+      await t.step({
+        name: spec.name,
+        fn: async () => {
+          await fn.deletebufline(denops, "%", 1, "$");
+          assertEquals(await fn.getline(denops, 1), "");
+          await send(denops, [
+            q`\<Esc>`,
+            "i",
+            ...toArray(spec.keys),
+          ]);
+          assertEquals(await fn.getline(denops, 1), spec.expect);
+        },
+      });
+    }
+  },
+});


### PR DESCRIPTION
`keymap` is a helper that send key sequences synchronously.

Example:
```typescript
import { Denops } from "../mod.ts";
import * as fn from "../function/mod.ts";
import { send } from "./keymap.ts";
import { exprQuote as q } from "./expr_string.ts";
                                                                                                
export async function main(denops: Denops): Promise<void> {
  denops.dispatcher = {
    send: async (): Promise<void> => {
      // Let's say the current buffer is "foo".
      await send(denops, "bar");
      // The buffer has been changed!
      // "foobar"
      console.log(await fn.getline(denops, "."));
                                                                                                
      // Send special keys.
      await send(denops, [
        q`${"\\<BS>".repeat(6)}`,
        "baz",
      ]);
      // "baz"
      console.log(await fn.getline(denops, "."));
                                                                                                
      // Send remaped keys.
      await send(denops, { keys: q`\<C-l>`, remap: true });
      // "bazsend"
      console.log(await fn.getline(denops, "."));
    },
  };
  await denops.cmd(`inoremap <C-k> <Cmd>call denops#notify('${denops.name}', 'send', [])<CR>`);
  await denops.cmd(`inoremap <C-l> send`);
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new key sequence sending functionality for improved user interaction with key mappings.

- **Documentation**
  - Added documentation for the new `send` function and related types to assist users in understanding their usage.

- **Tests**
  - Implemented new tests to ensure the reliability and correctness of the key sequence sending feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->