### PR TITLE
:bug: Fix lambda.unregister incorrectly removing non-lambda methods

### DIFF
--- a/lambda/mod.ts
+++ b/lambda/mod.ts
@@ -143,7 +143,7 @@ export function unregister(
   denops: Denops,
   id: Identifier,
 ): boolean {
-  if (id in denops.dispatcher) {
+  if (isRegisteredFnId(id) && id in denops.dispatcher) {
     delete denops.dispatcher[id];
     return true;
   }
@@ -293,3 +293,7 @@ const isFnWrapperArgs = isTupleOf([
   isLiteralOneOf(["notify", "request"] as const),
   isArray,
 ]) satisfies Predicate<FnWrapperArgs>;
+
+function isRegisteredFnId(id: unknown): id is Identifier {
+  return typeof id === "string" && id.startsWith("lambda:");
+}

--- a/lambda/mod_test.ts
+++ b/lambda/mod_test.ts
@@ -150,7 +150,7 @@ test({
         await t.step("does not unregister lambda functions", async () => {
           const fn = spy(returnsNext(["foo"]));
           const id = lambda.register(denops, fn);
-          lambda.unregister(denops, "not-registered-id");
+          lambda.unregister(denops, "lambda:not-registered-id");
 
           assertSpyCalls(fn, 0);
           assertEquals(
@@ -161,7 +161,35 @@ test({
           assertSpyCalls(fn, 1);
         });
         await t.step("returns `false`", () => {
-          assertEquals(lambda.unregister(denops, "not-registered-id"), false);
+          assertEquals(
+            lambda.unregister(denops, "lambda:not-registered-id"),
+            false,
+          );
+        });
+      });
+      await t.step("if 'id' is not a lambda identifier", async (t) => {
+        await t.step("does not unregister method", async () => {
+          const fn = spy(returnsNext(["foo"]));
+          const notLambdaId = "not-lambda-id";
+          denops.dispatcher = {
+            [notLambdaId]: fn,
+          };
+          lambda.unregister(denops, notLambdaId);
+
+          assertSpyCalls(fn, 0);
+          assertEquals(
+            await denops.dispatch(denops.name, notLambdaId),
+            "foo",
+            "The method is available",
+          );
+          assertSpyCalls(fn, 1);
+        });
+        await t.step("returns `false`", () => {
+          const notLambdaId = "not-lambda-id";
+          denops.dispatcher = {
+            [notLambdaId]: () => "foo",
+          };
+          assertEquals(lambda.unregister(denops, notLambdaId), false);
         });
       });
     });


### PR DESCRIPTION
Previously, `lambda.unregister` could unintentionally delete non-lambda methods of the dispatcher. This commit ensures that only methods with IDs beginning with "lambda:" are unregistered, and that passing a non-lambda method ID will do nothing and return false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the unregister process to prevent accidental removal of non-lambda functions.
- **Tests**
  - Enhanced test coverage for unregistering both valid and invalid lambda identifiers, ensuring correct behavior and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->