### PR TITLE
:coffee: separate `check:doc` task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
         run: deno fmt --check
       - name: Type check
         run: deno task check
+      - name: Doc check
+        run: deno task check:doc
       - name: Gen check
         run: |
           deno task gen

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -81,7 +81,8 @@
   },
   "tasks": {
     "check": "deno check ./**/*.ts",
-    "test": "deno test -A --doc --parallel --shuffle",
+    "check:doc": "deno test --doc --no-run",
+    "test": "deno test -A --parallel --shuffle",
     "test:coverage": "deno task test --coverage=.coverage",
     "coverage": "deno coverage .coverage",
     "update": "deno run --allow-env --allow-read --allow-write --allow-run=git,deno --allow-net=deno.land,jsr.io,registry.npmjs.org jsr:@molt/cli deno.jsonc **/*.ts",


### PR DESCRIPTION
`deno test --doc` vs `deno test --watch` is conflicts.
Now can `deno task test --watch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new documentation check task, allowing users to validate documentation separately from running tests.
  
- **Improvements**
	- Enhanced CI/CD workflow with a dedicated step for documentation validation to ensure quality before generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->