### PR TITLE
:coffee: add 'verbose' inputs in test CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ on:
         description: 'Denops revision to test'
         required: false
         default: 'main'
+      verbose:
+        type: boolean
+        required: false
+        description: 'Enable verbose output'
+        default: false
 
 defaults:
   run:
@@ -23,6 +28,7 @@ defaults:
 
 env:
   DENOPS_BRANCH: ${{ github.event.inputs.denops_branch || 'main' }}
+  DENOPS_TEST_VERBOSE: ${{ github.event.inputs.verbose }}
 
 jobs:
   check:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional `verbose` parameter for the GitHub Actions workflow, allowing users to enable detailed output during execution for better visibility and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->