### PR TITLE
:+1: Add functions in `popup.txt` for Vim

### DIFF
--- a/.scripts/gen-function/gen-function.ts
+++ b/.scripts/gen-function/gen-function.ts
@@ -37,6 +37,7 @@ const vimHelpDownloadUrls = [
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/builtin.txt`,
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/channel.txt`,
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/eval.txt`,
+  `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/popup.txt`,
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/sign.txt`,
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/terminal.txt`,
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,

--- a/.scripts/gen-function/gen-function.ts
+++ b/.scripts/gen-function/gen-function.ts
@@ -50,10 +50,10 @@ const vimDefs = parse(vimHelps.join("\n"));
 const vimFnSet = difference(new Set(vimDefs.map((def) => def.fn)), manualFnSet);
 
 const nvimHelpDownloadUrls = [
+  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
   `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/builtin.txt`,
   `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
   `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/sign.txt`,
-  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
 ];
 for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
   console.log(`Download from ${nvimHelpDownloadUrl}`);

--- a/function/nvim/_generated.ts
+++ b/function/nvim/_generated.ts
@@ -3,846 +3,6 @@
 import type { Denops } from "https://deno.land/x/denops_core@v6.0.5/mod.ts";
 
 /**
- * Returns Dictionary of `api-metadata`.
- *
- * View it in a nice human-readable format:
- *
- *     :lua print(vim.inspect(vim.fn.api_info()))
- */
-export function api_info(denops: Denops): Promise<Record<string, unknown>>;
-export function api_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("api_info", ...args);
-}
-
-/**
- * Close a channel or a specific stream associated with it.
- * For a job, **{stream}** can be one of "stdin", "stdout",
- * "stderr" or "rpc" (closes stdin/stdout for a job started
- * with `"rpc":v:true`) If **{stream}** is omitted, all streams
- * are closed. If the channel is a pty, this will then close the
- * pty master, sending SIGHUP to the job process.
- * For a socket, there is only one stream, and **{stream}** should be
- * omitted.
- */
-export function chanclose(
-  denops: Denops,
-  id: unknown,
-  stream?: unknown,
-): Promise<number>;
-export function chanclose(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("chanclose", ...args);
-}
-
-/**
- * Send data to channel **{id}**. For a job, it writes it to the
- * stdin of the process. For the stdio channel `channel-stdio`,
- * it writes to Nvim's stdout.  Returns the number of bytes
- * written if the write succeeded, 0 otherwise.
- * See `channel-bytes` for more information.
- *
- * **{data}** may be a string, string convertible, `Blob`, or a list.
- * If **{data}** is a list, the items will be joined by newlines; any
- * newlines in an item will be sent as NUL. To send a final
- * newline, include a final empty string. Example:
- *
- *     :call chansend(id, ["abc", "123\n456", ""])
- *
- * will send `"abc<NL>123<NUL>456<NL>"`.
- *
- * chansend() writes raw data, not RPC messages.  If the channel
- * was created with `"rpc":v:true` then the channel expects RPC
- * messages, use `rpcnotify()` and `rpcrequest()` instead.
- */
-export function chansend(
-  denops: Denops,
-  id: unknown,
-  data: unknown,
-): Promise<number>;
-export function chansend(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("chansend", ...args);
-}
-
-/**
- * Returns a `Dictionary` representing the `context` at **{index}**
- * from the top of the `context-stack` (see `context-dict`).
- * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
- */
-export function ctxget(
-  denops: Denops,
-  index?: unknown,
-): Promise<Record<string, unknown>>;
-export function ctxget(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("ctxget", ...args);
-}
-
-/**
- * Pops and restores the `context` at the top of the
- * `context-stack`.
- */
-export function ctxpop(denops: Denops): Promise<void>;
-export function ctxpop(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("ctxpop", ...args);
-}
-
-/**
- * Pushes the current editor state (`context`) on the
- * `context-stack`.
- * If **{types}** is given and is a `List` of `String`s, it specifies
- * which `context-types` to include in the pushed context.
- * Otherwise, all context types are included.
- */
-export function ctxpush(denops: Denops, types?: unknown): Promise<void>;
-export function ctxpush(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("ctxpush", ...args);
-}
-
-/**
- * Sets the `context` at **{index}** from the top of the
- * `context-stack` to that represented by **{context}**.
- * **{context}** is a Dictionary with context data (`context-dict`).
- * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
- */
-export function ctxset(
-  denops: Denops,
-  context: unknown,
-  index?: unknown,
-): Promise<void>;
-export function ctxset(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("ctxset", ...args);
-}
-
-/**
- * Returns the size of the `context-stack`.
- */
-export function ctxsize(denops: Denops): Promise<number>;
-export function ctxsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("ctxsize", ...args);
-}
-
-/**
- * Adds a watcher to a dictionary. A dictionary watcher is
- * identified by three components:
- *
- * - A dictionary(**{dict}**);
- * - A key pattern(**{pattern}**).
- * - A function(**{callback}**).
- *
- * After this is called, every change on **{dict}** and on keys
- * matching **{pattern}** will result in **{callback}** being invoked.
- *
- * For example, to watch all global variables:
- *
- *     silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
- *     function! OnDictChanged(d,k,z)
- *       echomsg string(a:k) string(a:z)
- *     endfunction
- *     call dictwatcheradd(g:, '*', 'OnDictChanged')
- *
- * For now **{pattern}** only accepts very simple patterns that can
- * contain a "*" at the end of the string, in which case it will
- * match every key that begins with the substring before the "*".
- * That means if "*" is not the last character of **{pattern}**, only
- * keys that are exactly equal as **{pattern}** will be matched.
- *
- * The **{callback}** receives three arguments:
- *
- * - The dictionary being watched.
- * - The key which changed.
- * - A dictionary containing the new and old values for the key.
- *
- * The type of change can be determined by examining the keys
- * present on the third argument:
- *
- * - If contains both `old` and `new`, the key was updated.
- * - If it contains only `new`, the key was added.
- * - If it contains only `old`, the key was deleted.
- *
- * This function can be used by plugins to implement options with
- * validation and parsing logic.
- */
-export function dictwatcheradd(
-  denops: Denops,
-  dict: unknown,
-  pattern: unknown,
-  callback: unknown,
-): Promise<unknown>;
-export function dictwatcheradd(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("dictwatcheradd", ...args);
-}
-
-/**
- * Removes a watcher added  with `dictwatcheradd()`. All three
- * arguments must match the ones passed to `dictwatcheradd()` in
- * order for the watcher to be successfully deleted.
- */
-export function dictwatcherdel(
-  denops: Denops,
-  dict: unknown,
-  pattern: unknown,
-  callback: unknown,
-): Promise<unknown>;
-export function dictwatcherdel(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("dictwatcherdel", ...args);
-}
-
-/**
- * Returns a `String` which is a unique identifier of the
- * container type (`List`, `Dict`, `Blob` and `Partial`). It is
- * guaranteed that for the mentioned types `id(v1) ==# id(v2)`
- * returns true iff `type(v1) == type(v2) && v1 is v2`.
- * Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
- * `v:_null_blob` have the same `id()` with different types
- * because they are internally represented as NULL pointers.
- * `id()` returns a hexadecimal representanion of the pointers to
- * the containers (i.e. like `0x994a40`), same as `printf("%p",
- * {expr})`, but it is advised against counting on the exact
- * format of the return value.
- *
- * It is not guaranteed that `id(no_longer_existing_container)`
- * will not be equal to some other `id()`: new containers may
- * reuse identifiers of the garbage-collected ones.
- */
-export function id(denops: Denops, expr: unknown): Promise<string>;
-export function id(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("id", ...args);
-}
-
-/**
- * Return the PID (process id) of `job-id` **{job}**.
- */
-export function jobpid(denops: Denops, job: unknown): Promise<number>;
-export function jobpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("jobpid", ...args);
-}
-
-/**
- * Resize the pseudo terminal window of `job-id` **{job}** to **{width}**
- * columns and **{height}** rows.
- * Fails if the job was not started with `"pty":v:true`.
- */
-export function jobresize(
-  denops: Denops,
-  job: unknown,
-  width: unknown,
-  height: unknown,
-): Promise<number>;
-export function jobresize(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("jobresize", ...args);
-}
-
-/**
- * Spawns **{cmd}** as a job.
- * If **{cmd}** is a List it runs directly (no 'shell').
- * If **{cmd}** is a String it runs in the 'shell', like this:
- *
- *     :call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
- *
- * (See `shell-unquoting` for details.)
- *
- * Example:
- *
- *     :call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
- *
- * Returns `job-id` on success, 0 on invalid arguments (or job
- * table is full), -1 if **{cmd}**[0] or 'shell' is not executable.
- * The returned job-id is a valid `channel-id` representing the
- * job's stdio streams. Use `chansend()` (or `rpcnotify()` and
- * `rpcrequest()` if "rpc" was enabled) to send data to stdin and
- * `chanclose()` to close the streams without stopping the job.
- *
- * See `job-control` and `RPC`.
- *
- * NOTE: on Windows if **{cmd}** is a List:
- *   - cmd[0] must be an executable (not a "built-in"). If it is
- *     in $PATH it can be called by name, without an extension:
- *
- *         :call jobstart(['ping', 'neovim.io'])
- *
- *     If it is a full or partial path, extension is required:
- *
- *         :call jobstart(['System32\ping.exe', 'neovim.io'])
- *
- *   - **{cmd}** is collapsed to a string of quoted args as expected
- *     by CommandLineToArgvW https://msdn.microsoft.com/bb776391
- *     unless cmd[0] is some form of "cmd.exe".
- *
- * The job environment is initialized as follows:
- *   $NVIM                is set to `v:servername` of the parent Nvim
- *   $NVIM_LISTEN_ADDRESS is unset
- *   $NVIM_LOG_FILE       is unset
- *   $VIM                 is unset
- *   $VIMRUNTIME          is unset
- * You can set these with the `env` option.
- *
- * **{opts}** is a dictionary with these keys:
- *   clear_env:  (boolean) `env` defines the job environment
- *               exactly, instead of merging current environment.
- *   cwd:        (string, default=`current-directory`) Working
- *               directory of the job.
- *   detach:     (boolean) Detach the job process: it will not be
- *               killed when Nvim exits. If the process exits
- *               before Nvim, `on_exit` will be invoked.
- *   env:        (dict) Map of environment variable name:value
- *               pairs extending (or replace with "clear_env")
- *               the current environment. `jobstart-env`
- *   height:     (number) Height of the `pty` terminal.
- *   `on_exit`:    (function) Callback invoked when the job exits.
- *   `on_stdout`:  (function) Callback invoked when the job emits
- *               stdout data.
- *   `on_stderr`:  (function) Callback invoked when the job emits
- *               stderr data.
- *   overlapped: (boolean) Set FILE_FLAG_OVERLAPPED for the
- *               standard input/output passed to the child process.
- *               Normally you do not need to set this.
- *               (Only available on MS-Windows, On other
- *               platforms, this option is silently ignored.)
- *   pty:        (boolean) Connect the job to a new pseudo
- *               terminal, and its streams to the master file
- *               descriptor. `on_stdout` receives all output,
- *               `on_stderr` is ignored. `terminal-start`
- *   rpc:        (boolean) Use `msgpack-rpc` to communicate with
- *               the job over stdio. Then `on_stdout` is ignored,
- *               but `on_stderr` can still be used.
- *   stderr_buffered: (boolean) Collect data until EOF (stream closed)
- *               before invoking `on_stderr`. `channel-buffered`
- *   stdout_buffered: (boolean) Collect data until EOF (stream
- *               closed) before invoking `on_stdout`. `channel-buffered`
- *   stdin:      (string) Either "pipe" (default) to connect the
- *               job's stdin to a channel or "null" to disconnect
- *               stdin.
- *   width:      (number) Width of the `pty` terminal.
- *
- * **{opts}** is passed as `self` dictionary to the callback; the
- * caller may set other keys to pass application-specific data.
- *
- * Returns:
- *   - `channel-id` on success
- *   - 0 on invalid arguments
- *   - -1 if **{cmd}**[0] is not executable.
- * See also `job-control`, `channel`, `msgpack-rpc`.
- */
-export function jobstart(
-  denops: Denops,
-  cmd: unknown,
-  opts?: unknown,
-): Promise<number>;
-export function jobstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("jobstart", ...args);
-}
-
-/**
- * Stop `job-id` **{id}** by sending SIGTERM to the job process. If
- * the process does not terminate after a timeout then SIGKILL
- * will be sent. When the job terminates its `on_exit` handler
- * (if any) will be invoked.
- * See `job-control`.
- *
- * Returns 1 for valid job id, 0 for invalid id, including jobs have
- * exited or stopped.
- */
-export function jobstop(denops: Denops, id: unknown): Promise<number>;
-export function jobstop(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("jobstop", ...args);
-}
-
-/**
- * Waits for jobs and their `on_exit` handlers to complete.
- *
- * **{jobs}** is a List of `job-id`s to wait for.
- * **{timeout}** is the maximum waiting time in milliseconds. If
- * omitted or -1, wait forever.
- *
- * Timeout of 0 can be used to check the status of a job:
- *
- *     let running = jobwait([{job-id}], 0)[0] == -1
- *
- * During jobwait() callbacks for jobs not in the **{jobs}** list may
- * be invoked. The screen will not redraw unless `:redraw` is
- * invoked by a callback.
- *
- * Returns a list of len(**{jobs}**) integers, where each integer is
- * the status of the corresponding job:
- *         Exit-code, if the job exited
- *         -1 if the timeout was exceeded
- *         -2 if the job was interrupted (by `CTRL-C`)
- *         -3 if the job-id is invalid
- */
-export function jobwait(
-  denops: Denops,
-  jobs: unknown,
-  timeout?: unknown,
-): Promise<number>;
-export function jobwait(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("jobwait", ...args);
-}
-
-/**
- * Returns a `List` of `Dictionaries` describing `menus` (defined
- * by `:menu`, `:amenu`, …), including `hidden-menus`.
- *
- * **{path}** matches a menu by name, or all menus if **{path}** is an
- * empty string.  Example:
- *
- *     :echo menu_get('File','')
- *     :echo menu_get('')
- *
- * **{modes}** is a string of zero or more modes (see `maparg()` or
- * `creating-menus` for the list of modes). "a" means "all".
- *
- * Example:
- *
- *     nnoremenu &Test.Test inormal
- *     inoremenu Test.Test insert
- *     vnoremenu Test.Test x
- *     echo menu_get("")
- *
- * returns something like this:
- *
- *     [ {
- *       "hidden": 0,
- *       "name": "Test",
- *       "priority": 500,
- *       "shortcut": 84,
- *       "submenus": [ {
- *         "hidden": 0,
- *         "mappings": {
- *           i": {
- *             "enabled": 1,
- *             "noremap": 1,
- *             "rhs": "insert",
- *             "sid": 1,
- *             "silent": 0
- *           },
- *           n": { ... },
- *           s": { ... },
- *           v": { ... }
- *         },
- *         "name": "Test",
- *         "priority": 500,
- *         "shortcut": 0
- *       } ]
- *     } ]
- */
-export function menu_get(
-  denops: Denops,
-  path: unknown,
-  modes?: unknown,
-): Promise<unknown[]>;
-export function menu_get(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("menu_get", ...args);
-}
-
-/**
- * Convert a list of VimL objects to msgpack. Returned value is a
- * `readfile()`-style list. When **{type}** contains "B", a `Blob` is
- * returned instead. Example:
- *
- *     call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
- *
- * or, using a `Blob`:
- *
- *     call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
- *
- * This will write the single 0x80 byte to a `fname.mpack` file
- * (dictionary with zero items is represented by 0x80 byte in
- * messagepack).
- *
- * Limitations:
- * 1. `Funcref`s cannot be dumped.
- * 2. Containers that reference themselves cannot be dumped.
- * 3. Dictionary keys are always dumped as STR strings.
- * 4. Other strings and `Blob`s are always dumped as BIN strings.
- * 5. Points 3. and 4. do not apply to `msgpack-special-dict`s.
- */
-export function msgpackdump(
-  denops: Denops,
-  list: unknown,
-  type?: unknown,
-): Promise<unknown[] | unknown>;
-export function msgpackdump(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("msgpackdump", ...args);
-}
-
-/**
- * Convert a `readfile()`-style list or a `Blob` to a list of
- * VimL objects.
- * Example:
- *
- *     let fname = expand('~/.config/nvim/shada/main.shada')
- *     let mpack = readfile(fname, 'b')
- *     let shada_objects = msgpackparse(mpack)
- *
- * This will read `~/.config/nvim/shada/main.shada` file to
- * `shada_objects` list.
- *
- * Limitations:
- * 1. Mapping ordering is not preserved unless messagepack
- *    mapping is dumped using generic mapping
- *    (`msgpack-special-map`).
- * 2. Since the parser aims to preserve all data untouched
- *    (except for 1.) some strings are parsed to
- *    `msgpack-special-dict` format which is not convenient to
- *    use.
- *
- * Some messagepack strings may be parsed to special
- * dictionaries. Special dictionaries are dictionaries which
- *
- * 1. Contain exactly two keys: `_TYPE` and `_VAL`.
- * 2. `_TYPE` key is one of the types found in `v:msgpack_types`
- *    variable.
- * 3. Value for `_VAL` has the following format (Key column
- *    contains name of the key from `v:msgpack_types`):
- *
- * Key     Value
- * nil     Zero, ignored when dumping.  Not returned by
- *         `msgpackparse()` since `v:null` was introduced.
- * boolean One or zero.  When dumping it is only checked that
- *         value is a `Number`.  Not returned by `msgpackparse()`
- *         since `v:true` and `v:false` were introduced.
- * integer `List` with four numbers: sign (-1 or 1), highest two
- *         bits, number with bits from 62nd to 31st, lowest 31
- *         bits. I.e. to get actual number one will need to use
- *         code like
- *
- *             _VAL[0] * ((_VAL[1] << 62)
- *                        & (_VAL[2] << 31)
- *                        & _VAL[3])
- *
- *         Special dictionary with this type will appear in
- *         `msgpackparse()` output under one of the following
- *         circumstances:
- *         1. `Number` is 32-bit and value is either above
- *            INT32_MAX or below INT32_MIN.
- *         2. `Number` is 64-bit and value is above INT64_MAX. It
- *            cannot possibly be below INT64_MIN because msgpack
- *            C parser does not support such values.
- * float   `Float`. This value cannot possibly appear in
- *         `msgpackparse()` output.
- * string  `readfile()`-style list of strings. This value will
- *         appear in `msgpackparse()` output if string contains
- *         zero byte or if string is a mapping key and mapping is
- *         being represented as special dictionary for other
- *         reasons.
- * binary  `String`, or `Blob` if binary string contains zero
- *         byte. This value cannot appear in `msgpackparse()`
- *         output since blobs were introduced.
- * array   `List`. This value cannot appear in `msgpackparse()`
- *         output.
- *
- * map     `List` of `List`s with two items (key and value) each.
- *         This value will appear in `msgpackparse()` output if
- *         parsed mapping contains one of the following keys:
- *         1. Any key that is not a string (including keys which
- *            are binary strings).
- *         2. String with NUL byte inside.
- *         3. Duplicate key.
- *         4. Empty key.
- * ext     `List` with two values: first is a signed integer
- *         representing extension type. Second is
- *         `readfile()`-style list of strings.
- */
-export function msgpackparse(denops: Denops, data: unknown): Promise<unknown[]>;
-export function msgpackparse(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("msgpackparse", ...args);
-}
-
-/**
- * Returns the single letter name of the last recorded register.
- * Returns an empty string when nothing was recorded yet.
- * See `q` and `Q`.
- */
-export function reg_recorded(denops: Denops): Promise<string>;
-export function reg_recorded(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("reg_recorded", ...args);
-}
-
-/**
- * Sends **{event}** to **{channel}** via `RPC` and returns immediately.
- * If **{channel}** is 0, the event is broadcast to all channels.
- * Example:
- *
- *     :au VimLeave call rpcnotify(0, "leaving")
- */
-export function rpcnotify(
-  denops: Denops,
-  channel: unknown,
-  event: unknown,
-  args?: unknown,
-): Promise<unknown>;
-export function rpcnotify(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("rpcnotify", ...args);
-}
-
-/**
- * Sends a request to **{channel}** to invoke **{method}** via
- * `RPC` and blocks until a response is received.
- * Example:
- *
- *     :let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
- */
-export function rpcrequest(
-  denops: Denops,
-  channel: unknown,
-  method: unknown,
-  args?: unknown,
-): Promise<unknown>;
-export function rpcrequest(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("rpcrequest", ...args);
-}
-
-/**
- * Deprecated. Replace
- *
- *     :let id = rpcstart('prog', ['arg1', 'arg2'])
- *
- * with
- *
- *     :let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
- */
-export function rpcstart(
-  denops: Denops,
-  prog: unknown,
-  argv?: unknown,
-): Promise<unknown>;
-export function rpcstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("rpcstart", ...args);
-}
-
-/**
- * Opens a socket or named pipe at **{address}** and listens for
- * `RPC` messages. Clients can send `API` commands to the
- * returned address to control Nvim.
- *
- * Returns the address string (which may differ from the
- * **{address}** argument, see below).
- *
- * - If **{address}** has a colon (":") it is a TCP/IPv4/IPv6 address
- *   where the last ":" separates host and port (empty or zero
- *   assigns a random port).
- * - Else **{address}** is the path to a named pipe (except on Windows).
- *   - If **{address}** has no slashes ("/") it is treated as the
- *     "name" part of a generated path in this format:
- *
- *         stdpath("run").."/{name}.{pid}.{counter}"
- *
- *   - If **{address}** is omitted the name is "nvim".
- *
- *         :echo serverstart()
- *         => /tmp/nvim.bram/oknANW/nvim.15430.5
- *
- * Example bash command to list all Nvim servers:
- *
- *         ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/* /nvim.*.0
- *
- * Example named pipe:
- *
- *         if has('win32')
- *           echo serverstart('\\.\pipe\nvim-pipe-1234')
- *         else
- *           echo serverstart('nvim.sock')
- *         endif
- *
- * Example TCP/IP address:
- *
- *     echo serverstart('::1:12345')
- */
-export function serverstart(
-  denops: Denops,
-  address?: unknown,
-): Promise<unknown>;
-export function serverstart(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("serverstart", ...args);
-}
-
-/**
- * Closes the pipe or socket at **{address}**.
- * Returns TRUE if **{address}** is valid, else FALSE.
- * If `v:servername` is stopped it is set to the next available
- * address in `serverlist()`.
- */
-export function serverstop(denops: Denops, address: unknown): Promise<unknown>;
-export function serverstop(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("serverstop", ...args);
-}
-
-/**
- * Connect a socket to an address. If **{mode}** is "pipe" then
- * **{address}** should be the path of a local domain socket (on
- * unix) or named pipe (on Windows). If **{mode}** is "tcp" then
- * **{address}** should be of the form "host:port" where the host
- * should be an ip adderess or host name, and port the port
- * number.
- *
- * For "pipe" mode, see `luv-pipe-handle`. For "tcp" mode, see
- * `luv-tcp-handle`.
- *
- * Returns a `channel` ID. Close the socket with `chanclose()`.
- * Use `chansend()` to send data over a bytes socket, and
- * `rpcrequest()` and `rpcnotify()` to communicate with a RPC
- * socket.
- *
- * **{opts}** is an optional dictionary with these keys:
- *   `on_data` : callback invoked when data was read from socket
- *   data_buffered : read socket data in `channel-buffered` mode.
- *   rpc     : If set, `msgpack-rpc` will be used to communicate
- *             over the socket.
- * Returns:
- *   - The channel ID on success (greater than zero)
- *   - 0 on invalid arguments or connection failure.
- */
-export function sockconnect(
-  denops: Denops,
-  mode: unknown,
-  address: unknown,
-  opts?: unknown,
-): Promise<number>;
-export function sockconnect(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("sockconnect", ...args);
-}
-
-/**
- * With `--headless` this opens stdin and stdout as a `channel`.
- * May be called only once. See `channel-stdio`. stderr is not
- * handled by this function, see `v:stderr`.
- *
- * Close the stdio handles with `chanclose()`. Use `chansend()`
- * to send data to stdout, and `rpcrequest()` and `rpcnotify()`
- * to communicate over RPC.
- *
- * **{opts}** is a dictionary with these keys:
- *   `on_stdin` : callback invoked when stdin is written to.
- *   on_print : callback invoked when Nvim needs to print a
- *              message, with the message (whose type is string)
- *              as sole argument.
- *   stdin_buffered : read stdin in `channel-buffered` mode.
- *   rpc      : If set, `msgpack-rpc` will be used to communicate
- *              over stdio
- * Returns:
- *   - `channel-id` on success (value is always 1)
- *   - 0 on invalid arguments
- */
-export function stdioopen(denops: Denops, opts: unknown): Promise<number>;
-export function stdioopen(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("stdioopen", ...args);
-}
-
-/**
- * Returns `standard-path` locations of various default files and
- * directories.
- *
- * **{what}**       Type    Description
- * cache        String  Cache directory: arbitrary temporary
- *                      storage for plugins, etc.
- * config       String  User configuration directory. `init.vim`
- *                      is stored here.
- * config_dirs  List    Other configuration directories.
- * data         String  User data directory.
- * data_dirs    List    Other data directories.
- * log          String  Logs directory (for use by plugins too).
- * run          String  Run directory: temporary, local storage
- *                      for sockets, named pipes, etc.
- * state        String  Session state directory: storage for file
- *                      drafts, swap, undo, `shada`.
- *
- * Example:
- *
- *     :echo stdpath("config")
- */
-export function stdpath(
-  denops: Denops,
-  what: unknown,
-): Promise<string | unknown[]>;
-export function stdpath(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("stdpath", ...args);
-}
-
-/**
- * Spawns **{cmd}** in a new pseudo-terminal session connected
- * to the current (unmodified) buffer. Parameters and behavior
- * are the same as `jobstart()` except "pty", "width", "height",
- * and "TERM" are ignored: "height" and "width" are taken from
- * the current window.
- * Returns the same values as `jobstart()`.
- *
- * Terminal environment is initialized as in `jobstart-env`,
- * except $TERM is set to "xterm-256color". Full behavior is
- * described in `terminal`.
- */
-export function termopen(
-  denops: Denops,
-  cmd: unknown,
-  opts?: unknown,
-): Promise<unknown>;
-export function termopen(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("termopen", ...args);
-}
-
-/**
- * Waits until **{condition}** evaluates to `TRUE`, where **{condition}**
- * is a `Funcref` or `string` containing an expression.
- *
- * **{timeout}** is the maximum waiting time in milliseconds, -1
- * means forever.
- *
- * Condition is evaluated on user events, internal events, and
- * every **{interval}** milliseconds (default: 200).
- *
- * Returns a status integer:
- *         0 if the condition was satisfied before timeout
- *         -1 if the timeout was exceeded
- *         -2 if the function was interrupted (by `CTRL-C`)
- *         -3 if an error occurred
- */
-export function wait(
-  denops: Denops,
-  timeout: unknown,
-  condition: unknown,
-  interval?: unknown,
-): Promise<number>;
-export function wait(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("wait", ...args);
-}
-
-/**
  * Find files in runtime directories
  *
  * Attributes:
@@ -5692,4 +4852,844 @@ export function nvim_ui_try_resize_grid(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("nvim_ui_try_resize_grid", ...args);
+}
+
+/**
+ * Returns Dictionary of `api-metadata`.
+ *
+ * View it in a nice human-readable format:
+ *
+ *     :lua print(vim.inspect(vim.fn.api_info()))
+ */
+export function api_info(denops: Denops): Promise<Record<string, unknown>>;
+export function api_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("api_info", ...args);
+}
+
+/**
+ * Close a channel or a specific stream associated with it.
+ * For a job, **{stream}** can be one of "stdin", "stdout",
+ * "stderr" or "rpc" (closes stdin/stdout for a job started
+ * with `"rpc":v:true`) If **{stream}** is omitted, all streams
+ * are closed. If the channel is a pty, this will then close the
+ * pty master, sending SIGHUP to the job process.
+ * For a socket, there is only one stream, and **{stream}** should be
+ * omitted.
+ */
+export function chanclose(
+  denops: Denops,
+  id: unknown,
+  stream?: unknown,
+): Promise<number>;
+export function chanclose(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("chanclose", ...args);
+}
+
+/**
+ * Send data to channel **{id}**. For a job, it writes it to the
+ * stdin of the process. For the stdio channel `channel-stdio`,
+ * it writes to Nvim's stdout.  Returns the number of bytes
+ * written if the write succeeded, 0 otherwise.
+ * See `channel-bytes` for more information.
+ *
+ * **{data}** may be a string, string convertible, `Blob`, or a list.
+ * If **{data}** is a list, the items will be joined by newlines; any
+ * newlines in an item will be sent as NUL. To send a final
+ * newline, include a final empty string. Example:
+ *
+ *     :call chansend(id, ["abc", "123\n456", ""])
+ *
+ * will send `"abc<NL>123<NUL>456<NL>"`.
+ *
+ * chansend() writes raw data, not RPC messages.  If the channel
+ * was created with `"rpc":v:true` then the channel expects RPC
+ * messages, use `rpcnotify()` and `rpcrequest()` instead.
+ */
+export function chansend(
+  denops: Denops,
+  id: unknown,
+  data: unknown,
+): Promise<number>;
+export function chansend(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("chansend", ...args);
+}
+
+/**
+ * Returns a `Dictionary` representing the `context` at **{index}**
+ * from the top of the `context-stack` (see `context-dict`).
+ * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
+ */
+export function ctxget(
+  denops: Denops,
+  index?: unknown,
+): Promise<Record<string, unknown>>;
+export function ctxget(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("ctxget", ...args);
+}
+
+/**
+ * Pops and restores the `context` at the top of the
+ * `context-stack`.
+ */
+export function ctxpop(denops: Denops): Promise<void>;
+export function ctxpop(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("ctxpop", ...args);
+}
+
+/**
+ * Pushes the current editor state (`context`) on the
+ * `context-stack`.
+ * If **{types}** is given and is a `List` of `String`s, it specifies
+ * which `context-types` to include in the pushed context.
+ * Otherwise, all context types are included.
+ */
+export function ctxpush(denops: Denops, types?: unknown): Promise<void>;
+export function ctxpush(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("ctxpush", ...args);
+}
+
+/**
+ * Sets the `context` at **{index}** from the top of the
+ * `context-stack` to that represented by **{context}**.
+ * **{context}** is a Dictionary with context data (`context-dict`).
+ * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
+ */
+export function ctxset(
+  denops: Denops,
+  context: unknown,
+  index?: unknown,
+): Promise<void>;
+export function ctxset(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("ctxset", ...args);
+}
+
+/**
+ * Returns the size of the `context-stack`.
+ */
+export function ctxsize(denops: Denops): Promise<number>;
+export function ctxsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("ctxsize", ...args);
+}
+
+/**
+ * Adds a watcher to a dictionary. A dictionary watcher is
+ * identified by three components:
+ *
+ * - A dictionary(**{dict}**);
+ * - A key pattern(**{pattern}**).
+ * - A function(**{callback}**).
+ *
+ * After this is called, every change on **{dict}** and on keys
+ * matching **{pattern}** will result in **{callback}** being invoked.
+ *
+ * For example, to watch all global variables:
+ *
+ *     silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
+ *     function! OnDictChanged(d,k,z)
+ *       echomsg string(a:k) string(a:z)
+ *     endfunction
+ *     call dictwatcheradd(g:, '*', 'OnDictChanged')
+ *
+ * For now **{pattern}** only accepts very simple patterns that can
+ * contain a "*" at the end of the string, in which case it will
+ * match every key that begins with the substring before the "*".
+ * That means if "*" is not the last character of **{pattern}**, only
+ * keys that are exactly equal as **{pattern}** will be matched.
+ *
+ * The **{callback}** receives three arguments:
+ *
+ * - The dictionary being watched.
+ * - The key which changed.
+ * - A dictionary containing the new and old values for the key.
+ *
+ * The type of change can be determined by examining the keys
+ * present on the third argument:
+ *
+ * - If contains both `old` and `new`, the key was updated.
+ * - If it contains only `new`, the key was added.
+ * - If it contains only `old`, the key was deleted.
+ *
+ * This function can be used by plugins to implement options with
+ * validation and parsing logic.
+ */
+export function dictwatcheradd(
+  denops: Denops,
+  dict: unknown,
+  pattern: unknown,
+  callback: unknown,
+): Promise<unknown>;
+export function dictwatcheradd(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("dictwatcheradd", ...args);
+}
+
+/**
+ * Removes a watcher added  with `dictwatcheradd()`. All three
+ * arguments must match the ones passed to `dictwatcheradd()` in
+ * order for the watcher to be successfully deleted.
+ */
+export function dictwatcherdel(
+  denops: Denops,
+  dict: unknown,
+  pattern: unknown,
+  callback: unknown,
+): Promise<unknown>;
+export function dictwatcherdel(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("dictwatcherdel", ...args);
+}
+
+/**
+ * Returns a `String` which is a unique identifier of the
+ * container type (`List`, `Dict`, `Blob` and `Partial`). It is
+ * guaranteed that for the mentioned types `id(v1) ==# id(v2)`
+ * returns true iff `type(v1) == type(v2) && v1 is v2`.
+ * Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
+ * `v:_null_blob` have the same `id()` with different types
+ * because they are internally represented as NULL pointers.
+ * `id()` returns a hexadecimal representanion of the pointers to
+ * the containers (i.e. like `0x994a40`), same as `printf("%p",
+ * {expr})`, but it is advised against counting on the exact
+ * format of the return value.
+ *
+ * It is not guaranteed that `id(no_longer_existing_container)`
+ * will not be equal to some other `id()`: new containers may
+ * reuse identifiers of the garbage-collected ones.
+ */
+export function id(denops: Denops, expr: unknown): Promise<string>;
+export function id(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("id", ...args);
+}
+
+/**
+ * Return the PID (process id) of `job-id` **{job}**.
+ */
+export function jobpid(denops: Denops, job: unknown): Promise<number>;
+export function jobpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("jobpid", ...args);
+}
+
+/**
+ * Resize the pseudo terminal window of `job-id` **{job}** to **{width}**
+ * columns and **{height}** rows.
+ * Fails if the job was not started with `"pty":v:true`.
+ */
+export function jobresize(
+  denops: Denops,
+  job: unknown,
+  width: unknown,
+  height: unknown,
+): Promise<number>;
+export function jobresize(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("jobresize", ...args);
+}
+
+/**
+ * Spawns **{cmd}** as a job.
+ * If **{cmd}** is a List it runs directly (no 'shell').
+ * If **{cmd}** is a String it runs in the 'shell', like this:
+ *
+ *     :call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
+ *
+ * (See `shell-unquoting` for details.)
+ *
+ * Example:
+ *
+ *     :call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
+ *
+ * Returns `job-id` on success, 0 on invalid arguments (or job
+ * table is full), -1 if **{cmd}**[0] or 'shell' is not executable.
+ * The returned job-id is a valid `channel-id` representing the
+ * job's stdio streams. Use `chansend()` (or `rpcnotify()` and
+ * `rpcrequest()` if "rpc" was enabled) to send data to stdin and
+ * `chanclose()` to close the streams without stopping the job.
+ *
+ * See `job-control` and `RPC`.
+ *
+ * NOTE: on Windows if **{cmd}** is a List:
+ *   - cmd[0] must be an executable (not a "built-in"). If it is
+ *     in $PATH it can be called by name, without an extension:
+ *
+ *         :call jobstart(['ping', 'neovim.io'])
+ *
+ *     If it is a full or partial path, extension is required:
+ *
+ *         :call jobstart(['System32\ping.exe', 'neovim.io'])
+ *
+ *   - **{cmd}** is collapsed to a string of quoted args as expected
+ *     by CommandLineToArgvW https://msdn.microsoft.com/bb776391
+ *     unless cmd[0] is some form of "cmd.exe".
+ *
+ * The job environment is initialized as follows:
+ *   $NVIM                is set to `v:servername` of the parent Nvim
+ *   $NVIM_LISTEN_ADDRESS is unset
+ *   $NVIM_LOG_FILE       is unset
+ *   $VIM                 is unset
+ *   $VIMRUNTIME          is unset
+ * You can set these with the `env` option.
+ *
+ * **{opts}** is a dictionary with these keys:
+ *   clear_env:  (boolean) `env` defines the job environment
+ *               exactly, instead of merging current environment.
+ *   cwd:        (string, default=`current-directory`) Working
+ *               directory of the job.
+ *   detach:     (boolean) Detach the job process: it will not be
+ *               killed when Nvim exits. If the process exits
+ *               before Nvim, `on_exit` will be invoked.
+ *   env:        (dict) Map of environment variable name:value
+ *               pairs extending (or replace with "clear_env")
+ *               the current environment. `jobstart-env`
+ *   height:     (number) Height of the `pty` terminal.
+ *   `on_exit`:    (function) Callback invoked when the job exits.
+ *   `on_stdout`:  (function) Callback invoked when the job emits
+ *               stdout data.
+ *   `on_stderr`:  (function) Callback invoked when the job emits
+ *               stderr data.
+ *   overlapped: (boolean) Set FILE_FLAG_OVERLAPPED for the
+ *               standard input/output passed to the child process.
+ *               Normally you do not need to set this.
+ *               (Only available on MS-Windows, On other
+ *               platforms, this option is silently ignored.)
+ *   pty:        (boolean) Connect the job to a new pseudo
+ *               terminal, and its streams to the master file
+ *               descriptor. `on_stdout` receives all output,
+ *               `on_stderr` is ignored. `terminal-start`
+ *   rpc:        (boolean) Use `msgpack-rpc` to communicate with
+ *               the job over stdio. Then `on_stdout` is ignored,
+ *               but `on_stderr` can still be used.
+ *   stderr_buffered: (boolean) Collect data until EOF (stream closed)
+ *               before invoking `on_stderr`. `channel-buffered`
+ *   stdout_buffered: (boolean) Collect data until EOF (stream
+ *               closed) before invoking `on_stdout`. `channel-buffered`
+ *   stdin:      (string) Either "pipe" (default) to connect the
+ *               job's stdin to a channel or "null" to disconnect
+ *               stdin.
+ *   width:      (number) Width of the `pty` terminal.
+ *
+ * **{opts}** is passed as `self` dictionary to the callback; the
+ * caller may set other keys to pass application-specific data.
+ *
+ * Returns:
+ *   - `channel-id` on success
+ *   - 0 on invalid arguments
+ *   - -1 if **{cmd}**[0] is not executable.
+ * See also `job-control`, `channel`, `msgpack-rpc`.
+ */
+export function jobstart(
+  denops: Denops,
+  cmd: unknown,
+  opts?: unknown,
+): Promise<number>;
+export function jobstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("jobstart", ...args);
+}
+
+/**
+ * Stop `job-id` **{id}** by sending SIGTERM to the job process. If
+ * the process does not terminate after a timeout then SIGKILL
+ * will be sent. When the job terminates its `on_exit` handler
+ * (if any) will be invoked.
+ * See `job-control`.
+ *
+ * Returns 1 for valid job id, 0 for invalid id, including jobs have
+ * exited or stopped.
+ */
+export function jobstop(denops: Denops, id: unknown): Promise<number>;
+export function jobstop(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("jobstop", ...args);
+}
+
+/**
+ * Waits for jobs and their `on_exit` handlers to complete.
+ *
+ * **{jobs}** is a List of `job-id`s to wait for.
+ * **{timeout}** is the maximum waiting time in milliseconds. If
+ * omitted or -1, wait forever.
+ *
+ * Timeout of 0 can be used to check the status of a job:
+ *
+ *     let running = jobwait([{job-id}], 0)[0] == -1
+ *
+ * During jobwait() callbacks for jobs not in the **{jobs}** list may
+ * be invoked. The screen will not redraw unless `:redraw` is
+ * invoked by a callback.
+ *
+ * Returns a list of len(**{jobs}**) integers, where each integer is
+ * the status of the corresponding job:
+ *         Exit-code, if the job exited
+ *         -1 if the timeout was exceeded
+ *         -2 if the job was interrupted (by `CTRL-C`)
+ *         -3 if the job-id is invalid
+ */
+export function jobwait(
+  denops: Denops,
+  jobs: unknown,
+  timeout?: unknown,
+): Promise<number>;
+export function jobwait(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("jobwait", ...args);
+}
+
+/**
+ * Returns a `List` of `Dictionaries` describing `menus` (defined
+ * by `:menu`, `:amenu`, …), including `hidden-menus`.
+ *
+ * **{path}** matches a menu by name, or all menus if **{path}** is an
+ * empty string.  Example:
+ *
+ *     :echo menu_get('File','')
+ *     :echo menu_get('')
+ *
+ * **{modes}** is a string of zero or more modes (see `maparg()` or
+ * `creating-menus` for the list of modes). "a" means "all".
+ *
+ * Example:
+ *
+ *     nnoremenu &Test.Test inormal
+ *     inoremenu Test.Test insert
+ *     vnoremenu Test.Test x
+ *     echo menu_get("")
+ *
+ * returns something like this:
+ *
+ *     [ {
+ *       "hidden": 0,
+ *       "name": "Test",
+ *       "priority": 500,
+ *       "shortcut": 84,
+ *       "submenus": [ {
+ *         "hidden": 0,
+ *         "mappings": {
+ *           i": {
+ *             "enabled": 1,
+ *             "noremap": 1,
+ *             "rhs": "insert",
+ *             "sid": 1,
+ *             "silent": 0
+ *           },
+ *           n": { ... },
+ *           s": { ... },
+ *           v": { ... }
+ *         },
+ *         "name": "Test",
+ *         "priority": 500,
+ *         "shortcut": 0
+ *       } ]
+ *     } ]
+ */
+export function menu_get(
+  denops: Denops,
+  path: unknown,
+  modes?: unknown,
+): Promise<unknown[]>;
+export function menu_get(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("menu_get", ...args);
+}
+
+/**
+ * Convert a list of VimL objects to msgpack. Returned value is a
+ * `readfile()`-style list. When **{type}** contains "B", a `Blob` is
+ * returned instead. Example:
+ *
+ *     call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
+ *
+ * or, using a `Blob`:
+ *
+ *     call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
+ *
+ * This will write the single 0x80 byte to a `fname.mpack` file
+ * (dictionary with zero items is represented by 0x80 byte in
+ * messagepack).
+ *
+ * Limitations:
+ * 1. `Funcref`s cannot be dumped.
+ * 2. Containers that reference themselves cannot be dumped.
+ * 3. Dictionary keys are always dumped as STR strings.
+ * 4. Other strings and `Blob`s are always dumped as BIN strings.
+ * 5. Points 3. and 4. do not apply to `msgpack-special-dict`s.
+ */
+export function msgpackdump(
+  denops: Denops,
+  list: unknown,
+  type?: unknown,
+): Promise<unknown[] | unknown>;
+export function msgpackdump(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("msgpackdump", ...args);
+}
+
+/**
+ * Convert a `readfile()`-style list or a `Blob` to a list of
+ * VimL objects.
+ * Example:
+ *
+ *     let fname = expand('~/.config/nvim/shada/main.shada')
+ *     let mpack = readfile(fname, 'b')
+ *     let shada_objects = msgpackparse(mpack)
+ *
+ * This will read `~/.config/nvim/shada/main.shada` file to
+ * `shada_objects` list.
+ *
+ * Limitations:
+ * 1. Mapping ordering is not preserved unless messagepack
+ *    mapping is dumped using generic mapping
+ *    (`msgpack-special-map`).
+ * 2. Since the parser aims to preserve all data untouched
+ *    (except for 1.) some strings are parsed to
+ *    `msgpack-special-dict` format which is not convenient to
+ *    use.
+ *
+ * Some messagepack strings may be parsed to special
+ * dictionaries. Special dictionaries are dictionaries which
+ *
+ * 1. Contain exactly two keys: `_TYPE` and `_VAL`.
+ * 2. `_TYPE` key is one of the types found in `v:msgpack_types`
+ *    variable.
+ * 3. Value for `_VAL` has the following format (Key column
+ *    contains name of the key from `v:msgpack_types`):
+ *
+ * Key     Value
+ * nil     Zero, ignored when dumping.  Not returned by
+ *         `msgpackparse()` since `v:null` was introduced.
+ * boolean One or zero.  When dumping it is only checked that
+ *         value is a `Number`.  Not returned by `msgpackparse()`
+ *         since `v:true` and `v:false` were introduced.
+ * integer `List` with four numbers: sign (-1 or 1), highest two
+ *         bits, number with bits from 62nd to 31st, lowest 31
+ *         bits. I.e. to get actual number one will need to use
+ *         code like
+ *
+ *             _VAL[0] * ((_VAL[1] << 62)
+ *                        & (_VAL[2] << 31)
+ *                        & _VAL[3])
+ *
+ *         Special dictionary with this type will appear in
+ *         `msgpackparse()` output under one of the following
+ *         circumstances:
+ *         1. `Number` is 32-bit and value is either above
+ *            INT32_MAX or below INT32_MIN.
+ *         2. `Number` is 64-bit and value is above INT64_MAX. It
+ *            cannot possibly be below INT64_MIN because msgpack
+ *            C parser does not support such values.
+ * float   `Float`. This value cannot possibly appear in
+ *         `msgpackparse()` output.
+ * string  `readfile()`-style list of strings. This value will
+ *         appear in `msgpackparse()` output if string contains
+ *         zero byte or if string is a mapping key and mapping is
+ *         being represented as special dictionary for other
+ *         reasons.
+ * binary  `String`, or `Blob` if binary string contains zero
+ *         byte. This value cannot appear in `msgpackparse()`
+ *         output since blobs were introduced.
+ * array   `List`. This value cannot appear in `msgpackparse()`
+ *         output.
+ *
+ * map     `List` of `List`s with two items (key and value) each.
+ *         This value will appear in `msgpackparse()` output if
+ *         parsed mapping contains one of the following keys:
+ *         1. Any key that is not a string (including keys which
+ *            are binary strings).
+ *         2. String with NUL byte inside.
+ *         3. Duplicate key.
+ *         4. Empty key.
+ * ext     `List` with two values: first is a signed integer
+ *         representing extension type. Second is
+ *         `readfile()`-style list of strings.
+ */
+export function msgpackparse(denops: Denops, data: unknown): Promise<unknown[]>;
+export function msgpackparse(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("msgpackparse", ...args);
+}
+
+/**
+ * Returns the single letter name of the last recorded register.
+ * Returns an empty string when nothing was recorded yet.
+ * See `q` and `Q`.
+ */
+export function reg_recorded(denops: Denops): Promise<string>;
+export function reg_recorded(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("reg_recorded", ...args);
+}
+
+/**
+ * Sends **{event}** to **{channel}** via `RPC` and returns immediately.
+ * If **{channel}** is 0, the event is broadcast to all channels.
+ * Example:
+ *
+ *     :au VimLeave call rpcnotify(0, "leaving")
+ */
+export function rpcnotify(
+  denops: Denops,
+  channel: unknown,
+  event: unknown,
+  args?: unknown,
+): Promise<unknown>;
+export function rpcnotify(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("rpcnotify", ...args);
+}
+
+/**
+ * Sends a request to **{channel}** to invoke **{method}** via
+ * `RPC` and blocks until a response is received.
+ * Example:
+ *
+ *     :let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
+ */
+export function rpcrequest(
+  denops: Denops,
+  channel: unknown,
+  method: unknown,
+  args?: unknown,
+): Promise<unknown>;
+export function rpcrequest(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("rpcrequest", ...args);
+}
+
+/**
+ * Deprecated. Replace
+ *
+ *     :let id = rpcstart('prog', ['arg1', 'arg2'])
+ *
+ * with
+ *
+ *     :let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+ */
+export function rpcstart(
+  denops: Denops,
+  prog: unknown,
+  argv?: unknown,
+): Promise<unknown>;
+export function rpcstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("rpcstart", ...args);
+}
+
+/**
+ * Opens a socket or named pipe at **{address}** and listens for
+ * `RPC` messages. Clients can send `API` commands to the
+ * returned address to control Nvim.
+ *
+ * Returns the address string (which may differ from the
+ * **{address}** argument, see below).
+ *
+ * - If **{address}** has a colon (":") it is a TCP/IPv4/IPv6 address
+ *   where the last ":" separates host and port (empty or zero
+ *   assigns a random port).
+ * - Else **{address}** is the path to a named pipe (except on Windows).
+ *   - If **{address}** has no slashes ("/") it is treated as the
+ *     "name" part of a generated path in this format:
+ *
+ *         stdpath("run").."/{name}.{pid}.{counter}"
+ *
+ *   - If **{address}** is omitted the name is "nvim".
+ *
+ *         :echo serverstart()
+ *         => /tmp/nvim.bram/oknANW/nvim.15430.5
+ *
+ * Example bash command to list all Nvim servers:
+ *
+ *         ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/* /nvim.*.0
+ *
+ * Example named pipe:
+ *
+ *         if has('win32')
+ *           echo serverstart('\\.\pipe\nvim-pipe-1234')
+ *         else
+ *           echo serverstart('nvim.sock')
+ *         endif
+ *
+ * Example TCP/IP address:
+ *
+ *     echo serverstart('::1:12345')
+ */
+export function serverstart(
+  denops: Denops,
+  address?: unknown,
+): Promise<unknown>;
+export function serverstart(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("serverstart", ...args);
+}
+
+/**
+ * Closes the pipe or socket at **{address}**.
+ * Returns TRUE if **{address}** is valid, else FALSE.
+ * If `v:servername` is stopped it is set to the next available
+ * address in `serverlist()`.
+ */
+export function serverstop(denops: Denops, address: unknown): Promise<unknown>;
+export function serverstop(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("serverstop", ...args);
+}
+
+/**
+ * Connect a socket to an address. If **{mode}** is "pipe" then
+ * **{address}** should be the path of a local domain socket (on
+ * unix) or named pipe (on Windows). If **{mode}** is "tcp" then
+ * **{address}** should be of the form "host:port" where the host
+ * should be an ip adderess or host name, and port the port
+ * number.
+ *
+ * For "pipe" mode, see `luv-pipe-handle`. For "tcp" mode, see
+ * `luv-tcp-handle`.
+ *
+ * Returns a `channel` ID. Close the socket with `chanclose()`.
+ * Use `chansend()` to send data over a bytes socket, and
+ * `rpcrequest()` and `rpcnotify()` to communicate with a RPC
+ * socket.
+ *
+ * **{opts}** is an optional dictionary with these keys:
+ *   `on_data` : callback invoked when data was read from socket
+ *   data_buffered : read socket data in `channel-buffered` mode.
+ *   rpc     : If set, `msgpack-rpc` will be used to communicate
+ *             over the socket.
+ * Returns:
+ *   - The channel ID on success (greater than zero)
+ *   - 0 on invalid arguments or connection failure.
+ */
+export function sockconnect(
+  denops: Denops,
+  mode: unknown,
+  address: unknown,
+  opts?: unknown,
+): Promise<number>;
+export function sockconnect(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("sockconnect", ...args);
+}
+
+/**
+ * With `--headless` this opens stdin and stdout as a `channel`.
+ * May be called only once. See `channel-stdio`. stderr is not
+ * handled by this function, see `v:stderr`.
+ *
+ * Close the stdio handles with `chanclose()`. Use `chansend()`
+ * to send data to stdout, and `rpcrequest()` and `rpcnotify()`
+ * to communicate over RPC.
+ *
+ * **{opts}** is a dictionary with these keys:
+ *   `on_stdin` : callback invoked when stdin is written to.
+ *   on_print : callback invoked when Nvim needs to print a
+ *              message, with the message (whose type is string)
+ *              as sole argument.
+ *   stdin_buffered : read stdin in `channel-buffered` mode.
+ *   rpc      : If set, `msgpack-rpc` will be used to communicate
+ *              over stdio
+ * Returns:
+ *   - `channel-id` on success (value is always 1)
+ *   - 0 on invalid arguments
+ */
+export function stdioopen(denops: Denops, opts: unknown): Promise<number>;
+export function stdioopen(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("stdioopen", ...args);
+}
+
+/**
+ * Returns `standard-path` locations of various default files and
+ * directories.
+ *
+ * **{what}**       Type    Description
+ * cache        String  Cache directory: arbitrary temporary
+ *                      storage for plugins, etc.
+ * config       String  User configuration directory. `init.vim`
+ *                      is stored here.
+ * config_dirs  List    Other configuration directories.
+ * data         String  User data directory.
+ * data_dirs    List    Other data directories.
+ * log          String  Logs directory (for use by plugins too).
+ * run          String  Run directory: temporary, local storage
+ *                      for sockets, named pipes, etc.
+ * state        String  Session state directory: storage for file
+ *                      drafts, swap, undo, `shada`.
+ *
+ * Example:
+ *
+ *     :echo stdpath("config")
+ */
+export function stdpath(
+  denops: Denops,
+  what: unknown,
+): Promise<string | unknown[]>;
+export function stdpath(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("stdpath", ...args);
+}
+
+/**
+ * Spawns **{cmd}** in a new pseudo-terminal session connected
+ * to the current (unmodified) buffer. Parameters and behavior
+ * are the same as `jobstart()` except "pty", "width", "height",
+ * and "TERM" are ignored: "height" and "width" are taken from
+ * the current window.
+ * Returns the same values as `jobstart()`.
+ *
+ * Terminal environment is initialized as in `jobstart-env`,
+ * except $TERM is set to "xterm-256color". Full behavior is
+ * described in `terminal`.
+ */
+export function termopen(
+  denops: Denops,
+  cmd: unknown,
+  opts?: unknown,
+): Promise<unknown>;
+export function termopen(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("termopen", ...args);
+}
+
+/**
+ * Waits until **{condition}** evaluates to `TRUE`, where **{condition}**
+ * is a `Funcref` or `string` containing an expression.
+ *
+ * **{timeout}** is the maximum waiting time in milliseconds, -1
+ * means forever.
+ *
+ * Condition is evaluated on user events, internal events, and
+ * every **{interval}** milliseconds (default: 200).
+ *
+ * Returns a status integer:
+ *         0 if the condition was satisfied before timeout
+ *         -1 if the timeout was exceeded
+ *         -2 if the function was interrupted (by `CTRL-C`)
+ *         -3 if an error occurred
+ */
+export function wait(
+  denops: Denops,
+  timeout: unknown,
+  condition: unknown,
+  interval?: unknown,
+): Promise<number>;
+export function wait(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("wait", ...args);
 }

