### PR TITLE
fix(popup): support relative: cusror on vim

### DIFF
--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -105,5 +105,29 @@ test({
         },
       });
     }
+
+    t.step({
+      name: `open() with relative cursor`,
+      fn: async () => {
+        await denops.cmd("normal! 10G10");
+        await using popupWindow = await popup.open(denops, {
+          relative: "cursor",
+          width: 20,
+          height: 20,
+          row: 3,
+          col: 3,
+        });
+        console.log(popupWindow.winid);
+        assertEquals(await fn.win_gettype(denops, popupWindow.winid), "popup");
+        assertEquals(await fn.winwidth(denops, popupWindow.winid), 20);
+        assertEquals(await fn.winheight(denops, popupWindow.winid), 20);
+
+        const info = (await fn.getwininfo(denops, popupWindow.winid))[0];
+        assertEquals(info.winrow, 13);
+        assertEquals(info.wincol, 13);
+
+        await denops.cmd("normal! 0G0");
+      },
+    })
   },
 });

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -109,9 +109,18 @@ test({
     await t.step({
       name: `open() with relative cursor`,
       fn: async () => {
-        for (let i = 0; i < 10; i++) {
-          await fn.append(denops, 0, "0123456789");
-        }
+        await fn.append(denops, 0, [
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+          "0123456789",
+        ]);
         await fn.cursor(denops, [5, 5]);
 
         await using popupWindow = await popup.open(denops, {

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -128,6 +128,6 @@ test({
 
         await denops.cmd("normal! 0G0");
       },
-    })
+    });
   },
 });

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -127,7 +127,7 @@ test({
         assertEquals(await fn.winheight(denops, popupWindow.winid), 20);
 
         const info = (await fn.getwininfo(denops, popupWindow.winid))[0];
-        assertEquals(info.winrow, 9);
+        assertEquals(info.winrow, 7);
         assertEquals(info.wincol, 8);
       },
     });

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -110,11 +110,10 @@ test({
       name: `open() with relative cursor`,
       fn: async () => {
         for (let i = 0; i < 10; i++) {
-          await fn.append(denops, 0, [
-            "0123456789",
-          ]);
+          await fn.append(denops, 0, "0123456789");
         }
-        await denops.cmd("normal! G$");
+        await fn.cursor(denops, [5, 5]);
+
         await using popupWindow = await popup.open(denops, {
           relative: "cursor",
           width: 20,
@@ -128,10 +127,8 @@ test({
         assertEquals(await fn.winheight(denops, popupWindow.winid), 20);
 
         const info = (await fn.getwininfo(denops, popupWindow.winid))[0];
-        assertEquals(info.winrow, 13);
-        assertEquals(info.wincol, 13);
-
-        await denops.cmd("normal! 0G0");
+        assertEquals(info.winrow, 9);
+        assertEquals(info.wincol, 8);
       },
     });
   },

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -106,7 +106,7 @@ test({
       });
     }
 
-    t.step({
+    await t.step({
       name: `open() with relative cursor`,
       fn: async () => {
         await denops.cmd("normal! 10G10");

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -127,8 +127,8 @@ test({
         assertEquals(await fn.winheight(denops, popupWindow.winid), 20);
 
         const info = (await fn.getwininfo(denops, popupWindow.winid))[0];
-        assertEquals(info.winrow, 7);
-        assertEquals(info.wincol, 8);
+        assertEquals(info.winrow, 7, "winrow should be 7");
+        assertEquals(info.wincol, 7, "wincol should be 7");
       },
     });
   },

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -129,6 +129,7 @@ test({
           height: 20,
           row: 3,
           col: 3,
+          anchor: "NW",
         });
 
         assertEquals(await fn.win_gettype(denops, popupWindow.winid), "popup");

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -122,7 +122,7 @@ test({
           row: 3,
           col: 3,
         });
-        console.log(popupWindow.winid);
+
         assertEquals(await fn.win_gettype(denops, popupWindow.winid), "popup");
         assertEquals(await fn.winwidth(denops, popupWindow.winid), 20);
         assertEquals(await fn.winheight(denops, popupWindow.winid), 20);

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -109,7 +109,12 @@ test({
     await t.step({
       name: `open() with relative cursor`,
       fn: async () => {
-        await denops.cmd("normal! 10G10");
+        for (let i = 0; i < 10; i++) {
+          await fn.append(denops, 0, [
+            "0123456789",
+          ]);
+        }
+        await denops.cmd("normal! G$");
         await using popupWindow = await popup.open(denops, {
           relative: "cursor",
           width: 20,

--- a/popup/vim.ts
+++ b/popup/vim.ts
@@ -39,15 +39,15 @@ function toPopupCreateOptions(
 
 function handleRelative(
   relative: "editor" | "cursor",
-  offset?: number,
-): string | number | undefined {
-  if (offset == undefined) {
-    return undefined;
-  }
-  if (relative == "editor") {
-    return offset;
-  } else {
-    return offset < 0 ? `cursor${offset}` : `cursor+${offset}`;
+  offset: number,
+): string | number {
+  switch (relative) {
+    case "editor":
+      return offset;
+    case "cursor":
+      return offset < 0 ? `cursor${offset}` : `cursor+${offset}`;
+    default:
+      unreachable(relative);
   }
 }
 
@@ -55,8 +55,8 @@ function toPopupSetOptionsOptions(
   options: Partial<Omit<OpenOptions, "bufnr" | "noRedraw">>,
 ): vimFn.PopupSetOptionsOptions {
   const v: vimFn.PopupCreateOptions = {
-    line: handleRelative(options.relative ?? "editor", options.row),
-    col: handleRelative(options.relative ?? "editor", options.col),
+    line: options.row ? handleRelative(options.relative ?? "editor", options.row) : undefined,
+    col: options.col ? handleRelative(options.relative ?? "editor", options.col) : undefined,
     pos: options.anchor ? posFromAnchor(options.anchor) : undefined,
     fixed: true, // To keep consistent with the behavior of Neovim's floating window
     flip: false, // To keep consistent with the behavior of Neovim's floating window

--- a/popup/vim.ts
+++ b/popup/vim.ts
@@ -37,12 +37,26 @@ function toPopupCreateOptions(
   };
 }
 
+function handleRelative(
+  relative: "editor" | "cursor",
+  offset?: number,
+): string | number | undefined {
+  if (offset == undefined) {
+    return undefined;
+  }
+  if (relative == "editor") {
+    return offset;
+  } else {
+    return offset < 0 ? `cursor${offset}` : `cursor+${offset}`;
+  }
+}
+
 function toPopupSetOptionsOptions(
   options: Partial<Omit<OpenOptions, "bufnr" | "noRedraw">>,
 ): vimFn.PopupSetOptionsOptions {
   const v: vimFn.PopupCreateOptions = {
-    line: options.row,
-    col: options.col,
+    line: handleRelative(options.relative ?? "editor", options.row),
+    col: handleRelative(options.relative ?? "editor", options.col),
     pos: options.anchor ? posFromAnchor(options.anchor) : undefined,
     fixed: true, // To keep consistent with the behavior of Neovim's floating window
     flip: false, // To keep consistent with the behavior of Neovim's floating window


### PR DESCRIPTION
This PR adds support for popup.open's relative option on vim.