### PR TITLE
:bug: Fix race condition in lambda.register with `once` option

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -47,6 +47,7 @@
     ]
   },
   "imports": {
+    "@core/asyncutil": "jsr:@core/asyncutil@^1.2.0",
     "@core/unknownutil": "jsr:@core/unknownutil@^4.3.0",
     "@denops/core": "jsr:@denops/core@^7.0.0",
     "@denops/test": "jsr:@denops/test@^3.0.1",

--- a/lambda/mod.ts
+++ b/lambda/mod.ts
@@ -120,11 +120,8 @@ export function register(
   const id = `lambda:${denops.name}:${uuid}`;
   if (options.once) {
     denops.dispatcher[id] = async (...args: unknown[]) => {
-      try {
-        return await fn(...args);
-      } finally {
-        unregister(denops, id);
-      }
+      unregister(denops, id);
+      return await fn(...args);
     };
   } else {
     denops.dispatcher[id] = async (...args: unknown[]) => {


### PR DESCRIPTION
Ensure the lambda is unregistered before invoking the function when `once` option is specified, preventing multiple concurrent calls from executing the function more than once.

Update test to cover the case where the lambda is called multiple times before the first call resolves.