### PR TITLE
:muscle: cache predicate functions

### DIFF
--- a/function/types.ts
+++ b/function/types.ts
@@ -1,8 +1,9 @@
+import type { Predicate } from "@core/unknownutil/type";
 import { assert } from "@core/unknownutil/assert";
+import { asOptional } from "@core/unknownutil/as/optional";
 import { isNumber } from "@core/unknownutil/is/number";
 import { isObjectOf } from "@core/unknownutil/is/object-of";
-import { isTupleOf } from "@core/unknownutil/is/tuple-of";
-import { isUnionOf } from "@core/unknownutil/is/union-of";
+import { isParametersOf } from "@core/unknownutil/is/parameters-of";
 
 /**
  * Type of `screenpos()` result.
@@ -17,15 +18,12 @@ export type ScreenPos = {
 /**
  * Return true if the value is ScreenPos.
  */
-export function isScreenPos(x: unknown): x is ScreenPos {
-  const predObj = {
-    row: isNumber,
-    col: isNumber,
-    endcol: isNumber,
-    curscol: isNumber,
-  };
-  return isObjectOf(predObj)(x);
-}
+export const isScreenPos: Predicate<ScreenPos> = isObjectOf({
+  row: isNumber,
+  col: isNumber,
+  endcol: isNumber,
+  curscol: isNumber,
+});
 
 /**
  * Assert if `x` is ScreenPos by raising an `AssertError` when it's not.
@@ -48,13 +46,9 @@ export type Position = [
 /**
  * Return true if the value is Position.
  */
-export function isPosition(x: unknown): x is Position {
-  const pred = isUnionOf([
-    isTupleOf([isNumber, isNumber, isNumber, isNumber]),
-    isTupleOf([isNumber, isNumber, isNumber, isNumber, isNumber]),
-  ]);
-  return pred(x);
-}
+export const isPosition: Predicate<Position> = isParametersOf(
+  [isNumber, isNumber, isNumber, isNumber, asOptional(isNumber)] as const,
+);
 
 /**
  * Assert if `x` is Position by raising an `AssertError` when it's not.

--- a/helper/expr_string.ts
+++ b/helper/expr_string.ts
@@ -25,6 +25,7 @@
  * @module
  */
 import type { Context, Denops, Dispatcher, Meta } from "@denops/core";
+import type { Predicate } from "@core/unknownutil/type";
 import { isArray } from "@core/unknownutil/is/array";
 import { isBoolean } from "@core/unknownutil/is/boolean";
 import { isFunction } from "@core/unknownutil/is/function";
@@ -120,11 +121,9 @@ const isInstanceOfString = isInstanceOf(String);
  * console.log(isExprString("foo")); // outputs: false
  * ```
  */
-export function isExprString(x: unknown): x is ExprString {
-  return isObjectOf({
-    [EXPR_STRING_MARK]: isLiteralOf(1),
-  })(x);
-}
+export const isExprString: Predicate<ExprString> = isObjectOf({
+  [EXPR_STRING_MARK]: isLiteralOf(1),
+}) as unknown as Predicate<ExprString>;
 
 function isJsonable(x: unknown): x is Jsonable {
   return x != null && isFunction((x as Jsonable).toJSON);

--- a/helper/expr_string.ts
+++ b/helper/expr_string.ts
@@ -122,6 +122,7 @@ const isInstanceOfString = isInstanceOf(String);
  * ```
  */
 export const isExprString: Predicate<ExprString> = isObjectOf({
+  // NOTE: `ExprString` has a different type in definition (primitive `string`) and implementation (`String`). Only checks `EXPR_STRING_MARK` existence.
   [EXPR_STRING_MARK]: isLiteralOf(1),
 }) as unknown as Predicate<ExprString>;
 


### PR DESCRIPTION
The unknownutil doc says "users are advised to cache the return value".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced type-checking capabilities for `ScreenPos`, `Position`, and `ExprString` through new constant definitions that improve readability and maintainability.
  
- **Bug Fixes**
	- Improved type safety and validation logic by utilizing updated predicate structures for type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->