### PR TITLE
:+1: change array argument types to readonly

### DIFF
--- a/argument/flags.ts
+++ b/argument/flags.ts
@@ -33,7 +33,7 @@ const shortPattern = /^-([a-zA-Z0-9])(.*)/;
  * }
  * ```
  */
-export function parseFlags(args: string[]): [Flags, string[]] {
+export function parseFlags(args: readonly string[]): [Flags, string[]] {
   const patterns = [longPattern, shortPattern];
   const flags: Flags = {};
   const residue: string[] = [];
@@ -86,7 +86,10 @@ export function parseFlags(args: string[]): [Flags, string[]] {
  * }
  * ```
  */
-export function validateFlags(flags: Flags, knownAttributes: string[]): void {
+export function validateFlags(
+  flags: Flags,
+  knownAttributes: readonly string[],
+): void {
   Object.keys(flags).forEach((v) => {
     if (!knownAttributes.includes(v)) {
       if (v.length === 1) {
@@ -116,7 +119,7 @@ export function validateFlags(flags: Flags, knownAttributes: string[]): void {
  */
 export function formatFlag(
   key: string,
-  value: string | string[] | undefined,
+  value: string | readonly string[] | undefined,
 ): string[] {
   if (value == undefined) {
     return [];
@@ -154,7 +157,10 @@ export function formatFlag(
  * }
  * ```
  */
-export function formatFlags(flags: Flags, includes?: string[]): string[] {
+export function formatFlags(
+  flags: Flags,
+  includes?: readonly string[],
+): string[] {
   let entries = Object.entries(flags);
   if (includes != undefined) {
     entries = entries.filter(([k, _]) => includes.includes(k));

--- a/argument/mod.ts
+++ b/argument/mod.ts
@@ -97,7 +97,7 @@ import { type Flags, parseFlags } from "./flags.ts";
  * }
  * ```
  */
-export function parse(args: string[]): [Opts, Flags, string[]] {
+export function parse(args: readonly string[]): [Opts, Flags, string[]] {
   const [opts, intermediate] = parseOpts(args);
   const [flags, residue] = parseFlags(intermediate);
   return [opts, flags, residue];

--- a/argument/opts.ts
+++ b/argument/opts.ts
@@ -16,7 +16,7 @@ export const builtinOpts = [
   "nobinary",
   "bad",
   "edit",
-];
+] as const;
 
 const optPattern = /^\+\+([a-zA-Z0-9-]+)(?:=(.*))?/;
 

--- a/argument/opts.ts
+++ b/argument/opts.ts
@@ -48,7 +48,7 @@ const optPattern = /^\+\+([a-zA-Z0-9-]+)(?:=(.*))?/;
  * }
  * ```
  */
-export function parseOpts(args: string[]): [Opts, string[]] {
+export function parseOpts(args: readonly string[]): [Opts, string[]] {
   const opts: Opts = {};
   const residue: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -100,7 +100,10 @@ export function parseOpts(args: string[]): [Opts, string[]] {
  * }
  * ```
  */
-export function validateOpts(opts: Opts, knownAttributes: string[]): void {
+export function validateOpts(
+  opts: Opts,
+  knownAttributes: readonly string[],
+): void {
   Object.keys(opts).forEach((v) => {
     if (!knownAttributes.includes(v)) {
       throw new Error(`Unknown option '++${v}' is specified.`);
@@ -153,7 +156,7 @@ export function formatOpt(key: string, value: string | undefined): string[] {
  * }
  * ```
  */
-export function formatOpts(opts: Opts, includes?: string[]): string[] {
+export function formatOpts(opts: Opts, includes?: readonly string[]): string[] {
   let entries = Object.entries(opts);
   if (includes != undefined) {
     entries = entries.filter(([k, _]) => includes.includes(k));


### PR DESCRIPTION
These functions do not update the arrays passed as arguments, so we should be able to pass readonly arrays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Enhanced type safety and inference for the `builtinOpts` array, improving TypeScript's autocompletion and type-checking capabilities.
	- Updated function signatures to enforce immutability for input parameters across various functions, promoting safer handling of data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->