### PR TITLE
:bug: Fix `helper/input` cancellation on Vim

### DIFF
--- a/helper/input.ts
+++ b/helper/input.ts
@@ -7,7 +7,7 @@ import * as fn from "../function/mod.ts";
 import * as lambda from "../lambda/mod.ts";
 import { execute } from "./execute.ts";
 
-const cacheKey = "denops_std/helper/input@2";
+const cacheKey = "denops_std/helper/input@3";
 
 async function ensurePrerequisites(denops: Denops): Promise<string> {
   if (typeof denops.context[cacheKey] === "string") {
@@ -71,8 +71,8 @@ async function ensurePrerequisites(denops: Denops): Promise<string> {
     function! s:input_${suffix}(prompt, text, completion) abort
       let originalEsc = maparg('<Esc>', 'c', 0, 1)
       let originalInt = maparg('<C-c>', 'c', 0, 1)
-      execute printf('cnoremap <nowait><buffer> <Esc> <C-u>%s<CR>', s:escape_token_${suffix})
-      execute printf('cnoremap <nowait><buffer> <C-c> <C-u>%s<CR>', s:escape_token_${suffix})
+      execute printf('cnoremap <nowait><buffer> <Esc> <C-e><C-u>%s<CR>', s:escape_token_${suffix})
+      execute printf('cnoremap <nowait><buffer> <C-c> <C-e><C-u>%s<CR>', s:escape_token_${suffix})
       try
         let result = a:completion is# v:null
               \\ ? input(a:prompt, a:text)

--- a/helper/input_test.ts
+++ b/helper/input_test.ts
@@ -158,6 +158,36 @@ test({
       },
     });
     await t.step({
+      name: "returns `null` when <Esc> is pressed outside EOL",
+      fn: async () => {
+        await autocmd.group(denops, "denops_std_helper_input", (helper) => {
+          helper.remove("*");
+          helper.define(
+            "CmdlineEnter",
+            "*",
+            `call feedkeys("Hello world!\\<Left>\\<Esc>", "it")`,
+          );
+        });
+        const result = await input(denops);
+        assertEquals(result, null);
+      },
+    });
+    await t.step({
+      name: "returns `null` when <C-c> is pressed outside EOL",
+      fn: async () => {
+        await autocmd.group(denops, "denops_std_helper_input", (helper) => {
+          helper.remove("*");
+          helper.define(
+            "CmdlineEnter",
+            "*",
+            `call feedkeys("Hello world!\\<Left>\\<C-c>", "it")`,
+          );
+        });
+        const result = await input(denops);
+        assertEquals(result, null);
+      },
+    });
+    await t.step({
       name: "should have global mapping restored",
       fn: async () => {
         await denops.cmd("cnoremap <Esc> foo");


### PR DESCRIPTION
Fix `helper/input` does not return `null` on <ESC>/<C-c> if the cursor is not at the end of line on Vim.

<C-u> does not remove text between cursor and the tail of line, so if <ESC>/<C-c> is typed outside the end of line, unexpected text appears after `###DenopsStdHelperInputCancelled###` and input cancellation fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated key mappings for input cancellation using `<Esc>` and `<C-c>` to enhance user input handling.

- **Bug Fixes**
	- Added new test cases to improve coverage of input handling for `<Esc>` and `<C-c>` key sequences when pressed outside the end of the line, ensuring accurate recognition during input processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->