### PR TITLE
:bug: Fix Lambda.dispose() to return void instead of boolean

### DIFF
--- a/lambda/mod.ts
+++ b/lambda/mod.ts
@@ -265,6 +265,7 @@ export function add(denops: Denops, fn: Fn): Lambda {
   };
   const id = register(denops, fnWrapper);
   const { name } = denops;
+  const dispose = (): void => void unregister(denops, id);
   return {
     id,
     notify: (...args: unknown[]) => {
@@ -275,8 +276,8 @@ export function add(denops: Denops, fn: Fn): Lambda {
       const fnArgs: FnWrapperArgs = [VIM_REQUEST_FLAG, "request", args];
       return expr`eval(denops#request(${name}, ${id}, ${fnArgs}))`;
     },
-    dispose: () => unregister(denops, id),
-    [Symbol.dispose]: () => void unregister(denops, id),
+    dispose,
+    [Symbol.dispose]: dispose,
   };
 }
 


### PR DESCRIPTION
Previously, `Lambda.dispose()` returned a boolean value from `unregister()`, even though its type definition specifies a return type of `void`. This commit updates the implementation to ensure that `dispose()` and `[Symbol.dispose]` both return `void` as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->