### PR TITLE
:+1: Add `readonly` to arguments in `buffer` module

### DIFF
--- a/buffer/buffer.ts
+++ b/buffer/buffer.ts
@@ -176,7 +176,7 @@ async function ensurePrerequisites(denops: Denops): Promise<string> {
 export async function open(
   denops: Denops,
   bufname: string,
-  options: OpenOptions = {},
+  options: Readonly<OpenOptions> = {},
 ): Promise<OpenResult> {
   const suffix = await ensurePrerequisites(denops);
   const bang = options.bang ?? false;
@@ -259,7 +259,7 @@ export async function decode(
   denops: Denops,
   bufnr: number,
   data: Uint8Array,
-  options: DecodeOptions = {},
+  options: Readonly<DecodeOptions> = {},
 ): Promise<DecodeResult> {
   const [fileformat, fileformatsStr, fileencodingsStr] = await batch.collect(
     denops,
@@ -321,8 +321,8 @@ export interface DecodeResult {
 export async function append(
   denops: Denops,
   bufnr: number,
-  repl: string[],
-  options: AppendOptions = {},
+  repl: readonly string[],
+  options: Readonly<AppendOptions> = {},
 ): Promise<void> {
   const suffix = await ensurePrerequisites(denops);
   const lnum = options.lnum ??
@@ -361,8 +361,8 @@ export interface AppendOptions {
 export async function replace(
   denops: Denops,
   bufnr: number,
-  repl: string[],
-  options: ReplaceOptions = {},
+  repl: readonly string[],
+  options: Readonly<ReplaceOptions> = {},
 ): Promise<void> {
   const suffix = await ensurePrerequisites(denops);
   await denops.call(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety for options in key functions, ensuring immutability of parameters for `open`, `decode`, `append`, and `replace`.

- **Bug Fixes**
	- Prevented accidental modifications to input data by changing mutable array types to readonly in the `append` and `replace` functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->