### PR TITLE
:+1: Add getbufinfo() helper function

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -20,6 +20,7 @@
     "./helper/echo": "./helper/echo.ts",
     "./helper/execute": "./helper/execute.ts",
     "./helper/expr_string": "./helper/expr_string.ts",
+    "./helper/getbufinfo": "./helper/getbufinfo.ts",
     "./helper/input": "./helper/input.ts",
     "./helper/keymap": "./helper/keymap.ts",
     "./helper/load": "./helper/load.ts",

--- a/helper/getbufinfo.ts
+++ b/helper/getbufinfo.ts
@@ -1,0 +1,52 @@
+import type { Denops } from "../mod.ts";
+import type { BufInfo } from "../function/types.ts";
+import type { BufNameArg, GetBufInfoDictArg } from "../function/buffer.ts";
+
+/**
+ * Get buffer information.
+ *
+ * This is same as getbufinfo() function in Vim script, but filters the
+ * 'variables' entry in order to avoid errors when returning values from Vim
+ * script world into Deno world due to appearances of Funcrefs in buffer-local
+ * variables.
+ *
+ * ```typescript
+ * import type { Entrypoint } from "jsr:@denops/std";
+ * import { getbufinfo } from "jsr:@denops/std/helper/getbufinfo";
+ *
+ * export const main: Entrypoint = async (denops) => {
+ *   console.log(
+ *     await getbufinfo(denops, await denops.call("bufnr") as number),
+ *   );
+ * }
+ * ```
+ */
+export function getbufinfo(
+  denops: Denops,
+  buf?: BufNameArg,
+): Promise<BufInfo[]>;
+export function getbufinfo(
+  denops: Denops,
+  dict?: GetBufInfoDictArg,
+): Promise<BufInfo[]>;
+export async function getbufinfo(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<BufInfo[]> {
+  const bufinfos = await denops.eval(
+    "map(call('getbufinfo', l:args), {_, v -> filter(v, {k -> k !=# 'variables'})})",
+    {
+      args: args,
+    },
+  ) as Record<
+    keyof BufInfo,
+    unknown
+  >[];
+  return bufinfos.map((bufinfo) => ({
+    ...bufinfo,
+    changed: !!bufinfo.changed,
+    hidden: !!bufinfo.hidden,
+    listed: !!bufinfo.listed,
+    loaded: !!bufinfo.loaded,
+  } as unknown as BufInfo));
+}

--- a/helper/getbufinfo_test.ts
+++ b/helper/getbufinfo_test.ts
@@ -1,0 +1,77 @@
+import { getbufinfo } from "./getbufinfo.ts";
+import { assertEquals, assertFalse } from "@std/assert";
+import { assert, is } from "@core/unknownutil";
+import { test } from "@denops/test";
+import type { BufInfo } from "../function/types.ts";
+
+test({
+  mode: "all",
+  name: "buffer",
+  fn: async (denops, t) => {
+    await t.step({
+      name: "getbufinfo()",
+      fn: async () => {
+        await denops.cmd("enew!");
+        await denops.cmd("new foo");
+        await denops.call("setline", 1, "abcdef");
+        await denops.cmd("new bar");
+        await denops.cmd("hide");
+        await denops.cmd("new baz");
+        await denops.cmd("bunload!");
+
+        const actual = await getbufinfo(denops);
+        assert(actual, is.ArrayOf((x): x is BufInfo => is.Record(x)));
+        assertEquals(actual.length, 4);
+        assertEquals(
+          actual.map(({ changed, hidden, listed, loaded }) => (
+            { changed, hidden, listed, loaded }
+          )),
+          [
+            {
+              // [No Name]
+              changed: false,
+              hidden: false,
+              listed: true,
+              loaded: true,
+            },
+            {
+              // foo
+              changed: true,
+              hidden: false,
+              listed: true,
+              loaded: true,
+            },
+            {
+              // bar
+              changed: false,
+              hidden: true,
+              listed: true,
+              loaded: true,
+            },
+            {
+              // baz
+              changed: false,
+              hidden: false,
+              listed: true,
+              loaded: false,
+            },
+          ],
+          "boolean properties are invalid.",
+        );
+      },
+    });
+    await denops.cmd("1,$bwipeout!");
+
+    await t.step({
+      name: "getbufinfo() will filter buffer-local variables",
+      fn: async () => {
+        await denops.cmd("enew!");
+        await denops.cmd("let b:var = 0");
+
+        const actual = await getbufinfo(denops);
+        assertEquals(actual.length, 1);
+        assertFalse("variables" in actual[0]);
+      },
+    });
+  },
+});

--- a/helper/mod.ts
+++ b/helper/mod.ts
@@ -6,6 +6,7 @@
 export * from "./echo.ts";
 export * from "./execute.ts";
 export * from "./expr_string.ts";
+export * from "./getbufinfo.ts";
 export * from "./input.ts";
 export * from "./keymap.ts";
 export * from "./load.ts";


### PR DESCRIPTION
`getbufnr()` function have dictionaries of buffer local variables in its return value.  Therefore, when there's a funcref in buffer local variables, denops will fail to send the return value back to the deno world.
This behavior is inconvenient, this PR makes denops-std's `getbufnr()` omit the "variables" entries from the return value.

**Reproduce Steps**

- Prepare this `/tmp/repro/denops/repro/main.ts`

```typescript
import type { Entrypoint } from "jsr:@denops/std@7.0.0";
import { getbufinfo } from "jsr:@denops/std@~7.4.0/function";

export const main: Entrypoint = (denops) => {
  denops.dispatcher = {
    async invoke() {
      await denops.cmd("let b:repro = {-> 0}");
      await getbufinfo(denops);
    },
  };
};
```

- Prepare this `vimrc.vim`

```vim
set nocompatible

set runtimepath^=/tmp/repro
set runtimepath^=~/.cache/vim/pack/minpac/opt/denops.vim  " Please change this path

command! Repro call denops#notify('repro', 'invoke', [])
```

- Launch vim with `vim -u vimrc.vim`
- Run command `:Repro`
- Get this error

```
[denops] Error: Failed to call 'invoke' API in 'repro': Error: Vim just returns "ERROR" for 'denops#api#vim#call()'. Check if 'denops.vim' exist in 'runtimepath' properly
[denops]     at Vim.call (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/host/vim.ts:55:13)
[denops]     at eventLoopTick (ext:core/01_core.js:175:7)
[denops]     at async getbufinfo (https://jsr.io/@denops/std/7.4.0/function/buffer.ts:453:20)
[denops]     at async Object.invoke (file:///tmp/repro/denops/repro/main.ts:12:7)
[denops]     at async Plugin.call (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/service.ts:276:14)
[denops]     at async Service.#dispatch (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/service.ts:117:12)
[denops]     at async Service.dispatch (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/service.ts:123:14)
[denops]     at async Vim.#dispatch (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/host/vim.ts:120:14)
[denops]     at Plugin.call (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/service.ts:281:13)
[denops]     at eventLoopTick (ext:core/01_core.js:175:7)
[denops]     at async Service.#dispatch (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/service.ts:117:12)
[denops]     at async Service.dispatch (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/service.ts:123:14)
[denops]     at async Vim.#dispatch (file:///Users/mityu/.cache/vim/pack/minpac/opt/denops.vim/denops/@denops-private/host/vim.ts:120:14)
```

**Environment**

- macOS Sequoia 15.2 (Apple Silicon)
- Deno

```
deno 2.1.4 (stable, release, aarch64-apple-darwin)
v8 13.0.245.12-rusty
typescript 5.6.2
```

- Vim: 9.1.954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to retrieve buffer information with various input options.
	- Expanded module exports to include new functionality.

- **Bug Fixes**
	- Implemented filtering to exclude unwanted buffer-local variables in the output.

- **Tests**
	- Added a test suite to validate the functionality and correctness of the new buffer information retrieval function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->