### PR TITLE
:bug: :boom: Correct `toJSON` to match the specifications of `JSON.stringify`

### DIFF
--- a/helper/expr_string.ts
+++ b/helper/expr_string.ts
@@ -43,7 +43,11 @@ export type ExprString = string & {
 };
 
 type Jsonable = {
-  toJSON(key: string | number | undefined): string;
+  /**
+   * Returns a JSON value that can be specified to {@link JSON.stringify}.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior|toJSON() behavior}
+   */
+  toJSON(key: string | number | undefined): unknown;
 };
 
 // deno-lint-ignore no-explicit-any
@@ -125,7 +129,7 @@ function isIgnoreRecordValue(x: unknown): boolean {
  */
 export function vimStringify(value: unknown, key?: string | number): string {
   if (isJsonable(value)) {
-    return vimStringify(JSON.parse(value.toJSON(key)));
+    return vimStringify(value.toJSON(key));
   }
   if (isExprString(value)) {
     // Return Vim's expr-string

--- a/helper/expr_string_test.ts
+++ b/helper/expr_string_test.ts
@@ -160,7 +160,7 @@ Deno.test({
       fn: () => {
         const actual = vimStringify({
           foo: 42,
-          toJSON: () => JSON.stringify([123, "bar"]),
+          toJSON: () => [123, "bar"],
         });
         assertEquals(actual, "[123,'bar']");
       },
@@ -171,10 +171,18 @@ Deno.test({
         const actual = vimStringify(Object.assign(
           () => {},
           {
-            toJSON: () => JSON.stringify([123, "bar"]),
+            toJSON: () => [123, "bar"],
           },
         ));
         assertEquals(actual, "[123,'bar']");
+      },
+    });
+    await t.step({
+      name: "stringify Date that has native `toJSON()` method.",
+      fn: () => {
+        // NOTE: `Date.prototype.toJSON` returns a string representing date in the same ISO format as `Date.prototype.toISOString()`.
+        const actual = vimStringify(new Date("2007-08-31T12:34:56.000Z"));
+        assertEquals(actual, "'2007-08-31T12:34:56.000Z'");
       },
     });
     await t.step({
@@ -197,7 +205,7 @@ Deno.test({
         });
         try {
           const actual = vimStringify(92382417n);
-          assertEquals(actual, "92382417");
+          assertEquals(actual, "'92382417'");
         } finally {
           // deno-lint-ignore no-explicit-any
           delete (BigInt.prototype as any).toJSON;
@@ -216,8 +224,9 @@ Deno.test({
           Symbol("foo"),
           "bar",
           {
-            toJSON: () => JSON.stringify([123, "baz"]),
+            toJSON: () => [123, "baz"],
           },
+          new Date("2007-08-31T12:34:56.000Z"),
           {
             k0: null,
             k1: undefined,
@@ -232,7 +241,7 @@ Deno.test({
         ]);
         assertEquals(
           actual,
-          `[v:null,v:null,42,v:true,v:null,v:null,'bar',[123,'baz'],{'k0':v:null,'k2':[{'key':234,'expr':"\\U0001F680"}]}]`,
+          `[v:null,v:null,42,v:true,v:null,v:null,'bar',[123,'baz'],'2007-08-31T12:34:56.000Z',{'k0':v:null,'k2':[{'key':234,'expr':"\\U0001F680"}]}]`,
         );
       },
     });
@@ -419,8 +428,9 @@ test({
                 Symbol("foo"),
                 "bar",
                 {
-                  toJSON: () => JSON.stringify([123, "baz"]),
+                  toJSON: () => [123, "baz"],
                 },
+                new Date("2007-08-31T12:34:56.000Z"),
                 {
                   k0: null,
                   k1: undefined,
@@ -448,6 +458,7 @@ test({
               123,
               "baz",
             ],
+            "2007-08-31T12:34:56.000Z",
             {
               k0: null,
               k2: [


### PR DESCRIPTION
`toJSON` returns a JSON value that can be specified to `JSON.stringify`.
It is NOT a JSON string that can be specified to `JSON.parse`.

This is a breaking change for code that depended on previous incorrect behavior.

### Previous (incorrect) behaviour:
```ts
await useExprString(denops, async (denops) => {
  await denops.cmd('echo type(value)', { value: { toJSON: () => "123" } });
  // output: 0 (equals `v:t_number`)
});
```

### New (correct) behaviour:
```ts
await useExprString(denops, async (denops) => {
  await denops.cmd('echo type(value)', { value: { toJSON: () => "123" } });
  // output: 1 (equals `v:t_string`)
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the `toJSON` method to enhance flexibility in handling various data types.
- **Tests**
	- Updated test cases to align with the new `toJSON` method behavior.
	- Added a new test case for better coverage of date stringification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->