### PR TITLE
Add `close` function to popup module

### DIFF
--- a/popup/mod.ts
+++ b/popup/mod.ts
@@ -176,6 +176,49 @@ export async function open(
 }
 
 /**
+ * Close a popup window by its window ID.
+ *
+ * This function closes a popup window in both Vim and Neovim using the
+ * appropriate platform-specific method. After closing, it automatically
+ * triggers a redraw to ensure the UI is updated.
+ *
+ * @param denops - The Denops instance
+ * @param winid - The window ID of the popup window to close
+ *
+ * @example
+ * ```typescript
+ * import type { Entrypoint } from "jsr:@denops/std";
+ * import * as popup from "jsr:@denops/std/popup";
+ *
+ * export const main: Entrypoint = async (denops) => {
+ *   // Open a popup window
+ *   const popupWindow = await popup.open(denops, {
+ *     relative: "editor",
+ *     width: 20,
+ *     height: 20,
+ *     row: 1,
+ *     col: 1,
+ *   });
+ *
+ *   // Do something with the popup window...
+ *
+ *   // Close the popup window using the standalone close function
+ *   await popup.close(denops, popupWindow.winid);
+ * }
+ * ```
+ *
+ * Note that this function does NOT work in `batch.collect()`.
+ */
+export async function close(
+  denops: Denops,
+  winid: number,
+): Promise<void> {
+  const close = denops.meta.host === "vim" ? closePopupVim : closePopupNvim;
+  await close(denops, winid);
+  await denops.redraw();
+}
+
+/**
  * Config a popup window in Vim/Neovim compatible way.
  *
  * ```typescript

--- a/popup/mod_test.ts
+++ b/popup/mod_test.ts
@@ -105,5 +105,28 @@ test({
         },
       });
     }
+
+    await t.step({
+      name: `close() closes a popup window by window ID`,
+      fn: async () => {
+        const popupWindow = await popup.open(denops, {
+          relative: "editor",
+          width: 30,
+          height: 30,
+          row: 10,
+          col: 10,
+        });
+        const { winid } = popupWindow;
+
+        // Verify popup is open
+        assertEquals(await fn.win_gettype(denops, winid), "popup");
+
+        // Close using standalone close() function
+        await popup.close(denops, winid);
+
+        // Verify popup is closed
+        assertEquals(await fn.win_gettype(denops, winid), "unknown");
+      },
+    });
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standalone function to close popup windows by their ID, compatible with both Vim and Neovim.

- **Tests**
  - Introduced a new test to verify that popup windows can be closed using the standalone close function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->