--- a/function/vim/_generated.ts
+++ b/function/vim/_generated.ts
@@ -2279,6 +2279,631 @@ export function job_stop(denops: Denops, ...args: unknown[]): Promise<unknown> {
 }
 
 /**
+ * Show the **{what}** above the cursor, and close it when the cursor
+ * moves.  This works like:
+ *
+ *     call popup_create({what}, #{
+ *             \ pos: 'botleft',
+ *             \ line: 'cursor-1',
+ *             \ col: 'cursor',
+ *             \ moved: 'WORD',
+ *             \ })
+ *
+ * Use **{options}** to change the properties.
+ * If "pos" is passed as "topleft" then the default for "line"
+ * becomes "cursor+1".
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetText()->popup_atcursor({})
+ */
+export function popup_atcursor(
+  denops: Denops,
+  what: unknown,
+  options: unknown,
+): Promise<number>;
+export function popup_atcursor(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_atcursor", ...args);
+}
+
+/**
+ * Show the **{what}** above the position from 'ballooneval' and
+ * close it when the mouse moves.  This works like:
+ *
+ *     let pos = screenpos(v:beval_winnr, v:beval_lnum, v:beval_col)
+ *     call popup_create({what}, #{
+ *           \ pos: 'botleft',
+ *           \ line: pos.row - 1,
+ *           \ col: pos.col,
+ *           \ mousemoved: 'WORD',
+ *           \ })
+ *
+ * Use **{options}** to change the properties.
+ * See `popup_beval_example` for an example.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetText()->popup_beval({})
+ */
+export function popup_beval(
+  denops: Denops,
+  what: unknown,
+  options: unknown,
+): Promise<number>;
+export function popup_beval(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_beval", ...args);
+}
+
+/**
+ * Emergency solution to a misbehaving plugin: close all popup
+ * windows for the current tab and global popups.
+ * Close callbacks are not invoked.
+ * When **{force}** is not present this will fail if the current
+ * window is a popup.
+ * When **{force}** is present and `TRUE` the popup is also closed
+ * when it is the current window.  If a terminal is running in a
+ * popup it is killed.
+ */
+export function popup_clear(denops: Denops, force?: unknown): Promise<void>;
+export function popup_clear(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_clear", ...args);
+}
+
+/**
+ * Close popup **{id}**.  The window and the associated buffer will
+ * be deleted.
+ *
+ * If the popup has a callback it will be called just before the
+ * popup window is deleted.  If the optional **{result}** is present
+ * it will be passed as the second argument of the callback.
+ * Otherwise zero is passed to the callback.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_close()
+ */
+export function popup_close(
+  denops: Denops,
+  id: unknown,
+  result?: unknown,
+): Promise<void>;
+export function popup_close(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_close", ...args);
+}
+
+/**
+ * Open a popup window showing **{what}**, which is either:
+ * - a buffer number
+ * - a string
+ * - a list of strings
+ * - a list of text lines with text properties
+ * When **{what}** is not a buffer number, a buffer is created with
+ * 'buftype' set to "popup".  That buffer will be wiped out once
+ * the popup closes.
+ *
+ * if **{what}** is a buffer number and loading the buffer runs into
+ * an existing swap file, it is silently opened read-only, as if
+ * a `SwapExists` autocommand had set `v:swapchoice` to 'o'.
+ * This is because we assume the buffer is only used for viewing.
+ *
+ * **{options}** is a dictionary with many possible entries.
+ * See `popup_create-arguments` for details.
+ *
+ * Returns a window-ID, which can be used with other popup
+ * functions.  Use `winbufnr()` to get the number of the buffer
+ * in the window:
+ *
+ *     let winid = popup_create('hello', {})
+ *     let bufnr = winbufnr(winid)
+ *     call setbufline(bufnr, 2, 'second line')
+ *
+ * In case of failure zero is returned.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetText()->popup_create({})
+ */
+export function popup_create(
+  denops: Denops,
+  what: unknown,
+  options: unknown,
+): Promise<number>;
+export function popup_create(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_create", ...args);
+}
+
+/**
+ * Just like `popup_create()` but with these default options:
+ *
+ *     call popup_create({what}, #{
+ *             \ pos: 'center',
+ *             \ zindex: 200,
+ *             \ drag: 1,
+ *             \ border: [],
+ *             \ padding: [],
+ *             \ mapping: 0,
+ *             \})
+ *
+ * Use **{options}** to change the properties. E.g. add a 'filter'
+ * option with value 'popup_filter_yesno'.  Example:
+ *
+ *     call popup_create('do you want to quit (Yes/no)?', #{
+ *             \ filter: 'popup_filter_yesno',
+ *             \ callback: 'QuitCallback',
+ *             \ })
+ *
+ * By default the dialog can be dragged, so that text below it
+ * can be read if needed.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetText()->popup_dialog({})
+ */
+export function popup_dialog(
+  denops: Denops,
+  what: unknown,
+  options: unknown,
+): Promise<number>;
+export function popup_dialog(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_dialog", ...args);
+}
+
+/**
+ * Filter that can be used for a popup. These keys can be used:
+ *     j `<Down>` `<C-N>`      select item below
+ *     k `<Up>` `<C-P>`        select item above
+ *     `<Space>` `<Enter>`     accept current selection
+ *     x Esc CTRL-C        cancel the menu
+ * Other keys are ignored.
+ * Always returns `v:true`.
+ *
+ * A match is set on that line to highlight it, see
+ * `popup_menu()`.
+ *
+ * When the current selection is accepted the "callback" of the
+ * popup menu is invoked with the index of the selected line as
+ * the second argument.  The first entry has index one.
+ * Cancelling the menu invokes the callback with -1.
+ *
+ * To add shortcut keys, see the example here:
+ * `popup_menu-shortcut-example`
+ */
+export function popup_filter_menu(
+  denops: Denops,
+  id: unknown,
+  key: unknown,
+): Promise<number>;
+export function popup_filter_menu(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_filter_menu", ...args);
+}
+
+/**
+ * Filter that can be used for a popup. It handles only the keys
+ * 'y', 'Y' and 'n' or 'N'.  Invokes the "callback" of the
+ * popup menu with the 1 for 'y' or 'Y' and zero for 'n' or 'N'
+ * as the second argument.  Pressing Esc and 'x' works like
+ * pressing 'n'.  CTRL-C invokes the callback with -1.  Other
+ * keys are ignored.
+ * See the example here: `popup_dialog-example`
+ */
+export function popup_filter_yesno(
+  denops: Denops,
+  id: unknown,
+  key: unknown,
+): Promise<number>;
+export function popup_filter_yesno(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_filter_yesno", ...args);
+}
+
+/**
+ * Get the `window-ID` for the popup that shows messages for the
+ * `:echowindow` command.  Return zero if there is none.
+ * Mainly useful to hide the popup.
+ */
+export function popup_findecho(denops: Denops): Promise<number>;
+export function popup_findecho(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_findecho", ...args);
+}
+
+/**
+ * Get the `window-ID` for the popup info window, as it used by
+ * the popup menu.  See `complete-popup`.  The info popup is
+ * hidden when not used, it can be deleted with `popup_clear()`
+ * and `popup_close()`.  Use `popup_show()` to reposition it to
+ * the item in the popup menu.
+ * Returns zero if there is none.
+ */
+export function popup_findinfo(denops: Denops): Promise<number>;
+export function popup_findinfo(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_findinfo", ...args);
+}
+
+/**
+ * Get the `window-ID` for the popup preview window.
+ * Return zero if there is none.
+ */
+export function popup_findpreview(denops: Denops): Promise<number>;
+export function popup_findpreview(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_findpreview", ...args);
+}
+
+/**
+ * Return the **{options}** for popup **{id}** in a Dict.
+ * A zero value means the option was not set.  For "zindex" the
+ * default value is returned, not zero.
+ *
+ * The "moved" entry is a list with line number, minimum and
+ * maximum column, [0, 0, 0] when not set.
+ *
+ * The "mousemoved" entry is a list with screen row, minimum and
+ * maximum screen column, [0, 0, 0] when not set.
+ *
+ * "firstline" is the property set on the popup, unlike the
+ * "firstline" obtained with `popup_getpos()` which is the actual
+ * buffer line at the top of the popup window.
+ *
+ * "border" and "padding" are not included when all values are
+ * zero.  When all values are one then an empty list is included.
+ *
+ * "borderhighlight" is not included when all values are empty.
+ * "scrollbarhighlight" and "thumbhighlight" are only included
+ * when set.
+ *
+ * "tabpage" will be -1 for a global popup, zero for a popup on
+ * the current tabpage and a positive number for a popup on
+ * another tabpage.
+ *
+ * "textprop", "textpropid" and "textpropwin" are only present
+ * when "textprop" was set.
+ *
+ * If popup window **{id}** is not found an empty Dict is returned.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_getoptions()
+ */
+export function popup_getoptions(
+  denops: Denops,
+  id: unknown,
+): Promise<Record<string, unknown>>;
+export function popup_getoptions(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_getoptions", ...args);
+}
+
+/**
+ * Return the position and size of popup **{id}**.  Returns a Dict
+ * with these entries:
+ *     col         screen column of the popup, one-based
+ *     line        screen line of the popup, one-based
+ *     width       width of the whole popup in screen cells
+ *     height      height of the whole popup in screen cells
+ *     core_col    screen column of the text box
+ *     core_line   screen line of the text box
+ *     core_width  width of the text box in screen cells
+ *     core_height height of the text box in screen cells
+ *     firstline   line of the buffer at top (1 unless scrolled)
+ *                 (not the value of the "firstline" property)
+ *     lastline    line of the buffer at the bottom (updated when
+ *                 the popup is redrawn)
+ *     scrollbar   non-zero if a scrollbar is displayed
+ *     visible     one if the popup is displayed, zero if hidden
+ * Note that these are the actual screen positions.  They differ
+ * from the values in `popup_getoptions()` for the sizing and
+ * positioning mechanism applied.
+ *
+ * The "core_" values exclude the padding and border.
+ *
+ * If popup window **{id}** is not found an empty Dict is returned.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_getpos()
+ */
+export function popup_getpos(
+  denops: Denops,
+  id: unknown,
+): Promise<Record<string, unknown>>;
+export function popup_getpos(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_getpos", ...args);
+}
+
+/**
+ * If **{id}** is a displayed popup, hide it now. If the popup has a
+ * filter it will not be invoked for so long as the popup is
+ * hidden.
+ * If window **{id}** does not exist nothing happens.  If window **{id}**
+ * exists but is not a popup window an error is given.
+ * If popup window **{id}** contains a terminal an error is given.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_hide()
+ */
+export function popup_hide(denops: Denops, id: unknown): Promise<void>;
+export function popup_hide(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_hide", ...args);
+}
+
+/**
+ * Return a List with the `window-ID` of all existing popups.
+ */
+export function popup_list(denops: Denops): Promise<unknown[]>;
+export function popup_list(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_list", ...args);
+}
+
+/**
+ * Return the `window-ID` of the popup at screen position **{row}**
+ * and **{col}**.  If there are multiple popups the one with the
+ * highest zindex is returned.  If there are no popups at this
+ * position then zero is returned.
+ */
+export function popup_locate(
+  denops: Denops,
+  row: unknown,
+  col: unknown,
+): Promise<number>;
+export function popup_locate(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_locate", ...args);
+}
+
+/**
+ * Show the **{what}** near the cursor, handle selecting one of the
+ * items with cursorkeys, and close it an item is selected with
+ * Space or Enter. **{what}** should have multiple lines to make this
+ * useful.  This works like:
+ *
+ *     call popup_create({what}, #{
+ *             \ pos: 'center',
+ *             \ zindex: 200,
+ *             \ drag: 1,
+ *             \ wrap: 0,
+ *             \ border: [],
+ *             \ cursorline: 1,
+ *             \ padding: [0,1,0,1],
+ *             \ filter: 'popup_filter_menu',
+ *             \ mapping: 0,
+ *             \ })
+ *
+ * The current line is highlighted with a match using
+ * "PopupSelected", or "PmenuSel" if that is not defined.
+ *
+ * Use **{options}** to change the properties.  Should at least set
+ * "callback" to a function that handles the selected item.
+ * Example:
+ *
+ *     func ColorSelected(id, result)
+ *        " use a:result
+ *     endfunc
+ *     call popup_menu(['red', 'green', 'blue'], #{
+ *             \ callback: 'ColorSelected',
+ *             \ })
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetChoices()->popup_menu({})
+ */
+export function popup_menu(
+  denops: Denops,
+  what: unknown,
+  options: unknown,
+): Promise<number>;
+export function popup_menu(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_menu", ...args);
+}
+
+/**
+ * Move popup **{id}** to the position specified with **{options}**.
+ * **{options}** may contain the items from `popup_create()` that
+ * specify the popup position:
+ *         line
+ *         col
+ *         pos
+ *         maxheight
+ *         minheight
+ *         maxwidth
+ *         minwidth
+ *         fixed
+ * For **{id}** see `popup_hide()`.
+ * For other options see `popup_setoptions()`.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_move(options)
+ */
+export function popup_move(
+  denops: Denops,
+  id: unknown,
+  options: unknown,
+): Promise<void>;
+export function popup_move(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_move", ...args);
+}
+
+/**
+ * Show the **{what}** for 3 seconds at the top of the Vim window.
+ * This works like:
+ *
+ *     call popup_create({what}, #{
+ *             \ line: 1,
+ *             \ col: 10,
+ *             \ minwidth: 20,
+ *             \ time: 3000,
+ *             \ tabpage: -1,
+ *             \ zindex: 300,
+ *             \ drag: 1,
+ *             \ highlight: 'WarningMsg',
+ *             \ border: [],
+ *             \ close: 'click',
+ *             \ padding: [0,1,0,1],
+ *             \ })
+ *
+ * The PopupNotification highlight group is used instead of
+ * WarningMsg if it is defined.
+ *
+ * Without the `+timers` feature the popup will not disappear
+ * automatically, the user has to click in it.
+ *
+ * The position will be adjusted to avoid overlap with other
+ * notifications.
+ * Use **{options}** to change the properties.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetText()->popup_notification({})
+ */
+export function popup_notification(
+  denops: Denops,
+  what: unknown,
+  options: unknown,
+): Promise<number>;
+export function popup_notification(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_notification", ...args);
+}
+
+/**
+ * Override options in popup **{id}** with entries in **{options}**.
+ * These options can be set:
+ *         border
+ *         borderchars
+ *         borderhighlight
+ *         callback
+ *         close
+ *         cursorline
+ *         drag
+ *         filter
+ *         firstline
+ *         flip
+ *         highlight
+ *         mapping
+ *         mask
+ *         moved
+ *         padding
+ *         resize
+ *         scrollbar
+ *         scrollbarhighlight
+ *         thumbhighlight
+ *         time
+ *         title
+ *         wrap
+ *         zindex
+ * The options from `popup_move()` can also be used.
+ * Generally, setting an option to zero or an empty string resets
+ * it to the default value, but there are exceptions.
+ * For "hidden" use `popup_hide()` and `popup_show()`.
+ * "tabpage" cannot be changed.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_setoptions(options)
+ */
+export function popup_setoptions(
+  denops: Denops,
+  id: unknown,
+  options: unknown,
+): Promise<void>;
+export function popup_setoptions(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_setoptions", ...args);
+}
+
+/**
+ * Set the text of the buffer in popup win **{id}**. **{text}** is the
+ * same as supplied to `popup_create()`, except that a buffer
+ * number is not allowed.
+ * Does not change the window size or position, other than caused
+ * by the different text.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_settext('hello')
+ */
+export function popup_settext(
+  denops: Denops,
+  id: unknown,
+  text: unknown,
+): Promise<void>;
+export function popup_settext(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_settext", ...args);
+}
+
+/**
+ * If **{id}** is a hidden popup, show it now.
+ * For **{id}** see `popup_hide()`.
+ * If **{id}** is the info popup it will be positioned next to the
+ * current popup menu item.
+ */
+export function popup_show(denops: Denops, id: unknown): Promise<void>;
+export function popup_show(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_show", ...args);
+}
+
+/**
  * Open a new window displaying the difference between the two
  * files.  The files must have been created with
  * `term_dumpwrite()`.


### PR DESCRIPTION
The following functions are added

- `popup_atcursor`
- `popup_beval`
- `popup_clear`
- `popup_close`
- `popup_create`
- `popup_dialog`
- `popup_filter_menu`
- `popup_filter_yesno`
- `popup_findecho`
- `popup_findinfo`
- `popup_findpreview`
- `popup_getoptions`
- `popup_getpos`
- `popup_hide`
- `popup_list`
- `popup_locate`
- `popup_menu`
- `popup_move`
- `popup_notification`
- `popup_setoptions`
- `popup_settext`
- `popup_show`