### PR TITLE
:bug: Re-export `BatchError` class and fix documentation of `buffer.concrete`

### DIFF
--- a/argument/mod.ts
+++ b/argument/mod.ts
@@ -1,7 +1,7 @@
 /**
  * A module to handle Vim's command arguments like the followings.
  *
- * ```vim
+ * ```
  * :MyCommand ++enc=sjis ++ff=dos -f --foo=foo --bar=bar --bar=baz hello world
  * ```
  *
@@ -10,7 +10,7 @@
  *
  * For example:
  *
- * ```vim
+ * ```
  * command! -nargs=* MyCommand call denops#request("myplugin", "test", [[<f-args>]])
  * ```
  *
@@ -60,6 +60,7 @@
  *   };
  * }
  * ```
+ *
  * @module
  */
 import { Opts, parseOpts } from "./opts.ts";

--- a/buffer/buffer.ts
+++ b/buffer/buffer.ts
@@ -388,11 +388,6 @@ export interface ReplaceOptions {
 /**
  * Concrete the buffer.
  *
- * - The `buftype` option become "nofile"
- * - The `swapfile` become disabled
- * - The `modifiable` become disabled
- * - The content of the buffer is restored on `BufReadCmd` synchronously
- *
  * Vim will discard the content of a non-file buffer when `:edit` is invoked. Use
  * this function to concrete the content of such buffer to prevent this discard.
  *

--- a/mod.ts
+++ b/mod.ts
@@ -59,10 +59,10 @@
  */
 
 // Re-export
-export type {
+export {
   BatchError,
-  Context,
-  Denops,
-  Dispatcher,
-  Meta,
+  type Context,
+  type Denops,
+  type Dispatcher,
+  type Meta,
 } from "https://deno.land/x/denops_core@v6.0.5/mod.ts";


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Modified export statements for enhanced module organization.
- **Bug Fixes**
	- Updated buffer options for improved reliability in content restoration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->