### PR TITLE
:+1: Allow users to specify the namespace for decorations

### DIFF
--- a/buffer/decoration_test.ts
+++ b/buffer/decoration_test.ts
@@ -54,7 +54,7 @@ test({
       length: 5,
       lnum: 1,
       start: 1,
-      type: "denops_std:buffer:decoration:decorate:Title",
+      type: "denops_std:buffer:decoration:decorate:denops-test:Title",
       type_bufnr: 0,
     }, {
       col: 2,
@@ -62,7 +62,7 @@ test({
       length: 3,
       lnum: 2,
       start: 1,
-      type: "denops_std:buffer:decoration:decorate:Search",
+      type: "denops_std:buffer:decoration:decorate:denops-test:Search",
       type_bufnr: 0,
     }]);
 
@@ -111,7 +111,7 @@ test({
     ]);
     const ns = await nvimFn.nvim_create_namespace(
       denops,
-      "denops_std:buffer:decoration:decorate",
+      "denops_std:buffer:decoration:decorate:denops-test",
     );
     assertEquals(
       await nvimFn.nvim_buf_get_extmarks(denops, bufnr, ns, 0, -1, {}),


### PR DESCRIPTION
Additionally, use `denops.name` to separate the namespace for each denops plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced decoration management with customizable namespaces for better organization.
  
- **Bug Fixes**
	- Updated decoration type identifiers in tests to reflect new namespace prefixes, improving clarity in test contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->