### PR TITLE
:bug: Fix `helper/input` in Vim

### DIFF
--- a/helper/input.ts
+++ b/helper/input.ts
@@ -5,7 +5,7 @@ import * as fn from "../function/mod.ts";
 import * as lambda from "../lambda/mod.ts";
 import { execute } from "./execute.ts";
 
-const cacheKey = "denops_std/helper/input@1";
+const cacheKey = "denops_std/helper/input@2";
 
 async function ensurePrerequisites(denops: Denops): Promise<string> {
   if (typeof denops.context[cacheKey] === "string") {
@@ -67,8 +67,10 @@ async function ensurePrerequisites(denops: Denops): Promise<string> {
     endfunction
   else
     function! s:input_${suffix}(prompt, text, completion) abort
-      let original = maparg('<Esc>', 'n')
+      let originalEsc = maparg('<Esc>', 'c', 0, 1)
+      let originalInt = maparg('<C-c>', 'c', 0, 1)
       execute printf('cnoremap <nowait><buffer> <Esc> <C-u>%s<CR>', s:escape_token_${suffix})
+      execute printf('cnoremap <nowait><buffer> <C-c> <C-u>%s<CR>', s:escape_token_${suffix})
       try
         let result = a:completion is# v:null
               \\ ? input(a:prompt, a:text)
@@ -81,10 +83,15 @@ async function ensurePrerequisites(denops: Denops): Promise<string> {
       catch /^Vim:Interrupt$/
         return v:null
       finally
-        if empty(original)
-          cunmap <buffer> <Esc>
+        if get(originalEsc, 'buffer')
+          call mapset(originalEsc)
         else
-          execute printf('cmap <buffer> %s', original)
+          cunmap <buffer> <Esc>
+        endif
+        if get(originalInt, 'buffer')
+          call mapset(originalInt)
+        else
+          cunmap <buffer> <C-c>
         endif
       endtry
     endfunction

--- a/helper/keymap_test.ts
+++ b/helper/keymap_test.ts
@@ -16,7 +16,7 @@ type Spec = {
 };
 
 test({
-  mode: "nvim",
+  mode: "all",
   name: "send()",
   fn: async (denops, t) => {
     const specs: Spec[] = [


### PR DESCRIPTION
- Fix `helper/input` does not returns `null` if `<C-c>` pressed in Vim.
- Fix `helper/input` breaks Vim mappings.
  Correctly restore global or buffer local mapping.
- Change test mode to "all" in `helper/input` and `helper/keymap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of `<Esc>` and `<C-c>` key mappings in command-line mode, enhancing user input during command execution.
	- Refined control flow for key mapping management, ensuring mappings are restored correctly based on their previous state.

- **Bug Fixes**
	- Addressed issues with input handling in the command-line interface, providing more reliable behavior.

- **Tests**
	- Updated test cases to reflect changes in key event processing, ensuring expected outcomes are maintained with the new command-line mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->