### PR TITLE
:bug: Fix behavior on `verbose` environment

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
       - name: Update dependencies and commit changes
-        run: deno task -q upgrade:commit --summary ../title.txt --report ../body.md
+        run: deno task -q update:commit --summary ../title.txt --report ../body.md
       - name: Check result
         id: result
         uses: andstor/file-existence-action@v2

--- a/autocmd/common.ts
+++ b/autocmd/common.ts
@@ -131,7 +131,7 @@ export async function list(
     }
   }
   const expr = terms.join(" ");
-  return await denops.call("execute", expr);
+  return await denops.call("execute", `0verbose ${expr}`);
 }
 
 /**

--- a/autocmd/common_test.ts
+++ b/autocmd/common_test.ts
@@ -163,12 +163,27 @@ test({
       });
     });
 
+    const verboseSaved = await denops.eval("&verbose");
     await t.step({
       name: "list() lists autocmds",
       fn: async () => {
         await define(denops, "User", "DenopsTestList", "echo '1'");
         await define(denops, "User", "DenopsTestList", "echo '2'");
         await define(denops, "User", "DenopsTestList", "echo '3'");
+        await denops.cmd(`set verbose=0`);
+        assertEquals(
+          await list(denops, "User", "DenopsTestList"),
+          [
+            "",
+            "--- Autocommands ---",
+            "User",
+            "    DenopsTestList",
+            "              echo '1'",
+            "              echo '2'",
+            "              echo '3'",
+          ].join("\n"),
+        );
+        await denops.cmd(`set verbose=1`);
         assertEquals(
           await list(denops, "User", "DenopsTestList"),
           [
@@ -183,6 +198,7 @@ test({
         );
       },
     });
+    await denops.cmd(`set verbose=${verboseSaved}`);
 
     await t.step({
       name: "emit() emits an autocmd",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,20 +1,15 @@
 {
-  "lock": false,
-  "exclude": [
-    "docs/**",
-    ".deps/**",
-    ".coverage/**"
-  ],
+  "exclude": ["docs/**", ".coverage/**"],
   "imports": {
     "https://deno.land/x/denops_std@$MODULE_VERSION/": "./"
   },
   "tasks": {
+    "check": "deno check ./**/*.ts",
     "test": "deno test -A --doc --parallel --shuffle",
     "test:coverage": "deno task test --coverage=.coverage",
-    "check": "deno check ./**/*.ts",
     "coverage": "deno coverage .coverage",
-    "upgrade": "deno run -q -A https://deno.land/x/molt@0.14.0/cli.ts ./**/*.ts",
-    "upgrade:commit": "deno task -q upgrade --commit --prefix :package: --pre-commit=fmt",
+    "update": "deno run --allow-env --allow-read --allow-write=. --allow-run=git,deno --allow-net=deno.land,jsr.io,registry.npmjs.org jsr:@molt/cli ./*.ts",
+    "update:commit": "deno task -q update --commit --pre-commit=fmt,lint",
     "gen:function": "deno run -A ./.scripts/gen-function/gen-function.ts",
     "gen:option": "deno run -A ./.scripts/gen-option/gen-option.ts",
     "gen": "deno task gen:function && deno task gen:option && deno fmt"

--- a/helper/expr_string.ts
+++ b/helper/expr_string.ts
@@ -26,7 +26,7 @@
  */
 
 import type { Context, Denops, Dispatcher, Meta } from "../mod.ts";
-import is from "https://deno.land/x/unknownutil@v3.16.3/is.ts";
+import { is } from "https://deno.land/x/unknownutil@v3.16.3/mod.ts";
 import { execute } from "./execute.ts";
 import { ulid } from "https://deno.land/std@0.217.0/ulid/mod.ts";
 

--- a/helper/keymap.ts
+++ b/helper/keymap.ts
@@ -8,7 +8,7 @@ import {
 import { batch } from "../batch/mod.ts";
 import { register } from "../lambda/mod.ts";
 import { feedkeys } from "../function/mod.ts";
-import is from "https://deno.land/x/unknownutil@v3.16.3/is.ts";
+import { is } from "https://deno.land/x/unknownutil@v3.16.3/mod.ts";
 
 export type Keys = {
   keys: string | ExprString;

--- a/mapping/mod.ts
+++ b/mapping/mod.ts
@@ -216,7 +216,10 @@ export async function list(
   options: ListOptions = {},
 ): Promise<Mapping[]> {
   const mode = options.mode ?? "";
-  const result = await fn.execute(denops, `${mode}map ${lhs}`) as string;
+  const result = await fn.execute(
+    denops,
+    `0verbose ${mode}map ${lhs}`,
+  ) as string;
   return result.split(/\r?\n/).flatMap((v) => {
     try {
       return [parse(v)];

--- a/mapping/mod_test.ts
+++ b/mapping/mod_test.ts
@@ -567,6 +567,7 @@ test({
       },
     });
 
+    const verboseSaved = await denops.eval("&verbose");
     for (const mode of modes) {
       await t.step({
         name: `list() lists mappings starts from {lhs} (${mode}map)`,
@@ -579,14 +580,33 @@ test({
               mode,
             },
           );
-          const result = await mapping.list(
+          await denops.cmd(`set verbose=0`);
+          const result1 = await mapping.list(
             denops,
             `<Plug>(test-denops-std-list-${mode}map)`,
             {
               mode,
             },
           );
-          assertEquals(result, [
+          assertEquals(result1, [
+            {
+              mode,
+              lhs: `<Plug>(test-denops-std-list-${mode}map)`,
+              rhs: "Hello",
+              noremap: false,
+              script: false,
+              buffer: false,
+            },
+          ]);
+          await denops.cmd(`set verbose=1`);
+          const result2 = await mapping.list(
+            denops,
+            `<Plug>(test-denops-std-list-${mode}map)`,
+            {
+              mode,
+            },
+          );
+          assertEquals(result2, [
             {
               mode,
               lhs: `<Plug>(test-denops-std-list-${mode}map)`,
@@ -599,5 +619,6 @@ test({
         },
       });
     }
+    await denops.cmd(`set verbose=${verboseSaved}`);
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `list` function to provide more detailed output using `0verbose`.

- **Bug Fixes**
  - Restored the `verbose` setting after listing autocmds to ensure consistent user environment.

- **Chores**
  - Updated task commands for better Deno script management.
  - Changed import statements to named imports for consistency.

- **Tests**
  - Improved test coverage by adding assertions and managing `verbose` settings during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->