### PR TITLE
Update supported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         runner:
           - ubuntu-latest
         deno_version:
-          - "1.x"
+          - "2.x"
     runs-on: ${{ matrix.runner }}
     steps:
       - run: git config --global core.autocrlf false
@@ -77,11 +77,11 @@ jobs:
           - macos-latest
           - ubuntu-latest
         deno_version:
-          - "1.45.0"
-          - "1.x"
+          - "2.3.0"
+          - "2.x"
         host_version:
-          - vim: "v9.1.0448"
-            nvim: "v0.10.0"
+          - vim: "v9.1.1646"
+            nvim: "v0.11.3"
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     steps:

--- a/.scripts/apply-supported-versions.ts
+++ b/.scripts/apply-supported-versions.ts
@@ -4,7 +4,7 @@ import {
 } from "./supported_versions.ts";
 
 async function main(): Promise<void> {
-  const supportedVersions = await loadSupportedVersions("main");
+  const supportedVersions = await loadSupportedVersions();
   await updateREADME(supportedVersions);
   await updateGithubWorkflowsTest(supportedVersions);
 }

--- a/.scripts/gen-function/format.ts
+++ b/.scripts/gen-function/format.ts
@@ -18,6 +18,7 @@ const translate: Record<string, string> = {
   "lnum-end": "lnum_end",
   "instanceof": "instanceof_",
   "class": "class_",
+  "package": "package_",
 };
 
 export function formatDocs(docs: string): string[] {

--- a/.scripts/gen-function/gen-function.ts
+++ b/.scripts/gen-function/gen-function.ts
@@ -41,22 +41,26 @@ const vimHelpDownloadUrls = [
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/testing.txt`,
   `https://raw.githubusercontent.com/vim/vim/v${VIM_VERSION}/runtime/doc/textprop.txt`,
 ];
-for (const vimHelpDownloadUrl of vimHelpDownloadUrls) {
-  console.log(`Download from ${vimHelpDownloadUrl}`);
-}
 const vimHelps = await Promise.all(vimHelpDownloadUrls.map(downloadString));
 const vimDefs = parse(vimHelps.join("\n"));
 const vimFnSet = new Set(vimDefs.map((def) => def.fn)).difference(manualFnSet);
 
 const nvimHelpDownloadUrls = [
   `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/api.txt`,
-  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/builtin.txt`,
-  `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
+  [
+    `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/builtin.txt`,
+    // Neovim 0.11+ removed "builtin.txt", but "vimfn.txt" seems to be equivalent.
+    // https://github.com/neovim/neovim/pull/24493
+    `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/vimfn.txt`,
+  ],
+  [
+    `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/eval.txt`,
+    // Neovim 0.11+ removed "eval.txt", but "vimeval.txt" seems to be equivalent.
+    // https://github.com/neovim/neovim/pull/24493
+    `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/vimeval.txt`,
+  ],
   `https://raw.githubusercontent.com/neovim/neovim/v${NVIM_VERSION}/runtime/doc/sign.txt`,
 ];
-for (const nvimHelpDownloadUrl of nvimHelpDownloadUrls) {
-  console.log(`Download from ${nvimHelpDownloadUrl}`);
-}
 const nvimHelps = await Promise.all(nvimHelpDownloadUrls.map(downloadString));
 const nvimDefs = parse(nvimHelps.join("\n"));
 const nvimFnSet = new Set(nvimDefs.map((def) => def.fn)).difference(

--- a/.scripts/utils.ts
+++ b/.scripts/utils.ts
@@ -4,12 +4,20 @@ import { toText } from "@std/streams/to-text";
  * Downloads a text file and returns the contents.
  * Throws error if fetch fails.
  */
-export async function downloadString(url: string): Promise<string> {
-  const response = await fetch(url);
-  if (response.status >= 400 || !response.body) {
-    throw new Error(`Failed to read ${url}`);
+export async function downloadString(urls: string | string[]): Promise<string> {
+  urls = Array.isArray(urls) ? urls : [urls];
+  for (const url of urls) {
+    console.log(`Download from ${url}`);
+    const response = await fetch(url);
+    if (response.status >= 400 || !response.body) {
+      console.debug(
+        `Failed to download ${url}. Fallback to next URL if exists.`,
+      );
+      continue;
+    }
+    return await toText(response.body);
   }
-  return await toText(response.body);
+  throw new Error(`Failed to download from ${urls.join(", ")}`);
 }
 
 /**

--- a/.scripts/utils_test.ts
+++ b/.scripts/utils_test.ts
@@ -47,7 +47,8 @@ Deno.test(downloadString.name, async (t) => {
 
   await t.step("Throws error if fetch fails", async () => {
     const url = "https://example.net/foo.ts";
-    const expectedMessage = "Failed to read https://example.net/foo.ts";
+    const expectedMessage =
+      "Failed to download from https://example.net/foo.ts";
     await mockFetch({
       init: { status: 404 },
       async fn() {

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Test](https://github.com/vim-denops/deno-denops-std/actions/workflows/test.yml/badge.svg)](https://github.com/vim-denops/deno-denops-std/actions/workflows/test.yml)
 [![codecov](https://codecov.io/github/vim-denops/deno-denops-std/branch/main/graph/badge.svg?token=RKAZMUQ3D9)](https://codecov.io/github/vim-denops/deno-denops-std)
 
-[![Deno 1.45.0 or above](https://img.shields.io/badge/Deno-Support%201.45.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v1.45.0)
-[![Vim 9.1.0448 or above](https://img.shields.io/badge/Vim-Support%209.1.0448-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v9.1.0448)
-[![Neovim 0.10.0 or above](https://img.shields.io/badge/Neovim-Support%200.10.0-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.10.0)
+[![Deno 2.3.0 or above](https://img.shields.io/badge/Deno-Support%202.3.0-yellowgreen.svg?logo=deno)](https://github.com/denoland/deno/tree/v2.3.0)
+[![Vim 9.1.1646 or above](https://img.shields.io/badge/Vim-Support%209.1.1646-yellowgreen.svg?logo=vim)](https://github.com/vim/vim/tree/v9.1.1646)
+[![Neovim 0.11.3 or above](https://img.shields.io/badge/Neovim-Support%200.11.3-yellowgreen.svg?logo=neovim&logoColor=white)](https://github.com/neovim/neovim/tree/v0.11.3)
 
 Standard module for [denops.vim].
 

--- a/buffer/decoration.ts
+++ b/buffer/decoration.ts
@@ -261,14 +261,16 @@ async function nvimDecorate(
   for (const chunk of itertools.chunked(decorations, 1000)) {
     await batch(denops, async (denops) => {
       for (const deco of chunk) {
-        await nvimFn.nvim_buf_add_highlight(
+        await nvimFn.nvim_buf_set_extmark(
           denops,
           bufnr,
           ns,
-          deco.highlight,
           deco.line - 1,
           deco.column - 1,
-          deco.column - 1 + deco.length,
+          {
+            end_col: deco.column - 1 + deco.length,
+            hl_group: deco.highlight,
+          },
         );
       }
     });

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -105,6 +105,6 @@
     "gen:function": "deno run -A ./.scripts/gen-function/gen-function.ts",
     "gen:option": "deno run -A ./.scripts/gen-option/gen-option.ts",
     "gen": "deno task gen:function && deno task gen:option && deno fmt",
-    "apply:supported-versions": "deno run --allow-net --allow-read --allow-write .scripts/apply-supported-versions.ts"
+    "apply:supported-versions": "deno run --allow-net --allow-read --allow-write --allow-env .scripts/apply-supported-versions.ts"
   }
 }

--- a/function/_generated.ts
+++ b/function/_generated.ts
@@ -24,6 +24,8 @@ import type { Denops } from "@denops/core";
  * Can also be used as a `method`:
  *
  *     Compute()->abs()
+ *
+ * Return type: `Number` or `Float` depending on **{expr}**
  */
 export function abs(denops: Denops, expr: unknown): Promise<number>;
 export function abs(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -48,6 +50,8 @@ export function abs(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->acos()
+ *
+ * Return type: `Float`
  */
 export function acos(denops: Denops, expr: unknown): Promise<number>;
 export function acos(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -70,6 +74,9 @@ export function acos(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->add(val1)->add(val2)
+ *
+ * Return type: list<**{type}**> (depending on the given `List`) or
+ * `Blob`
  */
 export function add(
   denops: Denops,
@@ -91,6 +98,8 @@ export function add(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     :let flag = bits->and(0x80)
+ *
+ * Return type: `Number`
  */
 export function and(
   denops: Denops,
@@ -122,6 +131,8 @@ export function and(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * passed as the second argument:
  *
  *     mylist->append(lnum)
+ *
+ * Return type: `Number`
  */
 export function append(
   denops: Denops,
@@ -141,6 +152,8 @@ export function append(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Otherwise **{winid}** specifies the window of which the argument
  * list is used: either the window number or the window ID.
  * Returns -1 if the **{winid}** argument is invalid.
+ *
+ * Return type: `Number`
  */
 export function argc(denops: Denops, winid?: unknown): Promise<number>;
 export function argc(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -150,6 +163,8 @@ export function argc(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * The result is the current index in the argument list.  0 is
  * the first file.  argc() - 1 is the last one.  See `arglist`.
+ *
+ * Return type: `Number`
  */
 export function argidx(denops: Denops): Promise<number>;
 export function argidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -167,6 +182,8 @@ export function argidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * With **{winnr}** and **{tabnr}** use the window in the specified tab
  * page.
  * **{winnr}** can be the window number or the `window-ID`.
+ *
+ * Return type: `Number`
  */
 export function arglistid(
   denops: Denops,
@@ -200,6 +217,8 @@ export function arglistid(
  * Returns an empty string if **{nr}**th argument is not present in
  * the argument list.  Returns an empty List if the **{winid}**
  * argument is invalid.
+ *
+ * Return type: `String`
  */
 export function argv(
   denops: Denops,
@@ -230,6 +249,8 @@ export function argv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->asin()
+ *
+ * Return type: `Float`
  */
 export function asin(denops: Denops, expr: unknown): Promise<number>;
 export function asin(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -254,6 +275,8 @@ export function asin(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->atan()
+ *
+ * Return type: `Float`
  */
 export function atan(denops: Denops, expr: unknown): Promise<number>;
 export function atan(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -279,6 +302,8 @@ export function atan(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->atan2(1)
+ *
+ * Return type: `Float`
  */
 export function atan2(
   denops: Denops,
@@ -302,6 +327,8 @@ export function atan2(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetBlob()->blob2list()
+ *
+ * Return type: list<any> or list<number>
  */
 export function blob2list(denops: Denops, blob: unknown): Promise<unknown[]>;
 export function blob2list(
@@ -321,6 +348,8 @@ export function blob2list(
  *     **{default}**   default file name
  * An empty string is returned when the "Cancel" button is hit,
  * something went wrong, or browsing is not possible.
+ *
+ * Return type: `String`
  */
 export function browse(
   denops: Denops,
@@ -344,6 +373,8 @@ export function browse(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     **{initdir}**   directory to start browsing in
  * When the "Cancel" button is hit, something went wrong, or
  * browsing is not possible, an empty string is returned.
+ *
+ * Return type: `String`
  */
 export function browsedir(
   denops: Denops,
@@ -400,6 +431,8 @@ export function browsedir(
  * Can also be used as a `method`:
  *
  *     GetName()->byteidx(idx)
+ *
+ * Return type: `Number`
  */
 export function byteidx(
   denops: Denops,
@@ -429,6 +462,8 @@ export function byteidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->byteidxcomp(idx)
+ *
+ * Return type: `Number`
  */
 export function byteidxcomp(
   denops: Denops,
@@ -455,6 +490,8 @@ export function byteidxcomp(
  * Can also be used as a `method`:
  *
  *     GetFunc()->call([arg, arg], dict)
+ *
+ * Return type: any, depending on **{func}**
  */
 export function call(
   denops: Denops,
@@ -489,6 +526,8 @@ export function call(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->ceil()
+ *
+ * Return type: `Float`
  */
 export function ceil(denops: Denops, expr: unknown): Promise<number>;
 export function ceil(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -503,6 +542,8 @@ export function ceil(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * redo it is the number of the redone change.  After undo it is
  * one less than the number of the undone change.
  * Returns 0 if the undo list is empty.
+ *
+ * Return type: `Number`
  */
 export function changenr(denops: Denops): Promise<number>;
 export function changenr(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -537,6 +578,8 @@ export function changenr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetChar()->char2nr()
+ *
+ * Return type: `Number`
  */
 export function char2nr(
   denops: Denops,
@@ -552,11 +595,13 @@ export function char2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The character class is one of:
  *         0       blank
  *         1       punctuation
- *         2       word character
+ *         2       word character (depends on 'iskeyword')
  *         3       emoji
  *         other   specific Unicode class
  * The class is used in patterns and word motions.
  * Returns 0 if **{string}** is not a `String`.
+ *
+ * Return type: `Number`
  */
 export function charclass(denops: Denops, string: unknown): Promise<number>;
 export function charclass(
@@ -579,6 +624,8 @@ export function charclass(
  * Can also be used as a `method`:
  *
  *     GetPos()->col()
+ *
+ * Return type: `Number`
  */
 export function charcol(
   denops: Denops,
@@ -626,6 +673,8 @@ export function charcol(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->charidx(idx)
+ *
+ * Return type: `Number`
  */
 export function charidx(
   denops: Denops,
@@ -639,15 +688,22 @@ export function charidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
 }
 
 /**
- * Change the current working directory to **{dir}**.  The scope of
- * the directory change depends on the directory of the current
- * window:
- *         - If the current window has a window-local directory
- *           (`:lcd`), then changes the window local directory.
- *         - Otherwise, if the current tabpage has a local
- *           directory (`:tcd`) then changes the tabpage local
- *           directory.
- *         - Otherwise, changes the global directory.
+ * Changes the current working directory to **{dir}**.  The scope of
+ * the change is determined as follows:
+ * If **{scope}** is not present, the current working directory is
+ * changed to the scope of the current directory:
+ *     - If the window local directory (`:lcd`) is set, it
+ *       changes the current working directory for that scope.
+ *     - Otherwise, if the tab page local directory (`:tcd`) is
+ *       set, it changes the current directory for that scope.
+ *     - Otherwise, changes the global directory for that scope.
+ *
+ * If **{scope}** is present, changes the current working directory
+ * for the specified scope:
+ *     "window"    Changes the window local directory.  `:lcd`
+ *     "tabpage"   Changes the tab page local directory.  `:tcd`
+ *     "global"    Changes the global directory.  `:cd`
+ *
  * **{dir}** must be a String.
  * If successful, returns the previous working directory.  Pass
  * this to another chdir() to restore the directory.
@@ -664,8 +720,14 @@ export function charidx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetDir()->chdir()
+ *
+ * Return type: `String`
  */
-export function chdir(denops: Denops, dir: unknown): Promise<string>;
+export function chdir(
+  denops: Denops,
+  dir: unknown,
+  scope?: unknown,
+): Promise<string>;
 export function chdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("chdir", ...args);
 }
@@ -681,6 +743,8 @@ export function chdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->cindent()
+ *
+ * Return type: `Number`
  */
 export function cindent(denops: Denops, lnum: unknown): Promise<number>;
 export function cindent(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -696,6 +760,8 @@ export function cindent(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetWin()->clearmatches()
+ *
+ * Return type: `Number`
  */
 export function clearmatches(denops: Denops, win?: unknown): Promise<void>;
 export function clearmatches(
@@ -741,6 +807,8 @@ export function clearmatches(
  * second argument:
  *
  *     GetMatches()->complete(col('.'))
+ *
+ * Return type: `Number`
  */
 export function complete(
   denops: Denops,
@@ -763,6 +831,8 @@ export function complete(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetMoreMatches()->complete_add()
+ *
+ * Return type: `Number`
  */
 export function complete_add(denops: Denops, expr: unknown): Promise<number>;
 export function complete_add(
@@ -779,6 +849,8 @@ export function complete_add(
  * zero otherwise.
  * Only to be used by the function specified with the
  * 'completefunc' option.
+ *
+ * Return type: `Number`
  */
 export function complete_check(denops: Denops): Promise<number>;
 export function complete_check(
@@ -796,16 +868,22 @@ export function complete_check(
  *                 See `complete_info_mode` for the values.
  *    pum_visible  `TRUE` if popup menu is visible.
  *                 See `pumvisible()`.
- *    items        List of completion matches.  Each item is a
- *                 dictionary containing the entries "word",
+ *    items        List of all completion candidates. Each item
+ *                 is a dictionary containing the entries "word",
  *                 "abbr", "menu", "kind", "info" and "user_data".
  *                 See `complete-items`.
+ *    matches      Same as "items", but only returns items that
+ *                 are matching current query. If both "matches"
+ *                 and "items" are in "what", the returned list
+ *                 will still be named "items", but each item
+ *                 will have an additional "match" field.
  *    selected     Selected item index.  First index is zero.
  *                 Index is -1 if no item is selected (showing
  *                 typed text only, or the last completion after
  *                 no item is selected when using the `<Up>` or
  *                 `<Down>` keys)
- *    inserted     Inserted string. [NOT IMPLEMENTED YET]
+ *    completed    Return a dictionary containing the entries of
+ *                 the currently selected index item.
  *
  * mode values are:
  *    ""                Not in completion mode
@@ -825,6 +903,7 @@ export function complete_check(
  *    "omni"            Omni completion `i_CTRL-X_CTRL-O`
  *    "spell"           Spelling suggestions `i_CTRL-X_s`
  *    "eval"            `complete()` completion
+ *    "register"        Words from registers `i_CTRL-X_CTRL-R`
  *    "unknown"         Other internal modes
  *
  * If the optional **{what}** list argument is supplied, then only
@@ -849,6 +928,8 @@ export function complete_check(
  * Can also be used as a `method`:
  *
  *     GetItems()->complete_info()
+ *
+ * Return type: dict<any>
  */
 export function complete_info(
   denops: Denops,
@@ -925,6 +1006,8 @@ export function complete_info(
  * Can also be used as a `method`in:
  *
  *     BuildMessage()->confirm("&Yes\n&No")
+ *
+ * Return type: `Number`
  */
 export function confirm(
   denops: Denops,
@@ -944,11 +1027,14 @@ export function confirm(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * that the original `List` can be changed without changing the
  * copy, and vice versa.  But the items are identical, thus
  * changing an item changes the contents of both `Lists`.
- * A `Dictionary` is copied in a similar way as a `List`.
+ * A `Tuple` or `Dictionary` is copied in a similar way as a
+ * `List`.
  * Also see `deepcopy()`.
  * Can also be used as a `method`:
  *
  *     mylist->copy()
+ *
+ * Return type: any, depending on **{expr}**
  */
 export function copy(denops: Denops, expr: unknown): Promise<unknown>;
 export function copy(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -972,6 +1058,8 @@ export function copy(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->cos()
+ *
+ * Return type: `Float`
  */
 export function cos(denops: Denops, expr: unknown): Promise<number>;
 export function cos(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -996,6 +1084,8 @@ export function cos(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->cosh()
+ *
+ * Return type: `Float`
  */
 export function cosh(denops: Denops, expr: unknown): Promise<number>;
 export function cosh(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1004,10 +1094,10 @@ export function cosh(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * Return the number of times an item with value **{expr}** appears
- * in `String`, `List` or `Dictionary` **{comp}**.
+ * in `String`, `List`, `Tuple` or `Dictionary` **{comp}**.
  *
  * If **{start}** is given then start with the item with this index.
- * **{start}** can only be used with a `List`.
+ * **{start}** can only be used with a `List` or a `Tuple`.
  *
  * When **{ic}** is given and it's `TRUE` then case is ignored.
  *
@@ -1018,6 +1108,8 @@ export function cosh(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->count(val)
+ *
+ * Return type: `Number`
  */
 export function count(
   denops: Denops,
@@ -1042,6 +1134,8 @@ export function count(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetPid()->debugbreak()
+ *
+ * Return type: `Number`
  */
 export function debugbreak(denops: Denops, pid: unknown): Promise<number>;
 export function debugbreak(
@@ -1060,7 +1154,8 @@ export function debugbreak(
  * `Dictionary`, a copy for it is made, recursively.  Thus
  * changing an item in the copy does not change the contents of
  * the original `List`.
- * A `Dictionary` is copied in a similar way as a `List`.
+ * A `Tuple` or `Dictionary` is copied in a similar way as a
+ * `List`.
  *
  * When **{noref}** is omitted or zero a contained `List` or
  * `Dictionary` is only copied once.  All references point to
@@ -1076,6 +1171,8 @@ export function debugbreak(
  * Can also be used as a `method`:
  *
  *     GetObject()->deepcopy()
+ *
+ * Return type: any, depending on **{expr}**
  */
 export function deepcopy(
   denops: Denops,
@@ -1112,6 +1209,8 @@ export function deepcopy(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->delete()
+ *
+ * Return type: `Number`
  */
 export function delete_(
   denops: Denops,
@@ -1133,6 +1232,8 @@ export function delete_(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * current buffer.  This allows an autocommand that starts
  * editing another buffer to set 'filetype' and load a syntax
  * file.
+ *
+ * Return type: `Number`
  */
 export function did_filetype(denops: Denops): Promise<number>;
 export function did_filetype(
@@ -1156,6 +1257,8 @@ export function did_filetype(
  * Can also be used as a `method`:
  *
  *     GetLnum()->diff_hlID(col)
+ *
+ * Return type: `Number`
  */
 export function diff_hlID(
   denops: Denops,
@@ -1194,6 +1297,8 @@ export function diff_hlID(
  *
  *     GetChars()->digraph_get()
  *
+ * Return type: `String`
+ *
  * This function works only when compiled with the `+digraphs`
  * feature.  If this feature is disabled, this function will
  * display an error message.
@@ -1229,6 +1334,8 @@ export function digraph_get(
  *
  *     GetNumber()->digraph_getlist()
  *
+ * Return type: list<list<string>>
+ *
  * This function works only when compiled with the `+digraphs`
  * feature.  If this feature is disabled, this function will
  * display an error message.
@@ -1252,7 +1359,7 @@ export function digraph_getlist(
  * function is similar to `:digraphs` command, but useful to add
  * digraphs start with a white space.
  *
- * The function result is v:true if `digraph` is registered.  If
+ * The function returns v:true if `digraph` is registered.  If
  * this fails an error message is given and v:false is returned.
  *
  * If you want to define multiple digraphs at once, you can use
@@ -1265,6 +1372,8 @@ export function digraph_getlist(
  * Can be used as a `method`:
  *
  *     GetString()->digraph_set('あ')
+ *
+ * Return type: `vim9-boolean`
  *
  * This function works only when compiled with the `+digraphs`
  * feature.  If this feature is disabled, this function will
@@ -1304,6 +1413,8 @@ export function digraph_set(
  *
  *     GetList()->digraph_setlist()
  *
+ * Return type: `vim9-boolean`
+ *
  * This function works only when compiled with the `+digraphs`
  * feature.  If this feature is disabled, this function will
  * display an error message.
@@ -1321,8 +1432,8 @@ export function digraph_setlist(
 
 /**
  * Return the Number 1 if **{expr}** is empty, zero otherwise.
- * - A `List` or `Dictionary` is empty when it does not have any
- *   items.
+ * - A `List`, `Tuple` or `Dictionary` is empty when it does
+ *   not have any items.
  * - A `String` is empty when its length is zero.
  * - A `Number` and `Float` are empty when their value is zero.
  * - `v:false`, `v:none` and `v:null` are empty, `v:true` is not.
@@ -1338,6 +1449,8 @@ export function digraph_setlist(
  * Can also be used as a `method`:
  *
  *     mylist->empty()
+ *
+ * Return type: `Number`
  */
 export function empty(denops: Denops, expr: unknown): Promise<number>;
 export function empty(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1354,6 +1467,8 @@ export function empty(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * use this:
  *
  *     :echo index(keys(environ()), 'HOME', 0, 1) != -1
+ *
+ * Return type: dict<string>
  */
 export function environ(denops: Denops): Promise<Record<string, unknown>>;
 export function environ(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1375,6 +1490,8 @@ export function environ(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->escape(' \')
+ *
+ * Return type: `String`
  */
 export function escape(
   denops: Denops,
@@ -1396,6 +1513,8 @@ export function escape(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     argv->join()->eval()
+ *
+ * Return type: any, depending on **{string}**
  */
 export function eval_(denops: Denops, string: unknown): Promise<unknown>;
 export function eval_(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1407,6 +1526,8 @@ export function eval_(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * interrupted while waiting for the user to type a character,
  * e.g., when dropping a file on Vim.  This means interactive
  * commands cannot be used.  Otherwise zero is returned.
+ *
+ * Return type: `Number`
  */
 export function eventhandler(denops: Denops): Promise<number>;
 export function eventhandler(
@@ -1420,8 +1541,10 @@ export function eventhandler(
  * This function checks if an executable with the name **{expr}**
  * exists.  **{expr}** must be the name of the program without any
  * arguments.
+ *
  * executable() uses the value of $PATH and/or the normal
  * searchpath for programs.
+ *
  * On MS-Windows the ".exe", ".bat", etc. can optionally be
  * included.  Then the extensions in $PATHEXT are tried.  Thus if
  * "foo.exe" does not exist, "foo.exe.bat" can be found.  If
@@ -1431,11 +1554,14 @@ export function eventhandler(
  * then the name is also tried without adding an extension.
  * On MS-Windows it only checks if the file exists and is not a
  * directory, not if it's really executable.
- * On MS-Windows an executable in the same directory as Vim is
- * normally found.  Since this directory is added to $PATH it
- * should also work to execute it `win32-PATH`.  This can be
- * disabled by setting the $NoDefaultCurrentDirectoryInExePath
- * environment variable.
+ * On MS-Windows an executable in the same directory as the Vim
+ * executable is always found.  Since this directory is added to
+ * $PATH it should also work to execute it `win32-PATH`.
+ *
+ * On MS-Windows an executable in Vim's current working directory
+ * is also normally found, but this can be disabled by setting
+ * the $NoDefaultCurrentDirectoryInExePath environment variable.
+ *
  * The result is a Number:
  *         1       exists
  *         0       does not exist
@@ -1445,6 +1571,8 @@ export function eventhandler(
  * Can also be used as a `method`:
  *
  *     GetCommand()->executable()
+ *
+ * Return type: `Number`
  */
 export function executable(denops: Denops, expr: unknown): Promise<number>;
 export function executable(
@@ -1490,6 +1618,8 @@ export function executable(
  * Can also be used as a `method`:
  *
  *     GetCommand()->execute()
+ *
+ * Return type: `String`
  */
 export function execute(
   denops: Denops,
@@ -1514,6 +1644,8 @@ export function execute(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetCommand()->exepath()
+ *
+ * Return type: `String`
  */
 export function exepath(denops: Denops, expr: unknown): Promise<string>;
 export function exepath(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1538,6 +1670,8 @@ export function exepath(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->exp()
+ *
+ * Return type: `Float`
  */
 export function exp(denops: Denops, expr: unknown): Promise<number>;
 export function exp(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1651,6 +1785,8 @@ export function exp(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Getpattern()->expand()
+ *
+ * Return type: `String` or list<string> depending on **{list}**
  */
 export function expand(
   denops: Denops,
@@ -1687,6 +1823,8 @@ export function expand(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetCommand()->expandcmd()
+ *
+ * Return type: `String` or list<string> depending on **{list}**
  */
 export function expandcmd(
   denops: Denops,
@@ -1733,7 +1871,8 @@ export function expandcmd(
  * When **{expr3}** is omitted then "force" is assumed.
  *
  * **{expr1}** is changed when **{expr2}** is not empty.  If necessary
- * make a copy of **{expr1}** first.
+ * make a copy of **{expr1}** first or use `extendnew()` to return a
+ * new List/Dictionary.
  * **{expr2}** remains unchanged.
  * When **{expr1}** is locked and **{expr2}** is not empty the operation
  * fails.
@@ -1742,6 +1881,9 @@ export function expandcmd(
  * Can also be used as a `method`:
  *
  *     mylist->extend(otherlist)
+ *
+ * Return type: list<**{type}**> or dict<**{type}**> depending on **{expr1}**
+ * and **{expr2}**, in case of error: `Number`
  */
 export function extend(
   denops: Denops,
@@ -1757,6 +1899,9 @@ export function extend(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Like `extend()` but instead of adding items to **{expr1}** a new
  * List or Dictionary is created and returned.  **{expr1}** remains
  * unchanged.
+ *
+ * Return type: list<**{type}**> or dict<**{type}**> depending on **{expr1}**
+ * and **{expr2}**, in case of error: `Number`
  */
 export function extendnew(
   denops: Denops,
@@ -1828,6 +1973,8 @@ export function extendnew(
  * Can also be used as a `method`:
  *
  *     GetInput()->feedkeys()
+ *
+ * Return type: `Number`
  */
 export function feedkeys(
   denops: Denops,
@@ -1836,6 +1983,30 @@ export function feedkeys(
 ): Promise<number>;
 export function feedkeys(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("feedkeys", ...args);
+}
+
+/**
+ * Copy the file pointed to by the name **{from}** to **{to}**. The
+ * result is a Number, which is `TRUE` if the file was copied
+ * successfully, and `FALSE` when it failed.
+ * If a file with name **{to}** already exists, it will fail.
+ * Note that it does not handle directories (yet).
+ *
+ * This function is not available in the `sandbox`.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetOldName()->filecopy(newname)
+ *
+ * Return type: `Number`
+ */
+export function filecopy(
+  denops: Denops,
+  from: unknown,
+  to: unknown,
+): Promise<number>;
+export function filecopy(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("filecopy", ...args);
 }
 
 /**
@@ -1856,6 +2027,8 @@ export function feedkeys(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetName()->filereadable()
  *
+ * Return type: `Number`
+ *
  * Obsolete name: file_readable().
  */
 export function filereadable(denops: Denops, file: unknown): Promise<number>;
@@ -1875,6 +2048,8 @@ export function filereadable(
  * Can also be used as a `method`:
  *
  *     GetName()->filewritable()
+ *
+ * Return type: `Number`
  */
 export function filewritable(denops: Denops, file: unknown): Promise<number>;
 export function filewritable(
@@ -1959,6 +2134,9 @@ export function filewritable(
  * Can also be used as a `method`:
  *
  *     mylist->filter(expr2)
+ *
+ * Return type: `String`, `Blob`, list<**{type}**> or dict<**{type}**>
+ * depending on **{expr1}**
  */
 export function filter(
   denops: Denops,
@@ -1990,13 +2168,16 @@ export function filter(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->finddir()
+ *
+ * Return type: list<string> if **{count}** is negative, `String`
+ * otherwise
  */
 export function finddir(
   denops: Denops,
   name: unknown,
   path?: unknown,
   count?: unknown,
-): Promise<string>;
+): Promise<unknown>;
 export function finddir(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("finddir", ...args);
 }
@@ -2014,13 +2195,16 @@ export function finddir(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->findfile()
+ *
+ * Return type: list<string> if **{count}** is negative, `String`
+ * otherwise
  */
 export function findfile(
   denops: Denops,
   name: unknown,
   path?: unknown,
   count?: unknown,
-): Promise<string>;
+): Promise<unknown>;
 export function findfile(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("findfile", ...args);
 }
@@ -2053,6 +2237,8 @@ export function findfile(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->flatten()
+ *
+ * Return type: list<**{type}**>
  */
 export function flatten(
   denops: Denops,
@@ -2065,6 +2251,8 @@ export function flatten(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * Like `flatten()` but first make a copy of **{list}**.
+ *
+ * Return type: list<**{type}**>
  */
 export function flattennew(
   denops: Denops,
@@ -2113,6 +2301,8 @@ export function flattennew(
  * Can also be used as a `method`:
  *
  *     Compute()->float2nr()
+ *
+ * Return type: `Number`
  */
 export function float2nr(denops: Denops, expr: unknown): Promise<number>;
 export function float2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -2141,6 +2331,8 @@ export function float2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->floor()
+ *
+ * Return type: `Float`
  */
 export function floor(denops: Denops, expr: unknown): Promise<number>;
 export function floor(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -2170,6 +2362,8 @@ export function floor(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->fmod(1.22)
+ *
+ * Return type: `Float`
  */
 export function fmod(
   denops: Denops,
@@ -2202,6 +2396,8 @@ export function fmod(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->fnameescape()
+ *
+ * Return type: `String`
  */
 export function fnameescape(denops: Denops, string: unknown): Promise<string>;
 export function fnameescape(
@@ -2235,6 +2431,8 @@ export function fnameescape(
  * Can also be used as a `method`:
  *
  *     GetName()->fnamemodify(':p:h')
+ *
+ * Return type: `String`
  */
 export function fnamemodify(
   denops: Denops,
@@ -2258,6 +2456,8 @@ export function fnamemodify(
  * Can also be used as a `method`:
  *
  *     GetLnum()->foldclosed()
+ *
+ * Return type: `Number`
  */
 export function foldclosed(denops: Denops, lnum: unknown): Promise<number>;
 export function foldclosed(
@@ -2277,6 +2477,8 @@ export function foldclosed(
  * Can also be used as a `method`:
  *
  *     GetLnum()->foldclosedend()
+ *
+ * Return type: `Number`
  */
 export function foldclosedend(denops: Denops, lnum: unknown): Promise<number>;
 export function foldclosedend(
@@ -2301,6 +2503,8 @@ export function foldclosedend(
  * Can also be used as a `method`:
  *
  *     GetLnum()->foldlevel()
+ *
+ * Return type: `Number`
  */
 export function foldlevel(denops: Denops, lnum: unknown): Promise<number>;
 export function foldlevel(
@@ -2328,6 +2532,8 @@ export function foldlevel(
  * will be filled with the fold char from the 'fillchars'
  * setting.
  * Returns an empty string when there is no fold.
+ *
+ * Return type: `String`
  * *not available when compiled without the `+folding` feature*
  */
 export function foldtext(denops: Denops): Promise<string>;
@@ -2348,6 +2554,8 @@ export function foldtext(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->foldtextresult()
+ *
+ * Return type: `String`
  */
 export function foldtextresult(denops: Denops, lnum: unknown): Promise<string>;
 export function foldtextresult(
@@ -2358,7 +2566,8 @@ export function foldtextresult(
 }
 
 /**
- * **{expr1}** must be a `List`, `String`, `Blob` or `Dictionary`.
+ * **{expr1}** must be a `List`, `Tuple`, `String`, `Blob` or
+ * `Dictionary`.
  * For each item in **{expr1}** execute **{expr2}**. **{expr1}** is not
  * modified; its values may be, as with `:lockvar` 1. `E741`
  * See `map()` and `filter()` to modify **{expr1}**.
@@ -2367,10 +2576,10 @@ export function foldtextresult(
  *
  * If **{expr2}** is a `string`, inside **{expr2}** `v:val` has the value
  * of the current item.  For a `Dictionary` `v:key` has the key
- * of the current item and for a `List` `v:key` has the index of
- * the current item.  For a `Blob` `v:key` has the index of the
- * current byte. For a `String` `v:key` has the index of the
- * current character.
+ * of the current item and for a `List` or a `Tuple` `v:key` has
+ * the index of the current item.  For a `Blob` `v:key` has the
+ * index of the current byte. For a `String` `v:key` has the
+ * index of the current character.
  * Examples:
  *
  *     call foreach(mylist, 'used[v:val] = true')
@@ -2398,12 +2607,15 @@ export function foldtextresult(
  * Can also be used as a `method`:
  *
  *     mylist->foreach(expr2)
+ *
+ * Return type: `String`, `Blob`, list<**{type}**>, tuple<**{type}**> or
+ * dict<**{type}**> depending on **{expr1}**
  */
 export function foreach(
   denops: Denops,
   expr1: unknown,
   expr2: unknown,
-): Promise<unknown[] | Record<string, unknown> | unknown | string>;
+): Promise<unknown[] | unknown | Record<string, unknown> | string>;
 export function foreach(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("foreach", ...args);
 }
@@ -2429,6 +2641,8 @@ export function foreach(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->fullcommand()
+ *
+ * Return type: `String`
  */
 export function fullcommand(
   denops: Denops,
@@ -2457,6 +2671,8 @@ export function fullcommand(
  * Can also be used as a `method`:
  *
  *     GetFuncname()->funcref([arg])
+ *
+ * Return type: func(...): any or `Number` on error
  */
 export function funcref(
   denops: Denops,
@@ -2565,6 +2781,8 @@ export function funcref(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetFuncname()->function([arg])
+ *
+ * Return type: func(...): any or `Number` on error
  */
 export function function_(
   denops: Denops,
@@ -2599,6 +2817,8 @@ export function function_(
  * it's safe to perform.  This is when waiting for the user to
  * type a character.  To force garbage collection immediately use
  * `test_garbagecollect_now()`.
+ *
+ * Return type: `String`
  */
 export function garbagecollect(denops: Denops, atexit?: unknown): Promise<void>;
 export function garbagecollect(
@@ -2615,6 +2835,8 @@ export function garbagecollect(
  * Preferably used as a `method`:
  *
  *     mylist->get(idx)
+ *
+ * Return type: any, depending on **{list}**
  */
 export function get(
   denops: Denops,
@@ -2629,6 +2851,8 @@ export function get(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Just like `getbufline()` but only get one line and return it
  * as a string.
+ *
+ * Return type: `String`
  */
 export function getbufoneline(
   denops: Denops,
@@ -2647,6 +2871,8 @@ export function getbufoneline(
  * by `setcellwidths()`.  The format is equal to the argument of
  * `setcellwidths()`.  If no character ranges have their cell
  * widths overridden, an empty List is returned.
+ *
+ * Return type: list<any>
  */
 export function getcellwidths(denops: Denops): Promise<unknown[]>;
 export function getcellwidths(
@@ -2658,12 +2884,14 @@ export function getcellwidths(
 
 /**
  * Get a single character from the user or input stream.
- * If **{expr}** is omitted, wait until a character is available.
+ * If **{expr}** is omitted or is -1, wait until a character is
+ *         available.
  * If **{expr}** is 0, only get a character when one is available.
  *         Return zero otherwise.
  * If **{expr}** is 1, only check if a character is available, it is
  *         not consumed.  Return zero if no character available.
- * If you prefer always getting a string use `getcharstr()`.
+ * If you prefer always getting a string use `getcharstr()`, or
+ * specify `FALSE` as "number" in **{opts}**.
  *
  * Without **{expr}** and when **{expr}** is 0 a whole character or
  * special key is returned.  If it is a single character, the
@@ -2673,7 +2901,8 @@ export function getcellwidths(
  * starting with 0x80 (decimal: 128).  This is the same value as
  * the String `"\<Key>"`, e.g., `"\<Left>"`.  The returned value is
  * also a String when a modifier (shift, control, alt) was used
- * that is not included in the character.
+ * that is not included in the character.  `keytrans()` can also
+ * be used to convert a returned String into a readable form.
  *
  * When **{expr}** is 0 and Esc is typed, there will be a short delay
  * while Vim waits to see if this is the start of an escape
@@ -2684,6 +2913,31 @@ export function getcellwidths(
  * Use nr2char() to convert it to a String.
  *
  * Use getcharmod() to obtain any additional modifiers.
+ *
+ * The optional argument **{opts}** is a Dict and supports the
+ * following items:
+ *
+ *         cursor          A String specifying cursor behavior
+ *                         when waiting for a character.
+ *                         "hide": hide the cursor.
+ *                         "keep": keep current cursor unchanged.
+ *                         "msg": move cursor to message area.
+ *                         (default: "msg")
+ *
+ *         number          If `TRUE`, return a Number when getting
+ *                         a single character.
+ *                         If `FALSE`, the return value is always
+ *                         converted to a String, and an empty
+ *                         String (instead of 0) is returned when
+ *                         no character is available.
+ *                         (default: `TRUE`)
+ *
+ *         simplify        If `TRUE`, include modifiers in the
+ *                         character if possible.  E.g., return
+ *                         the same value for CTRL-I and `<Tab>`.
+ *                         If `FALSE`, don't include modifiers in
+ *                         the character.
+ *                         (default: `TRUE`)
  *
  * When the user clicks a mouse button, the mouse event will be
  * returned.  The position can then be found in `v:mouse_col`,
@@ -2740,10 +2994,13 @@ export function getcellwidths(
  *     :  endwhile
  *     :  return c
  *     :endfunction
+ *
+ * Return type: `Number` or `String`
  */
 export function getchar(
   denops: Denops,
   expr?: unknown,
+  opts?: unknown,
 ): Promise<number | string>;
 export function getchar(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("getchar", ...args);
@@ -2764,6 +3021,8 @@ export function getchar(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Only the modifiers that have not been included in the
  * character itself are obtained.  Thus Shift-a results in "A"
  * without a modifier.  Returns 0 if no modifiers are used.
+ *
+ * Return type: `Number`
  */
 export function getcharmod(denops: Denops): Promise<number>;
 export function getcharmod(
@@ -2790,6 +3049,8 @@ export function getcharmod(
  * Can also be used as a `method`:
  *
  *     GetMark()->getcharpos()
+ *
+ * Return type: list<number>
  */
 export function getcharpos(denops: Denops, expr: unknown): Promise<unknown[]>;
 export function getcharpos(
@@ -2820,6 +3081,8 @@ export function getcharpos(
  *     :nnoremap <expr> , getcharsearch().forward ? ',' : ';'
  *
  * Also see `setcharsearch()`.
+ *
+ * Return type: dict<any>
  */
 export function getcharsearch(denops: Denops): Promise<Record<string, unknown>>;
 export function getcharsearch(
@@ -2830,18 +3093,16 @@ export function getcharsearch(
 }
 
 /**
- * Get a single character from the user or input stream as a
- * string.
- * If **{expr}** is omitted, wait until a character is available.
- * If **{expr}** is 0 or false, only get a character when one is
- *         available.  Return an empty string otherwise.
- * If **{expr}** is 1 or true, only check if a character is
- *         available, it is not consumed.  Return an empty string
- *         if no character is available.
- * Otherwise this works like `getchar()`, except that a number
- * result is converted to a string.
+ * The same as `getchar()`, except that this always returns a
+ * String, and "number" isn't allowed in **{opts}**.
+ *
+ * Return type: `String`
  */
-export function getcharstr(denops: Denops, expr?: unknown): Promise<string>;
+export function getcharstr(
+  denops: Denops,
+  expr?: unknown,
+  opts?: unknown,
+): Promise<string>;
 export function getcharstr(
   denops: Denops,
   ...args: unknown[]
@@ -2850,13 +3111,36 @@ export function getcharstr(
 }
 
 /**
+ * Return completion pattern of the current command-line.
+ * Only works when the command line is being edited, thus
+ * requires use of `c_CTRL-\_e` or `c_CTRL-R_=`.
+ * Also see `getcmdtype()`, `setcmdpos()`, `getcmdline()`,
+ * `getcmdprompt()`, `getcmdcompltype()` and `setcmdline()`.
+ * Returns an empty string when completion is not defined.
+ *
+ * Return type: `String`
+ */
+export function getcmdcomplpat(denops: Denops): Promise<string>;
+export function getcmdcomplpat(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("getcmdcomplpat", ...args);
+}
+
+/**
  * Return the type of the current command-line completion.
  * Only works when the command line is being edited, thus
  * requires use of `c_CTRL-\_e` or `c_CTRL-R_=`.
  * See `:command-completion` for the return string.
- * Also see `getcmdtype()`, `setcmdpos()`, `getcmdline()` and
- * `setcmdline()`.
+ * Also see `getcmdtype()`, `setcmdpos()`, `getcmdline()`,
+ * `getcmdprompt()`, `getcmdcomplpat()` and `setcmdline()`.
  * Returns an empty string when completion is not defined.
+ *
+ * To get the type of the command-line completion for a specified
+ * string, use `getcompletiontype()`.
+ *
+ * Return type: `String`
  */
 export function getcmdcompltype(denops: Denops): Promise<string>;
 export function getcmdcompltype(
@@ -2867,17 +3151,19 @@ export function getcmdcompltype(
 }
 
 /**
- * Return the current command-line.  Only works when the command
- * line is being edited, thus requires use of `c_CTRL-\_e` or
- * `c_CTRL-R_=`.
+ * Return the current command-line input.  Only works when the
+ * command line is being edited, thus requires use of
+ * `c_CTRL-\_e` or `c_CTRL-R_=`.
  * Example:
  *
  *     :cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
  *
- * Also see `getcmdtype()`, `getcmdpos()`, `setcmdpos()` and
- * `setcmdline()`.
+ * Also see `getcmdtype()`, `getcmdpos()`, `setcmdpos()`,
+ * `getcmdprompt()` and `setcmdline()`.
  * Returns an empty string when entering a password or using
  * `inputsecret()`.
+ *
+ * Return type: `String`
  */
 export function getcmdline(denops: Denops): Promise<string>;
 export function getcmdline(
@@ -2893,8 +3179,10 @@ export function getcmdline(
  * Only works when editing the command line, thus requires use of
  * `c_CTRL-\_e` or `c_CTRL-R_=` or an expression mapping.
  * Returns 0 otherwise.
- * Also see `getcmdtype()`, `setcmdpos()`, `getcmdline()` and
- * `setcmdline()`.
+ * Also see `getcmdtype()`, `setcmdpos()`, `getcmdline()`,
+ * `getcmdprompt()` and `setcmdline()`.
+ *
+ * Return type: `Number`
  */
 export function getcmdpos(denops: Denops): Promise<number>;
 export function getcmdpos(
@@ -2902,6 +3190,24 @@ export function getcmdpos(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("getcmdpos", ...args);
+}
+
+/**
+ * Return the current command-line prompt when using functions
+ * like `input()` or `confirm()`.
+ * Only works when the command line is being edited, thus
+ * requires use of `c_CTRL-\_e` or `c_CTRL-R_=`.
+ * Also see `getcmdtype()`, `getcmdline()`, `getcmdpos()`,
+ * `setcmdpos()` and `setcmdline()`.
+ *
+ * Return type: `String`
+ */
+export function getcmdprompt(denops: Denops): Promise<string>;
+export function getcmdprompt(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("getcmdprompt", ...args);
 }
 
 /**
@@ -2913,6 +3219,8 @@ export function getcmdpos(
  * Returns 0 otherwise.
  * Also see `getcmdpos()`, `setcmdpos()`, `getcmdline()` and
  * `setcmdline()`.
+ *
+ * Return type: `Number`
  */
 export function getcmdscreenpos(denops: Denops): Promise<number>;
 export function getcmdscreenpos(
@@ -2936,6 +3244,8 @@ export function getcmdscreenpos(
  * `c_CTRL-\_e` or `c_CTRL-R_=` or an expression mapping.
  * Returns an empty string otherwise.
  * Also see `getcmdpos()`, `setcmdpos()` and `getcmdline()`.
+ *
+ * Return type: `String`
  */
 export function getcmdtype(denops: Denops): Promise<string>;
 export function getcmdtype(
@@ -2949,6 +3259,8 @@ export function getcmdtype(
  * Return the current `command-line-window` type. Possible return
  * values are the same as `getcmdtype()`. Returns an empty string
  * when not in the command-line window.
+ *
+ * Return type: `String`
  */
 export function getcmdwintype(denops: Denops): Promise<string>;
 export function getcmdwintype(
@@ -2977,12 +3289,14 @@ export function getcmdwintype(
  * customlist,**{func}** custom completion, defined via **{func}**
  * diff_buffer     `:diffget` and `:diffput` completion
  * dir             directory names
+ * dir_in_path     directory names in 'cdpath'
  * environment     environment variable names
  * event           autocommand events
  * expression      Vim expression
  * file            file and directory names
- * file_in_path    file and directory names in `'path'`
- * filetype        filetype names `'filetype'`
+ * file_in_path    file and directory names in 'path'
+ * filetype        filetype names 'filetype'
+ * filetypecmd     `:filetype` suboptions
  * function        function name
  * help            help subjects
  * highlight       highlight groups
@@ -2995,11 +3309,13 @@ export function getcmdwintype(
  * messages        `:messages` suboptions
  * option          options
  * packadd         optional package `pack-add` names
+ * retab           `:retab` suboptions
  * runtime         `:runtime` completion
  * scriptnames     sourced script names `:scriptnames`
  * shellcmd        Shell command
+ * shellcmdline    Shell command line with filename arguments
  * sign            `:sign` suboptions
- * syntax          syntax file names `'syntax'`
+ * syntax          syntax file names 'syntax'
  * syntime         `:syntime` suboptions
  * tag             tags
  * tag_listfiles   tags, file names
@@ -3033,6 +3349,8 @@ export function getcmdwintype(
  * Can also be used as a `method`:
  *
  *     GetPattern()->getcompletion('color')
+ *
+ * Return type: list<string>
  */
 export function getcompletion(
   denops: Denops,
@@ -3060,6 +3378,8 @@ export function getcompletion(
  * Can also be used as a `method`:
  *
  *     GetWinid()->getcursorcharpos()
+ *
+ * Return type: list<number>
  */
 export function getcursorcharpos(
   denops: Denops,
@@ -3109,6 +3429,8 @@ export function getcursorcharpos(
  * Can also be used as a `method`:
  *
  *     GetWinnr()->getcwd()
+ *
+ * Return type: `String`
  */
 export function getcwd(
   denops: Denops,
@@ -3133,6 +3455,8 @@ export function getcwd(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetVarname()->getenv()
+ *
+ * Return type: `String` or `Number`
  */
 export function getenv(denops: Denops, name: unknown): Promise<string>;
 export function getenv(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -3152,6 +3476,8 @@ export function getenv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * function just after the GUI has started.
  * Note that the GTK GUI accepts any font name, thus checking for
  * a valid name does not work.
+ *
+ * Return type: `String`
  */
 export function getfontname(denops: Denops, name?: unknown): Promise<string>;
 export function getfontname(
@@ -3182,6 +3508,8 @@ export function getfontname(
  *
  *     GetFilename()->getfperm()
  *
+ * Return type: `String`
+ *
  * For setting permissions use `setfperm()`.
  */
 export function getfperm(denops: Denops, fname: unknown): Promise<string>;
@@ -3200,6 +3528,8 @@ export function getfperm(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetFilename()->getfsize()
+ *
+ * Return type: `Number`
  */
 export function getfsize(denops: Denops, fname: unknown): Promise<number>;
 export function getfsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -3216,6 +3546,8 @@ export function getfsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetFilename()->getftime()
+ *
+ * Return type: `Number`
  */
 export function getftime(denops: Denops, fname: unknown): Promise<number>;
 export function getftime(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -3248,6 +3580,8 @@ export function getftime(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetFilename()->getftype()
+ *
+ * Return type: `String`
  */
 export function getftype(denops: Denops, fname: unknown): Promise<string>;
 export function getftype(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -3277,6 +3611,8 @@ export function getftype(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetWinnr()->getjumplist()
+ *
+ * Return type: list<any>
  */
 export function getjumplist(
   denops: Denops,
@@ -3321,6 +3657,8 @@ export function getjumplist(
  *
  *     :echo getloclist(3, {'all': 0})
  *     :echo getloclist(5, {'filewinid': 0})
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function getloclist(
   denops: Denops,
@@ -3365,6 +3703,8 @@ export function getloclist(
  *         'pattern': 'FIXME', 'priority': 10, 'id': 2}]
  *
  *             :unlet m
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function getmatches(denops: Denops, win?: unknown): Promise<unknown[]>;
 export function getmatches(
@@ -3389,8 +3729,9 @@ export function getmatches(
  *                         start of the clicked char
  * All numbers are 1-based.
  *
- * If not over a window, e.g. when in the command line, then only
- * "screenrow" and "screencol" are valid, the others are zero.
+ * If not over a window, e.g. when in the command line or within
+ * `tabpanel`, then only "screenrow" and "screencol" are valid,
+ * the others are zero.
  *
  * When on the status line below a window or the vertical
  * separator right of a window, the "line" and "column" values
@@ -3403,6 +3744,8 @@ export function getmatches(
  *
  * When using `getchar()` the Vim variables `v:mouse_lnum`,
  * `v:mouse_col` and `v:mouse_winid` also provide these values.
+ *
+ * Return type: dict<number>
  */
 export function getmousepos(denops: Denops): Promise<Record<string, unknown>>;
 export function getmousepos(
@@ -3416,6 +3759,8 @@ export function getmousepos(
  * Return a Number which is the process ID of the Vim process.
  * On Unix and MS-Windows this is a unique number, until Vim
  * exits.
+ *
+ * Return type: `Number`
  */
 export function getpid(denops: Denops): Promise<number>;
 export function getpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -3526,6 +3871,8 @@ export function getpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :echo getqflist({'all': 1})
  *     :echo getqflist({'nr': 2, 'title': 1})
  *     :echo getqflist({'lines' : ["F1:10:L10"]})
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function getqflist(
   denops: Denops,
@@ -3568,6 +3915,8 @@ export function getqflist(
  * Can also be used as a `method`:
  *
  *     GetRegname()->getreg()
+ *
+ * Return type: `String` or list<string> depending on **{list}**
  */
 export function getreg(
   denops: Denops,
@@ -3622,6 +3971,10 @@ export function getreg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * - It is evaluated in current window context, which makes a
  *   difference if the buffer is displayed in a window with
  *   different 'virtualedit' or 'list' values.
+ * - When specifying an exclusive selection and **{pos1}** and **{pos2}**
+ *   are equal, the returned list contains a single character as
+ *   if selection is inclusive, to match the behavior of an empty
+ *   exclusive selection in Visual mode.
  *
  * Examples:
  *
@@ -3632,6 +3985,8 @@ export function getreg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     getpos('.')->getregion(getpos("'a"))
+ *
+ * Return type: list<string>
  */
 export function getregion(
   denops: Denops,
@@ -3644,6 +3999,60 @@ export function getregion(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("getregion", ...args);
+}
+
+/**
+ * Same as `getregion()`, but returns a list of positions
+ * describing the buffer text segments bound by **{pos1}** and
+ * **{pos2}**.
+ * The segments are a pair of positions for every line:
+ *
+ *     [[{start_pos}, {end_pos}], ...]
+ *
+ * The position is a `List` with four numbers:
+ *     [bufnum, lnum, col, off]
+ * "bufnum" is the buffer number.
+ * "lnum" and "col" are the position in the buffer.  The first
+ * column is 1.
+ * If the "off" number of a starting position is non-zero, it is
+ * the offset in screen columns from the start of the character.
+ * E.g., a position within a `<Tab>` or after the last character.
+ * If the "off" number of an ending position is non-zero, it is
+ * the offset of the character's first cell not included in the
+ * selection, otherwise all its cells are included.
+ *
+ * Apart from the options supported by `getregion()`, **{opts}** also
+ * supports the following:
+ *
+ *         eol             If `TRUE`, indicate positions beyond
+ *                         the end of a line with "col" values
+ *                         one more than the length of the line.
+ *                         If `FALSE`, positions are limited
+ *                         within their lines, and if a line is
+ *                         empty or the selection is entirely
+ *                         beyond the end of a line, a "col"
+ *                         value of 0 is used for both positions.
+ *                         (default: `FALSE`)
+ *
+ * Can also be used as a `method`:
+ *
+ *     getpos('.')->getregionpos(getpos("'a"))
+ *
+ * For an example, see the highlight-yank plugin `52.6`
+ *
+ * Return type: list<list<list<number>>>
+ */
+export function getregionpos(
+  denops: Denops,
+  pos1: unknown,
+  pos2: unknown,
+  opts?: unknown,
+): Promise<unknown[]>;
+export function getregionpos(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("getregionpos", ...args);
 }
 
 /**
@@ -3662,6 +4071,8 @@ export function getregion(
  * Can also be used as a `method`:
  *
  *     GetRegname()->getregtype()
+ *
+ * Return type: `String`
  */
 export function getregtype(denops: Denops, regname?: unknown): Promise<string>;
 export function getregtype(
@@ -3712,6 +4123,8 @@ export function getregtype(
  *
  *     :echo getscriptinfo({'name': 'myscript'})
  *     :echo getscriptinfo({'sid': 15})[0].variables
+ *
+ * Return type: list<dict<any>>
  */
 export function getscriptinfo(
   denops: Denops,
@@ -3722,6 +4135,28 @@ export function getscriptinfo(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("getscriptinfo", ...args);
+}
+
+/**
+ * Returns the current stack trace of Vim scripts.
+ * Stack trace is a `List`, of which each item is a `Dictionary`
+ * with the following items:
+ *     funcref     The funcref if the stack is at a function,
+ *                 otherwise this item is omitted.
+ *     event       The string of the event description if the
+ *                 stack is at an autocmd event, otherwise this
+ *                 item is omitted.
+ *     lnum        The line number in the script on the stack.
+ *     filepath    The file path of the script on the stack.
+ *
+ * Return type: list<dict<any>>
+ */
+export function getstacktrace(denops: Denops): Promise<unknown[]>;
+export function getstacktrace(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("getstacktrace", ...args);
 }
 
 /**
@@ -3740,6 +4175,8 @@ export function getscriptinfo(
  * Can also be used as a `method`:
  *
  *     GetTabnr()->gettabinfo()
+ *
+ * Return type: list<dict<any>>
  */
 export function gettabinfo(denops: Denops, tabnr?: unknown): Promise<unknown[]>;
 export function gettabinfo(
@@ -3762,6 +4199,8 @@ export function gettabinfo(
  * Can also be used as a `method`:
  *
  *     GetTabnr()->gettabvar(varname)
+ *
+ * Return type: any, depending on **{varname}**
  */
 export function gettabvar(
   denops: Denops,
@@ -3807,6 +4246,8 @@ export function gettabvar(
  * Can also be used as a `method`:
  *
  *     GetTabnr()->gettabwinvar(winnr, varname)
+ *
+ * Return type: any, depending on **{varname}**
  */
 export function gettabwinvar(
   denops: Denops,
@@ -3853,6 +4294,8 @@ export function gettabwinvar(
  * Can also be used as a `method`:
  *
  *     GetWinnr()->gettagstack()
+ *
+ * Return type: dict<any>
  */
 export function gettagstack(
   denops: Denops,
@@ -3867,16 +4310,26 @@ export function gettagstack(
 
 /**
  * Translate String **{text}** if possible.
- * This is mainly for use in the distributed Vim scripts.  When
- * generating message translations the **{text}** is extracted by
- * xgettext, the translator can add the translated message in the
- * .po file and Vim will lookup the translation when gettext() is
- * called.
+ * This is intended for use in Vim scripts.  When generating
+ * message translations the **{text}** is extracted by `xgettext`,
+ * the translator can add translated messages into the .po file
+ * and Vim will lookup the translation when gettext() is called.
  * For **{text}** double quoted strings are preferred, because
- * xgettext does not understand escaping in single quoted
- * strings.
+ * `xgettext` does not support single quoted escaped text.
+ *
+ * When the **{package}** is specified, the translation is looked up
+ * for that specific package.  This is mainly required for
+ * third-party Vim scripts.  You need to specify a path to the
+ * translations with the `bindtextdomain()` function before
+ * using the gettext() function.
+ *
+ * Return type: `String`
  */
-export function gettext(denops: Denops, text: unknown): Promise<string>;
+export function gettext(
+  denops: Denops,
+  text: unknown,
+  package_?: unknown,
+): Promise<string>;
 export function gettext(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("gettext", ...args);
 }
@@ -3888,6 +4341,8 @@ export function gettext(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The result will be -1 if the information is not available
  * (e.g. on the Wayland backend).
  * The value can be used with `:winpos`.
+ *
+ * Return type: `Number`
  */
 export function getwinposx(denops: Denops): Promise<number>;
 export function getwinposx(
@@ -3904,6 +4359,8 @@ export function getwinposx(
  * The result will be -1 if the information is not available
  * (e.g. on the Wayland backend).
  * The value can be used with `:winpos`.
+ *
+ * Return type: `Number`
  */
 export function getwinposy(denops: Denops): Promise<number>;
 export function getwinposy(
@@ -3923,6 +4380,8 @@ export function getwinposy(
  * Can also be used as a `method`:
  *
  *     GetWinnr()->getwinvar(varname)
+ *
+ * Return type: any, depending on **{varname}**
  */
 export function getwinvar(
   denops: Denops,
@@ -3978,6 +4437,9 @@ export function getwinvar(
  * Can also be used as a `method`:
  *
  *     GetExpr()->glob()
+ *
+ * Return type: `String` or list<string> or list<any> depending
+ * on **{list}**
  */
 export function glob(
   denops: Denops,
@@ -4009,6 +4471,8 @@ export function glob(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetExpr()->glob2regpat()
+ *
+ * Return type: `String`
  */
 export function glob2regpat(denops: Denops, string: unknown): Promise<string>;
 export function glob2regpat(
@@ -4061,6 +4525,9 @@ export function glob2regpat(
  * second argument:
  *
  *     GetExpr()->globpath(&rtp)
+ *
+ * Return type: `String` or list<string> or list<any> depending
+ * on **{list}**
  */
 export function globpath(
   denops: Denops,
@@ -4085,6 +4552,8 @@ export function globpath(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mydict->has_key(key)
+ *
+ * Return type: `Number`
  */
 export function has_key(
   denops: Denops,
@@ -4133,6 +4602,8 @@ export function has_key(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetWinnr()->haslocaldir()
+ *
+ * Return type: `Number`
  */
 export function haslocaldir(
   denops: Denops,
@@ -4182,6 +4653,8 @@ export function haslocaldir(
  * Can also be used as a `method`:
  *
  *     GetRHS()->hasmapto()
+ *
+ * Return type: `Number`
  */
 export function hasmapto(
   denops: Denops,
@@ -4220,6 +4693,8 @@ export function hasmapto(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * second argument:
  *
  *     GetHistory()->histadd('search')
+ *
+ * Return type: `Number`
  */
 export function histadd(
   denops: Denops,
@@ -4269,6 +4744,8 @@ export function histadd(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetHistory()->histdel()
+ *
+ * Return type: `Number`
  */
 export function histdel(
   denops: Denops,
@@ -4299,6 +4776,8 @@ export function histdel(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetHistory()->histget()
+ *
+ * Return type: `String`
  */
 export function histget(
   denops: Denops,
@@ -4321,6 +4800,8 @@ export function histget(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetHistory()->histnr()
+ *
+ * Return type: `Number`
  */
 export function histnr(denops: Denops, history: unknown): Promise<number>;
 export function histnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4339,6 +4820,8 @@ export function histnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->hlexists()
+ *
+ * Return type: `Number`
  */
 export function hlexists(denops: Denops, name: unknown): Promise<number>;
 export function hlexists(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4360,6 +4843,8 @@ export function hlexists(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->hlID()
+ *
+ * Return type: `Number`
  */
 export function hlID(denops: Denops, name: unknown): Promise<number>;
 export function hlID(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4370,6 +4855,8 @@ export function hlID(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * The result is a String, which is the name of the machine on
  * which Vim is currently running.  Machine names greater than
  * 256 characters long are truncated.
+ *
+ * Return type: `String`
  */
 export function hostname(denops: Denops): Promise<string>;
 export function hostname(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4400,6 +4887,8 @@ export function hostname(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->iconv('latin1', 'utf-8')
+ *
+ * Return type: `String`
  */
 export function iconv(
   denops: Denops,
@@ -4409,6 +4898,41 @@ export function iconv(
 ): Promise<string>;
 export function iconv(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("iconv", ...args);
+}
+
+/**
+ * The result is a unique String associated with the **{item}** and
+ * not with the **{item}**'s contents. It is only valid while the
+ * **{item}** exists and is referenced. It is valid only in the
+ * instance of vim that produces the result. The whole idea is
+ * that `id({item})` does not change if the contents of **{item}**
+ * changes. This is useful as a `key` for creating an identity
+ * dictionary, rather than one based on equals.
+ *
+ * This operation does not reference **{item}** and there is no
+ * function to convert the `id` to the **{item}**. It may be useful to
+ * have a map of `id` to **{item}**. The following
+ *
+ *     var referenceMap: dict<any>
+ *     var id = item->id()
+ *     referenceMap[id] = item
+ *
+ * prevents **{item}** from being garbage collected and provides a
+ * way to get the **{item}** from the `id`.
+ *
+ * **{item}** may be a List, Tuple, Dictionary, Object, Job, Channel
+ * or Blob. If the item is not a permitted type, or it is a null
+ * value, then an empty String is returned.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetItem()->id()
+ *
+ * Return type: `String`
+ */
+export function id(denops: Denops, item: unknown): Promise<string>;
+export function id(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("id", ...args);
 }
 
 /**
@@ -4422,6 +4946,8 @@ export function iconv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->indent()
+ *
+ * Return type: `Number`
  */
 export function indent(denops: Denops, lnum: unknown): Promise<number>;
 export function indent(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4432,12 +4958,12 @@ export function indent(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Find **{expr}** in **{object}** and return its index.  See
  * `indexof()` for using a lambda to select the item.
  *
- * If **{object}** is a `List` return the lowest index where the item
- * has a value equal to **{expr}**.  There is no automatic
- * conversion, so the String "4" is different from the Number 4.
- * And the number 4 is different from the Float 4.0.  The value
- * of 'ignorecase' is not used here, case matters as indicated by
- * the **{ic}** argument.
+ * If **{object}** is a `List` or a `Tuple` return the lowest index
+ * where the item has a value equal to **{expr}**.  There is no
+ * automatic conversion, so the String "4" is different from the
+ * Number 4.  And the number 4 is different from the Float 4.0.
+ * The value of 'ignorecase' is not used here, case matters as
+ * indicated by the **{ic}** argument.
  *
  * If **{object}** is `Blob` return the lowest index where the byte
  * value is equal to **{expr}**.
@@ -4457,6 +4983,8 @@ export function indent(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetObject()->index(what)
+ *
+ * Return type: `Number`
  */
 export function index(
   denops: Denops,
@@ -4471,11 +4999,11 @@ export function index(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * Returns the index of an item in **{object}** where **{expr}** is
- * v:true.  **{object}** must be a `List` or a `Blob`.
+ * v:true.  **{object}** must be a `List`, a `Tuple` or a `Blob`.
  *
- * If **{object}** is a `List`, evaluate **{expr}** for each item in the
- * List until the expression is v:true and return the index of
- * this item.
+ * If **{object}** is a `List` or a `Tuple`, evaluate **{expr}** for each
+ * item in the List or Tuple until the expression is v:true
+ * and return the index of this item.
  *
  * If **{object}** is a `Blob` evaluate **{expr}** for each byte in the
  * Blob until the expression is v:true and return the index of
@@ -4483,11 +5011,11 @@ export function index(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * **{expr}** must be a `string` or `Funcref`.
  *
- * If **{expr}** is a `string`: If **{object}** is a `List`, inside
- * **{expr}** `v:key` has the index of the current List item and
- * `v:val` has the value of the item.  If **{object}** is a `Blob`,
- * inside **{expr}** `v:key` has the index of the current byte and
- * `v:val` has the byte value.
+ * If **{expr}** is a `string`: If **{object}** is a `List` or a `Tuple`,
+ * inside **{expr}** `v:key` has the index of the current List or
+ * Tuple item and `v:val` has the value of the item.  If **{object}**
+ * is a `Blob`, inside **{expr}** `v:key` has the index of the
+ * current byte and `v:val` has the byte value.
  *
  * If **{expr}** is a `Funcref` it must take two arguments:
  *         1. the key or the index of the current item.
@@ -4511,6 +5039,8 @@ export function index(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->indexof(expr)
+ *
+ * Return type: `Number`
  */
 export function indexof(
   denops: Denops,
@@ -4544,6 +5074,8 @@ export function indexof(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->insert(item)
+ *
+ * Return type: `Number`
  */
 export function insert(
   denops: Denops,
@@ -4568,6 +5100,8 @@ export function insert(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :   endif
  *     :endfunction
  *     :au BufWritePre * call s:check_typoname(expand('<amatch>'))
+ *
+ * Return type: void
  */
 export function interrupt(denops: Denops): Promise<void>;
 export function interrupt(
@@ -4586,10 +5120,41 @@ export function interrupt(
  * Can also be used as a `method`:
  *
  *     :let bits = bits->invert()
+ *
+ * Return type: `Number`
  */
 export function invert(denops: Denops, expr: unknown): Promise<number>;
 export function invert(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("invert", ...args);
+}
+
+/**
+ * The result is a Number, which is `TRUE` when **{path}** is an
+ * absolute path.
+ * On Unix, a path is considered absolute when it starts with '/'.
+ * On MS-Windows, it is considered absolute when it starts with an
+ * optional drive prefix and is followed by a '\' or '/'. UNC paths
+ * are always absolute.
+ * Example:
+ *
+ *     echo isabsolutepath('/usr/share/')      " 1
+ *     echo isabsolutepath('./foobar')         " 0
+ *     echo isabsolutepath('C:\Windows')       " 1
+ *     echo isabsolutepath('foobar')           " 0
+ *     echo isabsolutepath('\\remote\file')    " 1
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetName()->isabsolutepath()
+ *
+ * Return type: `Number`
+ */
+export function isabsolutepath(denops: Denops, path: unknown): Promise<number>;
+export function isabsolutepath(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("isabsolutepath", ...args);
 }
 
 /**
@@ -4601,6 +5166,8 @@ export function invert(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->isdirectory()
+ *
+ * Return type: `Number`
  */
 export function isdirectory(
   denops: Denops,
@@ -4628,6 +5195,8 @@ export function isdirectory(
  * Can also be used as a `method`:
  *
  *     Compute()->isinf()
+ *
+ * Return type: `Number`
  */
 export function isinf(denops: Denops, expr: unknown): Promise<number>;
 export function isinf(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4655,6 +5224,8 @@ export function isinf(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->islocked()
+ *
+ * Return type: `Number`
  */
 export function islocked(denops: Denops, expr: unknown): Promise<number>;
 export function islocked(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4671,6 +5242,8 @@ export function islocked(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->isnan()
+ *
+ * Return type: `Number`
  */
 export function isnan(denops: Denops, expr: unknown): Promise<number>;
 export function isnan(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4678,31 +5251,38 @@ export function isnan(denops: Denops, ...args: unknown[]): Promise<unknown> {
 }
 
 /**
- * Return a `List` with all the key-value pairs of **{dict}**.  Each
- * `List` item is a list with two items: the key of a **{dict}**
- * entry and the value of this entry.  The `List` is in arbitrary
- * order.  Also see `keys()` and `values()`.
- * Example:
+ * Return a `List` with all the key/index and value pairs of **{expr}**.
+ * Each `List` item is a list with two items:
+ * - for a `Dict`: the key and the value
+ * - for a `List`, `Tuple` or `String`: the index and the value
+ * The `List` is in arbitrary order.
  *
+ * Also see `keys()` and `values()`.
+ *
+ * Examples:
+ *
+ *     let mydict = #{a: 'red', b: 'blue'}
  *     for [key, value] in items(mydict)
- *        echo key .. ': ' .. value
+ *        echo $"{key} = {value}"
  *     endfor
- *
- * A List or a String argument is also supported.  In these
- * cases, items() returns a List with the index and the value at
- * the index.
+ *     echo items([1, 2, 3])
+ *     echo items(('a', 'b', 'c'))
+ *     echo items("foobar")
  *
  * Can also be used as a `method`:
  *
  *     mydict->items()
+ *
+ * Return type: list<list<any>> or list<any>
  */
-export function items(denops: Denops, dict: unknown): Promise<unknown[]>;
+export function items(denops: Denops, expr: unknown): Promise<unknown[]>;
 export function items(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("items", ...args);
 }
 
 /**
- * Join the items in **{list}** together into one String.
+ * Join the items in **{expr}** together into one String.  **{expr}** can
+ * be a `List` or a `Tuple`.
  * When **{sep}** is specified it is put in between the items.  If
  * **{sep}** is omitted a single space is used.
  * Note that **{sep}** is not added at the end.  You might want to
@@ -4710,17 +5290,19 @@ export function items(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     let lines = join(mylist, "\n") .. "\n"
  *
- * String items are used as-is.  `Lists` and `Dictionaries` are
- * converted into a string like with `string()`.
- * The opposite function is `split()`.
+ * String items are used as-is.  `Lists`, `Tuples` and
+ * `Dictionaries` are converted into a string like with
+ * `string()`.  The opposite function is `split()`.
  *
  * Can also be used as a `method`:
  *
  *     mylist->join()
+ *
+ * Return type: `String`
  */
 export function join(
   denops: Denops,
-  list: unknown,
+  expr: unknown,
   sep?: unknown,
 ): Promise<string>;
 export function join(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4763,6 +5345,8 @@ export function join(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     ReadObject()->json_decode()
+ *
+ * Return type: any, depending on **{varname}**
  */
 export function json_decode(denops: Denops, string: unknown): Promise<unknown>;
 export function json_decode(
@@ -4786,6 +5370,8 @@ export function json_decode(
  *    `Funcref`            not possible, error
  *    `List`               as an array (possibly null); when
  *                         used recursively: []
+ *    `Tuple`              as an array (possibly null); when
+ *                         used recursively: []
  *    `Dict`               as an object (possibly null); when
  *                         used recursively: {}
  *    `Blob`               as an array of the individual bytes
@@ -4802,6 +5388,8 @@ export function json_decode(
  * Can also be used as a `method`:
  *
  *     GetObject()->json_encode()
+ *
+ * Return type: `String`
  */
 export function json_encode(denops: Denops, expr: unknown): Promise<string>;
 export function json_encode(
@@ -4818,6 +5406,8 @@ export function json_encode(
  * Can also be used as a `method`:
  *
  *     mydict->keys()
+ *
+ * Return type: list<string>
  */
 export function keys(denops: Denops, dict: unknown): Promise<unknown[]>;
 export function keys(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4836,6 +5426,8 @@ export function keys(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     "\<C-Home>"->keytrans()
+ *
+ * Return type: `String`
  */
 export function keytrans(denops: Denops, string: unknown): Promise<string>;
 export function keytrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4848,6 +5440,8 @@ export function keytrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * used, as with `strlen()`.
  * When **{expr}** is a `List` the number of items in the `List` is
  * returned.
+ * When **{expr}** is a `Tuple` the number of items in the `Tuple` is
+ * returned.
  * When **{expr}** is a `Blob` the number of bytes is returned.
  * When **{expr}** is a `Dictionary` the number of entries in the
  * `Dictionary` is returned.
@@ -4858,6 +5452,8 @@ export function keytrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->len()
+ *
+ * Return type: `Number`
  */
 export function len(denops: Denops, expr: unknown): Promise<number>;
 export function len(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4928,7 +5524,7 @@ export function libcall(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Just like `libcall()`, but used for a function that returns an
  * int instead of a string.
- * *only in Win32 on some Unix versions, when the `+libcall`
+ * *only in Win32 and some Unix versions, when the `+libcall`
  * feature is present*
  * Examples:
  *
@@ -4940,6 +5536,8 @@ export function libcall(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * third argument:
  *
  *     GetValue()->libcallnr("libc.so", "printf")
+ *
+ * Return type: `String`
  */
 export function libcallnr(
   denops: Denops,
@@ -4965,6 +5563,8 @@ export function libcallnr(
  * Can also be used as a `method`:
  *
  *     GetLnum()->lispindent()
+ *
+ * Return type: `Number`
  */
 export function lispindent(denops: Denops, lnum: unknown): Promise<number>;
 export function lispindent(
@@ -4989,6 +5589,8 @@ export function lispindent(
  * Can also be used as a `method`:
  *
  *     GetList()->list2blob()
+ *
+ * Return type: `Blob`
  */
 export function list2blob(denops: Denops, list: unknown): Promise<unknown>;
 export function list2blob(
@@ -4999,8 +5601,8 @@ export function list2blob(
 }
 
 /**
- * Convert each number in **{list}** to a character string can
- * concatenate them all.  Examples:
+ * Convert each number in **{list}** to a character string and
+ * concatenates them all.  Examples:
  *
  *     list2str([32])          returns " "
  *     list2str([65, 66, 67])  returns "ABC"
@@ -5022,6 +5624,8 @@ export function list2blob(
  * Can also be used as a `method`:
  *
  *     GetList()->list2str()
+ *
+ * Return type: `String`
  */
 export function list2str(
   denops: Denops,
@@ -5035,6 +5639,8 @@ export function list2str(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Return the current time, measured as seconds since 1st Jan
  * 1970.  See also `strftime()`, `strptime()` and `getftime()`.
+ *
+ * Return type: `Number`
  */
 export function localtime(denops: Denops): Promise<number>;
 export function localtime(
@@ -5062,6 +5668,8 @@ export function localtime(
  * Can also be used as a `method`:
  *
  *     Compute()->log()
+ *
+ * Return type: `Float`
  */
 export function log(denops: Denops, expr: unknown): Promise<number>;
 export function log(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -5085,6 +5693,8 @@ export function log(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->log10()
+ *
+ * Return type: `Float`
  */
 export function log10(denops: Denops, expr: unknown): Promise<number>;
 export function log10(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -5108,6 +5718,8 @@ export function log10(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetExpr()->luaeval()
+ *
+ * Return type: any, depending on **{expr}**
  *
  * *only available when compiled with the `+lua` feature*
  */
@@ -5192,6 +5804,9 @@ export function luaeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->map(expr2)
+ *
+ * Return type: `String`, `Blob`, list<**{type}**> or dict<**{type}**>
+ * depending on **{expr1}**
  */
 export function map(
   denops: Denops,
@@ -5278,6 +5893,8 @@ export function map(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetKey()->maparg('n')
+ *
+ * Return type: `String` or dict<any> depending on **{dict}**
  */
 export function maparg(
   denops: Denops,
@@ -5328,6 +5945,8 @@ export function maparg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetKey()->mapcheck('n')
+ *
+ * Return type: `String`
  */
 export function mapcheck(
   denops: Denops,
@@ -5376,6 +5995,8 @@ export function mapcheck(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         (_, m) => m.lhs == 'xyzzy')[0].mode_bits
  *     ounmap xyzzy
  *     echo printf("Operator-pending mode bit: 0x%x", op_bit)
+ *
+ * Return type: list<dict<any>>
  */
 export function maplist(denops: Denops, abbr?: unknown): Promise<unknown[]>;
 export function maplist(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -5387,6 +6008,9 @@ export function maplist(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * List or Dictionary is created and returned.  **{expr1}** remains
  * unchanged.  Items can still be changed by **{expr2}**, if you
  * don't want that use `deepcopy()` first.
+ *
+ * Return type: `String`, `Blob`, list<**{type}**> or dict<**{type}**>
+ * depending on **{expr1}**
  */
 export function mapnew(
   denops: Denops,
@@ -5436,6 +6060,8 @@ export function mapnew(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     for d in save_maps
  *         mapset(d)
  *     endfor
+ *
+ * Return type: `Number`
  */
 export function mapset(
   denops: Denops,
@@ -5526,6 +6152,8 @@ export function mapset(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetText()->match('word')
  *     GetList()->match('word')
+ *
+ * Return type: `Number`
  */
 export function match(
   denops: Denops,
@@ -5602,6 +6230,8 @@ export function match(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetGroup()->matchadd('TODO')
+ *
+ * Return type: `Number`
  */
 export function matchadd(
   denops: Denops,
@@ -5618,10 +6248,10 @@ export function matchadd(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Same as `matchadd()`, but requires a list of positions **{pos}**
  * instead of a pattern. This command is faster than `matchadd()`
- * because it does not require to handle regular expressions and
- * sets buffer line boundaries to redraw screen. It is supposed
- * to be used when fast match additions and deletions are
- * required, for example to highlight matching parentheses.
+ * because it does not handle regular expressions and it sets
+ * buffer line boundaries to redraw screen. It is supposed to be
+ * used when fast match additions and deletions are required, for
+ * example to highlight matching parentheses.
  *
  * **{pos}** is a list of positions.  Each position can be one of
  * these:
@@ -5654,6 +6284,8 @@ export function matchadd(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetGroup()->matchaddpos([23, 11])
+ *
+ * Return type: `Number`
  */
 export function matchaddpos(
   denops: Denops,
@@ -5685,6 +6317,8 @@ export function matchaddpos(
  * Can also be used as a `method`:
  *
  *     GetMatch()->matcharg()
+ *
+ * Return type: list<string>
  */
 export function matcharg(denops: Denops, nr: unknown): Promise<unknown[]>;
 export function matcharg(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -5724,7 +6358,8 @@ export function matcharg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     [{'lnum': 3, 'byteidx': 0, 'text': 'a'}]
  *     " Assuming line 4 in buffer 10 contains "tik tok"
  *     :echo matchbufline(10, '\<\k\+\>', 1, 4)
- *     [{'lnum': 4, 'byteidx': 0, 'text': 'tik'}, {'lnum': 4, 'byteidx': 4, 'text': 'tok'}]
+ *     [{'lnum': 4, 'byteidx': 0, 'text': 'tik'},
+ *      {'lnum': 4, 'byteidx': 4, 'text': 'tok'}]
  *
  * If **{submatch}** is present and is v:true, then submatches like
  * "\1", "\2", etc. are also returned.  Example:
@@ -5732,7 +6367,8 @@ export function matcharg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     " Assuming line 2 in buffer 2 contains "acd"
  *     :echo matchbufline(2, '\(a\)\?\(b\)\?\(c\)\?\(.*\)', 2, 2
  *                                 \ {'submatches': v:true})
- *     [{'lnum': 2, 'byteidx': 0, 'text': 'acd', 'submatches': ['a', '', 'c', 'd', '', '', '', '', '']}]
+ *     [{'lnum': 2, 'byteidx': 0, 'text': 'acd', 'submatches':
+ *     ['a', '', 'c', 'd', '', '', '', '', '']}]
  *
  * The "submatches" List always contains 9 items.  If a submatch
  * is not found, then an empty string is returned for that
@@ -5741,6 +6377,8 @@ export function matcharg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetBuffer()->matchbufline('mypat', 1, '$')
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function matchbufline(
   denops: Denops,
@@ -5768,6 +6406,8 @@ export function matchbufline(
  * Can also be used as a `method`:
  *
  *     GetMatch()->matchdelete()
+ *
+ * Return type: `Number`
  */
 export function matchdelete(
   denops: Denops,
@@ -5811,6 +6451,8 @@ export function matchdelete(
  * Can also be used as a `method`:
  *
  *     GetText()->matchend('word')
+ *
+ * Return type: `Number`
  */
 export function matchend(
   denops: Denops,
@@ -5901,6 +6543,8 @@ export function matchend(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *                                  \ {'matchseq': 1})
  *
  * results in ['two one'].
+ *
+ * Return type: list<string> or list<any>
  */
 export function matchfuzzy(
   denops: Denops,
@@ -5938,9 +6582,12 @@ export function matchfuzzy(
  *
  * results in [['lacy', 'clay'], [[0, 1], [1, 2]], [153, 133]]
  *
- *     :echo [{'text': 'hello', 'id' : 10}]->matchfuzzypos('ll', {'key' : 'text'})
+ *     :echo [{'text': 'hello', 'id' : 10}]
+ *       \ ->matchfuzzypos('ll', {'key' : 'text'})
  *
  * results in [[{'id': 10, 'text': 'hello'}], [[2, 3]], [127]]
+ *
+ * Return type: list<list<any>>
  */
 export function matchfuzzypos(
   denops: Denops,
@@ -5972,6 +6619,8 @@ export function matchfuzzypos(
  * Can also be used as a `method`:
  *
  *     GetText()->matchlist('word')
+ *
+ * Return type: list<string> or list<any>
  */
 export function matchlist(
   denops: Denops,
@@ -6008,16 +6657,19 @@ export function matchlist(
  * Example:
  *
  *     :echo matchstrlist(['tik tok'], '\<\k\+\>')
- *     [{'idx': 0, 'byteidx': 0, 'text': 'tik'}, {'idx': 0, 'byteidx': 4, 'text': 'tok'}]
+ *     [{'idx': 0, 'byteidx': 0, 'text': 'tik'},
+ *      {'idx': 0, 'byteidx': 4, 'text': 'tok'}]
  *     :echo matchstrlist(['a', 'b'], '\<\k\+\>')
- *     [{'idx': 0, 'byteidx': 0, 'text': 'a'}, {'idx': 1, 'byteidx': 0, 'text': 'b'}]
+ *     [{'idx': 0, 'byteidx': 0, 'text': 'a'},
+ *      {'idx': 1, 'byteidx': 0, 'text': 'b'}]
  *
  * If "submatches" is present and is v:true, then submatches like
  * "\1", "\2", etc. are also returned.  Example:
  *
  *     :echo matchstrlist(['acd'], '\(a\)\?\(b\)\?\(c\)\?\(.*\)',
  *                                 \ #{submatches: v:true})
- *     [{'idx': 0, 'byteidx': 0, 'text': 'acd', 'submatches': ['a', '', 'c', 'd', '', '', '', '', '']}]
+ *     [{'idx': 0, 'byteidx': 0, 'text': 'acd',
+ *       'submatches': ['a', '', 'c', 'd', '', '', '', '', '']}]
  *
  * The "submatches" List always contains 9 items.  If a submatch
  * is not found, then an empty string is returned for that
@@ -6026,6 +6678,8 @@ export function matchlist(
  * Can also be used as a `method`:
  *
  *     GetListOfStrings()->matchstrlist('mypat')
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function matchstrlist(
   denops: Denops,
@@ -6062,6 +6716,8 @@ export function matchstrlist(
  * Can also be used as a `method`:
  *
  *     GetText()->matchstr('word')
+ *
+ * Return type: `String`
  */
 export function matchstr(
   denops: Denops,
@@ -6103,6 +6759,8 @@ export function matchstr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->matchstrpos('word')
+ *
+ * Return type: list<any>
  */
 export function matchstrpos(
   denops: Denops,
@@ -6123,15 +6781,18 @@ export function matchstrpos(
  *
  *     echo max([apples, pears, oranges])
  *
- * **{expr}** can be a `List` or a `Dictionary`.  For a Dictionary,
- * it returns the maximum of all values in the Dictionary.
- * If **{expr}** is neither a List nor a Dictionary, or one of the
- * items in **{expr}** cannot be used as a Number this results in
- * an error.  An empty `List` or `Dictionary` results in zero.
+ * **{expr}** can be a `List`, a `Tuple` or a `Dictionary`.  For a
+ * Dictionary, it returns the maximum of all values in the
+ * Dictionary.  If **{expr}** is neither a List nor a Tuple nor a
+ * Dictionary, or one of the items in **{expr}** cannot be used as a
+ * Number this results in an error.  An empty `List`, `Tuple`
+ * or `Dictionary` results in zero.
  *
  * Can also be used as a `method`:
  *
  *     mylist->max()
+ *
+ * Return type: `Number`
  */
 export function max(denops: Denops, expr: unknown): Promise<number>;
 export function max(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -6212,6 +6873,8 @@ export function max(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetMenuName()->menu_info('v')
+ *
+ * Return type: dict<any>
  */
 export function menu_info(
   denops: Denops,
@@ -6230,15 +6893,18 @@ export function menu_info(
  *
  *     echo min([apples, pears, oranges])
  *
- * **{expr}** can be a `List` or a `Dictionary`.  For a Dictionary,
- * it returns the minimum of all values in the Dictionary.
- * If **{expr}** is neither a List nor a Dictionary, or one of the
- * items in **{expr}** cannot be used as a Number this results in
- * an error.  An empty `List` or `Dictionary` results in zero.
+ * **{expr}** can be a `List`, a `Tuple` or a `Dictionary`.  For a
+ * Dictionary, it returns the minimum of all values in the
+ * Dictionary.  If **{expr}** is neither a List nor a Tuple nor a
+ * Dictionary, or one of the items in **{expr}** cannot be used as a
+ * Number this results in an error.  An empty `List`, `Tuple` or
+ * `Dictionary` results in zero.
  *
  * Can also be used as a `method`:
  *
  *     mylist->min()
+ *
+ * Return type: `Number`
  */
 export function min(denops: Denops, expr: unknown): Promise<number>;
 export function min(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -6251,18 +6917,12 @@ export function min(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * When **{flags}** is present it must be a string.  An empty string
  * has no effect.
  *
- * If **{flags}** contains "p" then intermediate directories are
- * created as necessary.
- *
- * If **{flags}** contains "D" then **{name}** is deleted at the end of
- * the current function, as with:
- *
- *     defer delete({name}, 'd')
- *
- * If **{flags}** contains "R" then **{name}** is deleted recursively at
- * the end of the current function, as with:
- *
- *     defer delete({name}, 'rf')
+ * **{flags}** can contain these character flags:
+ *  "p"    intermediate directories will be created as necessary
+ *  "D"    **{name}** will be deleted at the end of the current
+ *         function, but not recursively `:defer`
+ *  "R"    **{name}** will be deleted recursively at the end of the
+ *         current function `:defer`
  *
  * Note that when **{name}** has more than one part and "p" is used
  * some directories may already exist.  Only the first one that
@@ -6282,9 +6942,8 @@ export function min(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * If **{prot}** is given it is used to set the protection bits of
  * the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
  * the user, readable for others).  Use 0o700 to make it
- * unreadable for others.  This is only used for the last part of
- * **{name}**.  Thus if you create /tmp/foo/bar then /tmp/foo will be
- * created with 0o755.
+ * unreadable for others.  This is used for the newly created
+ * directories.  Note: umask is applied to **{prot}** (on Unix).
  * Example:
  *
  *     :call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
@@ -6306,6 +6965,8 @@ export function min(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->mkdir()
+ *
+ * Return type: `Number`
  */
 export function mkdir(
   denops: Denops,
@@ -6331,6 +6992,8 @@ export function mkdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->nextnonblank()
+ *
+ * Return type: `Number`
  */
 export function nextnonblank(denops: Denops, lnum: unknown): Promise<number>;
 export function nextnonblank(
@@ -6367,6 +7030,8 @@ export function nextnonblank(
  * Can also be used as a `method`:
  *
  *     GetNumber()->nr2char()
+ *
+ * Return type: `String`
  */
 export function nr2char(
   denops: Denops,
@@ -6393,6 +7058,8 @@ export function nr2char(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * character like many languages, is that Vi has always used "|"
  * to separate commands.  In many places it would not be clear if
  * "|" is an operator or a command separator.
+ *
+ * Return type: `Number`
  */
 export function or(
   denops: Denops,
@@ -6423,6 +7090,8 @@ export function or(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetDirectories()->pathshorten()
+ *
+ * Return type: `String`
  */
 export function pathshorten(
   denops: Denops,
@@ -6455,6 +7124,8 @@ export function pathshorten(
  *
  *     GetExpr()->perleval()
  *
+ * Return type: any, depending on **{expr}**
+ *
  * *only available when compiled with the `+perl` feature*
  */
 export function perleval(denops: Denops, expr: unknown): Promise<unknown>;
@@ -6483,6 +7154,8 @@ export function perleval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->pow(3)
+ *
+ * Return type: `Number`
  */
 export function pow(denops: Denops, x: unknown, y: unknown): Promise<number>;
 export function pow(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -6503,6 +7176,8 @@ export function pow(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->prevnonblank()
+ *
+ * Return type: `Number`
  */
 export function prevnonblank(denops: Denops, lnum: unknown): Promise<number>;
 export function prevnonblank(
@@ -6788,7 +7463,8 @@ export function prevnonblank(
  *       1.41
  *
  * You will get an overflow error `E1510`, when the field-width
- * or precision will result in a string longer than 6400 chars.
+ * or precision will result in a string longer than 1 MiB
+ * (1024*1024 = 1048576) chars.
  *
  * You cannot mix positional and non-positional arguments:
  *
@@ -6858,6 +7534,8 @@ export function prevnonblank(
  * otherwise reported.  Please file a bug against Vim if you run
  * into this, copying the exact format string and parameters that
  * were used.
+ *
+ * Return type: `String`
  */
 export function printf(
   denops: Denops,
@@ -6878,6 +7556,8 @@ export function printf(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetBuffer()->prompt_getprompt()
+ *
+ * Return type: `String`
  *
  * *only available when compiled with the `+channel` feature*
  */
@@ -6953,6 +7633,8 @@ export function prompt_setcallback(
  *
  *     GetBuffer()->prompt_setinterrupt(callback)
  *
+ * Return type: `Number`
+ *
  * *only available when compiled with the `+channel` feature*
  */
 export function prompt_setinterrupt(
@@ -6978,6 +7660,8 @@ export function prompt_setinterrupt(
  * Can also be used as a `method`:
  *
  *     GetBuffer()->prompt_setprompt('command: ')
+ *
+ * Return type: `Number`
  *
  * *only available when compiled with the `+channel` feature*
  */
@@ -7006,6 +7690,8 @@ export function prompt_setprompt(
  *
  * The values are the same as in `v:event` during
  * `CompleteChanged`.
+ *
+ * Return type: dict<any>
  */
 export function pum_getpos(denops: Denops): Promise<Record<string, unknown>>;
 export function pum_getpos(
@@ -7020,6 +7706,8 @@ export function pum_getpos(
  * otherwise.  See `ins-completion-menu`.
  * This can be used to avoid some things that would remove the
  * popup menu.
+ *
+ * Return type: `Number`
  */
 export function pumvisible(denops: Denops): Promise<number>;
 export function pumvisible(
@@ -7032,10 +7720,16 @@ export function pumvisible(
 /**
  * Evaluate Python expression **{expr}** and return its result
  * converted to Vim data structures.
+ * If a **{locals}** `Dictionary` is given, it defines set of local
+ * variables available in the expression. The keys are variable
+ * names and the values are the variable values. `Dictionary`,
+ * `List` and `Tuple` values are referenced, and may be updated
+ * by the expression (as if `python-bindeval` was used).
  * Numbers and strings are returned as they are (strings are
  * copied though, Unicode strings are additionally converted to
  * 'encoding').
  * Lists are represented as Vim `List` type.
+ * Tuples are represented as Vim `Tuple` type.
  * Dictionaries are represented as Vim `Dictionary` type with
  * keys converted to strings.
  * Note that in a `:def` function local variables are not visible
@@ -7044,10 +7738,17 @@ export function pumvisible(
  * Can also be used as a `method`:
  *
  *     GetExpr()->py3eval()
+ *     'b",".join(l)'->py3eval({'l': ['a', 'b', 'c']})
+ *
+ * Return type: any, depending on **{expr}**
  *
  * *only available when compiled with the `+python3` feature*
  */
-export function py3eval(denops: Denops, expr: unknown): Promise<unknown>;
+export function py3eval(
+  denops: Denops,
+  expr: unknown,
+  locals?: unknown,
+): Promise<unknown>;
 export function py3eval(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("py3eval", ...args);
 }
@@ -7055,9 +7756,11 @@ export function py3eval(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Evaluate Python expression **{expr}** and return its result
  * converted to Vim data structures.
+ * For **{locals}** see `py3eval()`.
  * Numbers and strings are returned as they are (strings are
  * copied though).
  * Lists are represented as Vim `List` type.
+ * Tuples are represented as Vim `Tuple` type.
  * Dictionaries are represented as Vim `Dictionary` type,
  * non-string keys result in error.
  * Note that in a `:def` function local variables are not visible
@@ -7067,9 +7770,15 @@ export function py3eval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetExpr()->pyeval()
  *
+ * Return type: any, depending on **{expr}**
+ *
  * *only available when compiled with the `+python` feature*
  */
-export function pyeval(denops: Denops, expr: unknown): Promise<unknown>;
+export function pyeval(
+  denops: Denops,
+  expr: unknown,
+  locals?: unknown,
+): Promise<unknown>;
 export function pyeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("pyeval", ...args);
 }
@@ -7077,6 +7786,7 @@ export function pyeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Evaluate Python expression **{expr}** and return its result
  * converted to Vim data structures.
+ * For **{locals}** see `py3eval()`.
  * Uses Python 2 or 3, see `python_x` and 'pyxversion'.
  * See also: `pyeval()`, `py3eval()`
  *
@@ -7084,10 +7794,16 @@ export function pyeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetExpr()->pyxeval()
  *
+ * Return type: any, depending on **{expr}**
+ *
  * *only available when compiled with the `+python` or the
  * `+python3` feature*
  */
-export function pyxeval(denops: Denops, expr: unknown): Promise<unknown>;
+export function pyxeval(
+  denops: Denops,
+  expr: unknown,
+  locals?: unknown,
+): Promise<unknown>;
 export function pyxeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("pyxeval", ...args);
 }
@@ -7107,6 +7823,8 @@ export function pyxeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :let seed = srand()
  *     :echo rand(seed)
  *     :echo rand(seed) % 16  " random number 0 - 15
+ *
+ * Return type: `Number`
  */
 export function rand(denops: Denops, expr?: unknown): Promise<number>;
 export function rand(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -7135,6 +7853,8 @@ export function rand(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetExpr()->range()
+ *
+ * Return type: list<number>
  */
 export function range(
   denops: Denops,
@@ -7175,6 +7895,8 @@ export function range(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * When trying to read more bytes than are available the result
  * is truncated.
  * Also see `readfile()` and `writefile()`.
+ *
+ * Return type: `Blob`
  */
 export function readblob(
   denops: Denops,
@@ -7248,6 +7970,8 @@ export function readblob(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetDirName()->readdir()
+ *
+ * Return type: list<string> or list<any>
  */
 export function readdir(
   denops: Denops,
@@ -7298,6 +8022,8 @@ export function readdir(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetFileName()->readfile()
+ *
+ * Return type: list<string> or list<any>
  */
 export function readfile(
   denops: Denops,
@@ -7311,8 +8037,8 @@ export function readfile(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * **{func}** is called for every item in **{object}**, which can be a
- * `String`, `List` or a `Blob`.  **{func}** is called with two
- * arguments: the result so far and current item.  After
+ * `String`, `List`, `Tuple` or a `Blob`.  **{func}** is called with
+ * two arguments: the result so far and current item.  After
  * processing all items the result is returned.
  *
  * **{initial}** is the initial result.  When omitted, the first item
@@ -7330,6 +8056,9 @@ export function readfile(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     echo mylist->reduce({ acc, val -> acc + val }, 0)
+ *
+ * Return type: `String`, `Blob`, list<**{type}**> or dict<**{type}**>
+ * depending on **{object}** and **{func}**
  */
 export function reduce(
   denops: Denops,
@@ -7345,6 +8074,8 @@ export function reduce(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Returns the single letter name of the register being executed.
  * Returns an empty string when no register is being executed.
  * See `@`.
+ *
+ * Return type: `String`
  */
 export function reg_executing(denops: Denops): Promise<string>;
 export function reg_executing(
@@ -7357,6 +8088,8 @@ export function reg_executing(
 /**
  * Returns the single letter name of the register being recorded.
  * Returns an empty string when not recording.  See `q`.
+ *
+ * Return type: `String`
  */
 export function reg_recording(denops: Denops): Promise<string>;
 export function reg_recording(
@@ -7394,8 +8127,12 @@ export function reg_recording(
  *
  *     GetStart()->reltime()
  *
+ * Return type: list<number>
+ *
  * *only available when compiled with the `+reltime` feature*
  */
+export function reltime(denops: Denops): Promise<unknown[]>;
+export function reltime(denops: Denops, start: unknown): Promise<unknown[]>;
 export function reltime(
   denops: Denops,
   start: unknown,
@@ -7421,6 +8158,8 @@ export function reltime(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     reltime(start)->reltimefloat()
+ *
+ * Return type: `Float`
  *
  * *only available when compiled with the `+reltime` feature*
  */
@@ -7457,6 +8196,8 @@ export function reltimefloat(
  *
  *     reltime(start)->reltimestr()
  *
+ * Return type: `String`
+ *
  * *only available when compiled with the `+reltime` feature*
  */
 export function reltimestr(denops: Denops, time: unknown): Promise<string>;
@@ -7486,7 +8227,14 @@ export function reltimestr(
  * Can also be used as a `method`:
  *
  *     mylist->remove(idx)
+ *
+ * Return type: any, depending on **{list}**
  */
+export function remove(
+  denops: Denops,
+  list: unknown,
+  idx: unknown,
+): Promise<unknown>;
 export function remove(
   denops: Denops,
   list: unknown,
@@ -7508,6 +8256,8 @@ export function remove(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetOldName()->rename(newname)
+ *
+ * Return type: `Number`
  */
 export function rename(
   denops: Denops,
@@ -7525,8 +8275,8 @@ export function rename(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :let separator = repeat('-', 80)
  *
  * When **{count}** is zero or negative the result is empty.
- * When **{expr}** is a `List` or a `Blob` the result is **{expr}**
- * concatenated **{count}** times.  Example:
+ * When **{expr}** is a `List`, a `Tuple` or a `Blob` the result is
+ * **{expr}** concatenated **{count}** times.  Example:
  *
  *     :let longlist = repeat(['a', 'b'], 3)
  *
@@ -7535,6 +8285,9 @@ export function rename(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->repeat(count)
+ *
+ * Return type: `String`, `Blob`, list<**{type}**> or tuple<**{type}**>
+ * depending on **{expr}**
  */
 export function repeat(
   denops: Denops,
@@ -7564,6 +8317,8 @@ export function repeat(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->resolve()
+ *
+ * Return type: `String`
  */
 export function resolve(denops: Denops, filename: unknown): Promise<string>;
 export function resolve(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -7572,18 +8327,22 @@ export function resolve(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * Reverse the order of items in **{object}**.  **{object}** can be a
- * `List`, a `Blob` or a `String`.  For a List and a Blob the
- * items are reversed in-place and **{object}** is returned.
+ * `List`, a `Tuple`, a `Blob` or a `String`.  For a List and a
+ * Blob the items are reversed in-place and **{object}** is returned.
+ * For a Tuple, a new Tuple is returned.
  * For a String a new String is returned.
- * Returns zero if **{object}** is not a List, Blob or a String.
- * If you want a List or Blob to remain unmodified make a copy
- * first:
+ * Returns zero if **{object}** is not a List, Tuple, Blob or a
+ * String.  If you want a List or Blob to remain unmodified make
+ * a copy first:
  *
  *     :let revlist = reverse(copy(mylist))
  *
  * Can also be used as a `method`:
  *
  *     mylist->reverse()
+ *
+ * Return type: `String`, `Blob`, list<**{type}**> or tuple<**{type}**>
+ * depending on **{object}**
  */
 export function reverse(
   denops: Denops,
@@ -7616,6 +8375,8 @@ export function reverse(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->round()
+ *
+ * Return type: `Float`
  */
 export function round(denops: Denops, expr: unknown): Promise<number>;
 export function round(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -7638,6 +8399,8 @@ export function round(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetRubyExpr()->rubyeval()
  *
+ * Return type: any, depending on **{expr}**
+ *
  * *only available when compiled with the `+ruby` feature*
  */
 export function rubyeval(denops: Denops, expr: unknown): Promise<unknown>;
@@ -7654,6 +8417,8 @@ export function rubyeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetRow()->screenattr(col)
+ *
+ * Return type: `Number`
  */
 export function screenattr(
   denops: Denops,
@@ -7680,6 +8445,8 @@ export function screenattr(
  * Can also be used as a `method`:
  *
  *     GetRow()->screenchar(col)
+ *
+ * Return type: `Number`
  */
 export function screenchar(
   denops: Denops,
@@ -7703,6 +8470,8 @@ export function screenchar(
  * Can also be used as a `method`:
  *
  *     GetRow()->screenchars(col)
+ *
+ * Return type: list<number> or list<any>
  */
 export function screenchars(
   denops: Denops,
@@ -7730,6 +8499,8 @@ export function screenchars(
  *     nnoremap <expr> GG ":echom " .. screencol() .. "\n"
  *     nnoremap <silent> GG :echom screencol()<CR>
  *     nnoremap GG <Cmd>echom screencol()<CR>
+ *
+ * Return type: `Number`
  */
 export function screencol(denops: Denops): Promise<number>;
 export function screencol(
@@ -7746,6 +8517,8 @@ export function screencol(
  * Alternatively you can use `winline()`.
  *
  * Note: Same restrictions as with `screencol()`.
+ *
+ * Return type: `Number`
  */
 export function screenrow(denops: Denops): Promise<number>;
 export function screenrow(
@@ -7766,6 +8539,8 @@ export function screenrow(
  * Can also be used as a `method`:
  *
  *     GetRow()->screenstring(col)
+ *
+ * Return type: `String`
  */
 export function screenstring(
   denops: Denops,
@@ -7797,7 +8572,7 @@ export function screenstring(
  * 's'     Set the ' mark at the previous location of the cursor
  * 'w'     Wrap around the end of the file
  * 'W'     don't Wrap around the end of the file
- * 'z'     start searching at the cursor column instead of zero
+ * 'z'     start searching at the cursor column instead of Zero
  * If neither 'w' or 'W' is given, the 'wrapscan' option applies.
  *
  * If the 's' flag is supplied, the ' mark is set, only if the
@@ -7835,6 +8610,9 @@ export function screenstring(
  * **{timeout}** is 500 the search stops after half a second.
  * The value must not be negative.  A zero value is like not
  * giving the argument.
+ *
+ * Note: the timeout is only considered when searching, not
+ * while evaluating the **{skip}** expression.
  * *only available when compiled with the `+reltime` feature*
  *
  * If the **{skip}** expression is given it is evaluated with the
@@ -7890,6 +8668,8 @@ export function screenstring(
  * Can also be used as a `method`:
  *
  *     GetPattern()->search()
+ *
+ * Return type: `Number`
  */
 export function search(
   denops: Denops,
@@ -7926,11 +8706,12 @@ export function search(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * To get the last search count when `n` or `N` was pressed, call
  * this function with `recompute: 0` . This sometimes returns
- * wrong information because `n` and `N`'s maximum count is 99.
- * If it exceeded 99 the result must be max count + 1 (100). If
- * you want to get correct information, specify `recompute: 1`:
+ * wrong information because of 'maxsearchcount'.
+ * If the count exceeded 'maxsearchcount', the result must be
+ * 'maxsearchcount' + 1. If you want to get correct information,
+ * specify `recompute: 1`:
  *
- *     " result == maxcount + 1 (100) when many matches
+ *     " result == 'maxsearchcount' + 1 when many matches
  *     let result = searchcount(#{recompute: 0})
  *
  *     " Below returns correct result (recompute defaults
@@ -8020,7 +8801,7 @@ export function search(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *                                 result.  if search exceeded
  *                                 total count, "total" value
  *                                 becomes `maxcount + 1`
- *                                 (default: 99)
+ *                                 (default: 'maxsearchcount')
  *   pos           `List`          `[lnum, col, off]` value
  *                                 when recomputing the result.
  *                                 this changes "current" result
@@ -8031,6 +8812,8 @@ export function search(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetSearchOpts()->searchcount()
+ *
+ * Return type: dict<number>
  */
 export function searchcount(
   denops: Denops,
@@ -8065,6 +8848,8 @@ export function searchcount(
  * Can also be used as a `method`:
  *
  *     GetName()->searchdecl()
+ *
+ * Return type: `Number`
  */
 export function searchdecl(
   denops: Denops,
@@ -8168,6 +8953,8 @@ export function searchdecl(
  *
  *     :echo searchpair('{', '', '}', 'bW',
  *          \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
+ *
+ * Return type: `Number`
  */
 export function searchpair(
   denops: Denops,
@@ -8196,6 +8983,8 @@ export function searchpair(
  *     :let [lnum,col] = searchpairpos('{', '', '}', 'n')
  *
  * See `match-parens` for a bigger and more useful example.
+ *
+ * Return type: list<number>
  */
 export function searchpairpos(
   denops: Denops,
@@ -8235,6 +9024,8 @@ export function searchpairpos(
  * Can also be used as a `method`:
  *
  *     GetPattern()->searchpos()
+ *
+ * Return type: list<number>
  */
 export function searchpos(
   denops: Denops,
@@ -8259,6 +9050,8 @@ export function searchpos(
  * Example:
  *
  *     :echo serverlist()
+ *
+ * Return type: `String`
  */
 export function serverlist(denops: Denops): Promise<string>;
 export function serverlist(
@@ -8303,6 +9096,8 @@ export function serverlist(
  * through the text to check if the cell widths of your terminal
  * match with what Vim knows about each emoji.  If it doesn't
  * look right you need to adjust the **{list}** argument.
+ *
+ * Return type: `Number`
  */
 export function setcellwidths(denops: Denops, list: unknown): Promise<void>;
 export function setcellwidths(
@@ -8330,6 +9125,8 @@ export function setcellwidths(
  * Can also be used as a `method`:
  *
  *     GetPosition()->setcharpos('.')
+ *
+ * Return type: `Number`
  */
 export function setcharpos(
   denops: Denops,
@@ -8368,6 +9165,8 @@ export function setcharpos(
  * Can also be used as a `method`:
  *
  *     SavedSearch()->setcharsearch()
+ *
+ * Return type: dict<any>
  */
 export function setcharsearch(
   denops: Denops,
@@ -8390,6 +9189,8 @@ export function setcharsearch(
  * Can also be used as a `method`:
  *
  *     GetText()->setcmdline()
+ *
+ * Return type: `Number`
  */
 export function setcmdline(
   denops: Denops,
@@ -8421,6 +9222,8 @@ export function setcmdline(
  * Can also be used as a `method`:
  *
  *     GetPos()->setcmdpos()
+ *
+ * Return type: `Number`
  */
 export function setcmdpos(denops: Denops, pos: unknown): Promise<number>;
 export function setcmdpos(
@@ -8448,6 +9251,9 @@ export function setcmdpos(
  * Can also be used as a `method`:
  *
  *     GetCursorPos()->setcursorcharpos()
+ *
+ * Returns 0 when the position could be set, -1 otherwise.
+ * Return type: `Number`
  */
 export function setcursorcharpos(
   denops: Denops,
@@ -8478,6 +9284,8 @@ export function setcursorcharpos(
  * second argument:
  *
  *     GetPath()->setenv('PATH')
+ *
+ * Return type: `Number`
  */
 export function setenv(
   denops: Denops,
@@ -8508,6 +9316,8 @@ export function setenv(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     GetFilename()->setfperm(mode)
  *
  * To read permissions see `getfperm()`.
+ *
+ * Return type: `Number`
  */
 export function setfperm(
   denops: Denops,
@@ -8538,6 +9348,8 @@ export function setfperm(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * second argument:
  *
  *     GetLoclist()->setloclist(winnr)
+ *
+ * Return type: `Number`
  */
 export function setloclist(
   denops: Denops,
@@ -8564,6 +9376,8 @@ export function setloclist(
  * Can also be used as a `method`:
  *
  *     GetMatches()->setmatches()
+ *
+ * Return type: `Number`
  */
 export function setmatches(
   denops: Denops,
@@ -8636,6 +9450,8 @@ export function setmatches(
  *
  *             :call setqflist([], 'r')
  *
+ * 'u'     Like 'r', but tries to preserve the current selection
+ *         in the quickfix list.
  * 'f'     All the quickfix lists in the quickfix stack are
  *         freed.
  *
@@ -8696,6 +9512,8 @@ export function setmatches(
  * second argument:
  *
  *     GetErrorlist()->setqflist()
+ *
+ * Return type: `Number`
  */
 export function setqflist(
   denops: Denops,
@@ -8774,6 +9592,8 @@ export function setqflist(
  * second argument:
  *
  *     GetText()->setreg('a')
+ *
+ * Return type: `Number`
  */
 export function setreg(
   denops: Denops,
@@ -8799,6 +9619,8 @@ export function setreg(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * third argument:
  *
  *     GetValue()->settabvar(tab, name)
+ *
+ * Return type: `Number`
  */
 export function settabvar(
   denops: Denops,
@@ -8837,6 +9659,8 @@ export function settabvar(
  * fourth argument:
  *
  *     GetValue()->settabwinvar(tab, winnr, name)
+ *
+ * Return type: `Number`
  */
 export function settabwinvar(
   denops: Denops,
@@ -8891,6 +9715,8 @@ export function settabwinvar(
  * second argument:
  *
  *     GetStack()->settagstack(winnr)
+ *
+ * Return type: `Number`
  */
 export function settagstack(
   denops: Denops,
@@ -8916,6 +9742,8 @@ export function settagstack(
  * third argument:
  *
  *     GetValue()->setwinvar(winnr, name)
+ *
+ * Return type: `Number`
  */
 export function setwinvar(
   denops: Denops,
@@ -8937,6 +9765,8 @@ export function setwinvar(
  * Can also be used as a `method`:
  *
  *     GetText()->sha256()
+ *
+ * Return type: `String`
  *
  * *only available when compiled with the `+cryptv` feature*
  */
@@ -8991,6 +9821,8 @@ export function sha256(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetCommand()->shellescape()
+ *
+ * Return type: `String`
  */
 export function shellescape(
   denops: Denops,
@@ -9019,6 +9851,8 @@ export function shellescape(
  * Can also be used as a `method`:
  *
  *     GetColumn()->shiftwidth()
+ *
+ * Return type: `Number`
  */
 export function shiftwidth(denops: Denops, col?: unknown): Promise<number>;
 export function shiftwidth(
@@ -9050,6 +9884,8 @@ export function shiftwidth(
  * Can also be used as a `method`:
  *
  *     GetName()->simplify()
+ *
+ * Return type: `String`
  */
 export function simplify(denops: Denops, filename: unknown): Promise<string>;
 export function simplify(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9073,6 +9909,8 @@ export function simplify(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->sin()
+ *
+ * Return type: `Float`
  */
 export function sin(denops: Denops, expr: unknown): Promise<number>;
 export function sin(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9097,6 +9935,8 @@ export function sin(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->sinh()
+ *
+ * Return type: `Float`
  */
 export function sinh(denops: Denops, expr: unknown): Promise<number>;
 export function sinh(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9116,6 +9956,8 @@ export function sinh(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetList()->slice(offset)
+ *
+ * Return type: list<**{type}**> or tuple<**{type}**>
  */
 export function slice(
   denops: Denops,
@@ -9213,6 +10055,8 @@ export function slice(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * For a simple expression you can use a lambda:
  *
  *     eval mylist->sort({i1, i2 -> i1 - i2})
+ *
+ * Return type: list<**{type}**>
  */
 export function sort(
   denops: Denops,
@@ -9235,6 +10079,8 @@ export function sort(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetWord()->soundfold()
+ *
+ * Return type: `String`
  */
 export function soundfold(denops: Denops, word: unknown): Promise<string>;
 export function soundfold(
@@ -9273,6 +10119,8 @@ export function soundfold(
  * Can also be used as a `method`:
  *
  *     GetText()->spellbadword()
+ *
+ * Return type: list<string>
  */
 export function spellbadword(
   denops: Denops,
@@ -9309,6 +10157,8 @@ export function spellbadword(
  * Can also be used as a `method`:
  *
  *     GetWord()->spellsuggest()
+ *
+ * Return type: list<string> or list<any>
  */
 export function spellsuggest(
   denops: Denops,
@@ -9325,8 +10175,8 @@ export function spellsuggest(
 
 /**
  * Make a `List` out of **{string}**.  When **{pattern}** is omitted or
- * empty each white-separated sequence of characters becomes an
- * item.
+ * empty each white space separated sequence of characters
+ * becomes an item.
  * Otherwise the string is split where **{pattern}** matches,
  * removing the matched characters. 'ignorecase' is not used
  * here, add \c to ignore case. `/\c`
@@ -9357,6 +10207,8 @@ export function spellsuggest(
  * Can also be used as a `method`:
  *
  *     GetString()->split()
+ *
+ * Return type: list<string>
  */
 export function split(
   denops: Denops,
@@ -9388,6 +10240,8 @@ export function split(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->sqrt()
+ *
+ * Return type: `Float`
  */
 export function sqrt(denops: Denops, expr: unknown): Promise<number>;
 export function sqrt(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9408,6 +10262,8 @@ export function sqrt(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :let seed = srand()
  *     :let seed = srand(userinput)
  *     :echo rand(seed)
+ *
+ * Return type: list<number>
  */
 export function srand(denops: Denops, expr?: unknown): Promise<unknown[]>;
 export function srand(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9450,6 +10306,8 @@ export function srand(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     c   callback invoked, including timer (repeats for
  *         recursiveness up to "ccc")
  *     s   screen has scrolled for messages
+ *
+ * Return type: `String`
  */
 export function state(denops: Denops, what?: unknown): Promise<string>;
 export function state(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9479,6 +10337,8 @@ export function state(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     let f = text->substitute(',', '', 'g')->str2float()
+ *
+ * Return type: `Float`
  */
 export function str2float(
   denops: Denops,
@@ -9511,6 +10371,8 @@ export function str2float(
  * Can also be used as a `method`:
  *
  *     GetString()->str2list()
+ *
+ * Return type: list<number>
  */
 export function str2list(
   denops: Denops,
@@ -9544,6 +10406,8 @@ export function str2list(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->str2nr()
+ *
+ * Return type: `Number`
  */
 export function str2nr(
   denops: Denops,
@@ -9568,6 +10432,8 @@ export function str2nr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->strcharlen()
+ *
+ * Return type: `Number`
  */
 export function strcharlen(denops: Denops, string: unknown): Promise<number>;
 export function strcharlen(
@@ -9597,6 +10463,8 @@ export function strcharlen(
  * Can also be used as a `method`:
  *
  *     GetText()->strcharpart(5)
+ *
+ * Return type: `String`
  */
 export function strcharpart(
   denops: Denops,
@@ -9644,6 +10512,8 @@ export function strcharpart(
  * Can also be used as a `method`:
  *
  *     GetText()->strchars()
+ *
+ * Return type: `Number`
  */
 export function strchars(
   denops: Denops,
@@ -9671,6 +10541,8 @@ export function strchars(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->strdisplaywidth()
+ *
+ * Return type: `Number`
  */
 export function strdisplaywidth(
   denops: Denops,
@@ -9709,6 +10581,8 @@ export function strdisplaywidth(
  * Can also be used as a `method`:
  *
  *     GetFormat()->strftime()
+ *
+ * Return type: `String`
  */
 export function strftime(
   denops: Denops,
@@ -9731,6 +10605,8 @@ export function strftime(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->strgetchar(5)
+ *
+ * Return type: `Number`
  */
 export function strgetchar(
   denops: Denops,
@@ -9769,6 +10645,8 @@ export function strgetchar(
  * Can also be used as a `method`:
  *
  *     GetHaystack()->stridx(needle)
+ *
+ * Return type: `Number`
  */
 export function stridx(
   denops: Denops,
@@ -9791,15 +10669,16 @@ export function stridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         Funcref         function('name')
  *         Blob            0z00112233.44556677.8899
  *         List            [item, item]
+ *         Tuple           (item, item)
  *         Dictionary      {key: value, key: value}
  *         Class           class SomeName
  *         Object          object of SomeName {lnum: 1, col: 3}
  *         Enum            enum EnumName
  *         EnumValue       enum name.value {name: str, ordinal: nr}
  *
- * When a `List` or `Dictionary` has a recursive reference it is
- * replaced by "[...]" or "**{...}**".  Using eval() on the result
- * will then fail.
+ * When a `List`, `Tuple` or `Dictionary` has a recursive
+ * reference it is replaced by "[...]" or "(...)" or "**{...}**".
+ * Using eval() on the result will then fail.
  *
  * For an object, invokes the string() method to get a textual
  * representation of the object.  If the method is not present,
@@ -9810,6 +10689,8 @@ export function stridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     mylist->string()
  *
  * Also see `strtrans()`.
+ *
+ * Return type: `String`
  */
 export function string(denops: Denops, expr: unknown): Promise<string>;
 export function string(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9828,6 +10709,8 @@ export function string(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetString()->strlen()
+ *
+ * Return type: `Number`
  */
 export function strlen(denops: Denops, string: unknown): Promise<number>;
 export function strlen(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -9864,6 +10747,8 @@ export function strlen(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->strpart(5)
+ *
+ * Return type: `String`
  */
 export function strpart(
   denops: Denops,
@@ -9913,6 +10798,8 @@ export function strpart(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Not available on all systems.  To check use:
  *
  *     :if exists("*strptime")
+ *
+ * Return type: `Number`
  */
 export function strptime(
   denops: Denops,
@@ -9947,6 +10834,8 @@ export function strptime(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetHaystack()->strridx(needle)
+ *
+ * Return type: `Number`
  */
 export function strridx(
   denops: Denops,
@@ -9960,7 +10849,7 @@ export function strridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * The result is a String, which is **{string}** with all unprintable
- * characters translated into printable characters `'isprint'`.
+ * characters translated into printable characters 'isprint'.
  * Like they are shown in a window.  Example:
  *
  *     echo strtrans(@a)
@@ -9973,6 +10862,8 @@ export function strridx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetString()->strtrans()
+ *
+ * Return type: `String`
  */
 export function strtrans(denops: Denops, string: unknown): Promise<string>;
 export function strtrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10002,6 +10893,8 @@ export function strtrans(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->strutf16len()
+ *
+ * Return type: `Number`
  */
 export function strutf16len(
   denops: Denops,
@@ -10027,6 +10920,8 @@ export function strutf16len(
  * Can also be used as a `method`:
  *
  *     GetString()->strwidth()
+ *
+ * Return type: `Number`
  */
 export function strwidth(denops: Denops, string: unknown): Promise<number>;
 export function strwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10066,6 +10961,8 @@ export function strwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetNr()->submatch()
+ *
+ * Return type: `String` or list<string> depending on **{list}**
  */
 export function submatch(
   denops: Denops,
@@ -10130,6 +11027,8 @@ export function submatch(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetString()->substitute(pat, sub, flags)
+ *
+ * Return type: `String`
  */
 export function substitute(
   denops: Denops,
@@ -10156,6 +11055,8 @@ export function substitute(
  *     let &directory = '.'
  *     let swapfiles = swapfilelist()
  *     let &directory = save_dir
+ *
+ * Return type: list<string>
  */
 export function swapfilelist(denops: Denops): Promise<unknown[]>;
 export function swapfilelist(
@@ -10187,6 +11088,8 @@ export function swapfilelist(
  * Can also be used as a `method`:
  *
  *     GetFilename()->swapinfo()
+ *
+ * Return type: dict<any> or dict<string>
  */
 export function swapinfo(
   denops: Denops,
@@ -10221,6 +11124,8 @@ export function swapinfo(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Example (echoes the name of the syntax item under the cursor):
  *
  *     :echo synIDattr(synID(line("."), col("."), 1), "name")
+ *
+ * Return type: `Number`
  */
 export function synID(
   denops: Denops,
@@ -10276,6 +11181,8 @@ export function synID(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     :echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
+ *
+ * Return type: `String`
  */
 export function synIDattr(
   denops: Denops,
@@ -10301,6 +11208,8 @@ export function synIDattr(
  * Can also be used as a `method`:
  *
  *     :echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
+ *
+ * Return type: `Number`
  */
 export function synIDtrans(denops: Denops, synID: unknown): Promise<number>;
 export function synIDtrans(
@@ -10338,6 +11247,8 @@ export function synIDtrans(
  * Note: Doesn't consider `matchadd()` highlighting items,
  * since syntax and matching highlighting are two different
  * mechanisms `syntax-vs-match`.
+ *
+ * Return type: list<any>
  */
 export function synconcealed(
   denops: Denops,
@@ -10371,6 +11282,8 @@ export function synconcealed(
  * an empty List is returned.  The position just after the last
  * character in a line and the first column in an empty line are
  * valid positions.
+ *
+ * Return type: list<number> or list<any>
  */
 export function synstack(
   denops: Denops,
@@ -10446,6 +11359,8 @@ export function synstack(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     :echo GetCmd()->system()
+ *
+ * Return type: `String`
  */
 export function system(
   denops: Denops,
@@ -10474,6 +11389,8 @@ export function system(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     :echo GetCmd()->systemlist()
+ *
+ * Return type: list<string>
  */
 export function systemlist(
   denops: Denops,
@@ -10505,6 +11422,8 @@ export function systemlist(
  * Can also be used as a `method`:
  *
  *     GetTabpage()->tabpagebuflist()
+ *
+ * Return type: list<number>
  */
 export function tabpagebuflist(
   denops: Denops,
@@ -10530,6 +11449,8 @@ export function tabpagebuflist(
  * The number can be used with the `:tab` command.
  *
  * Returns zero on error.
+ *
+ * Return type: `Number`
  */
 export function tabpagenr(denops: Denops, arg?: unknown): Promise<number>;
 export function tabpagenr(
@@ -10557,6 +11478,8 @@ export function tabpagenr(
  * Can also be used as a `method`:
  *
  *     GetTabpage()->tabpagewinnr()
+ *
+ * Return type: `Number`
  */
 export function tabpagewinnr(
   denops: Denops,
@@ -10573,6 +11496,8 @@ export function tabpagewinnr(
 /**
  * Returns a `List` with the file names used to search for tags
  * for the current buffer.  This is the 'tags' option expanded.
+ *
+ * Return type: list<string> or list<any>
  */
 export function tagfiles(denops: Denops): Promise<unknown[]>;
 export function tagfiles(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10618,13 +11543,15 @@ export function tagfiles(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Refer to `tag-regexp` for more information about the tag
  * search regular expression pattern.
  *
- * Refer to `'tags'` for information about how the tags file is
+ * Refer to 'tags' for information about how the tags file is
  * located by Vim. Refer to `tags-file-format` for the format of
  * the tags file generated by the different ctags tools.
  *
  * Can also be used as a `method`:
  *
  *     GetTagpattern()->taglist()
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function taglist(
   denops: Denops,
@@ -10653,6 +11580,8 @@ export function taglist(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->tan()
+ *
+ * Return type: `Float`
  */
 export function tan(denops: Denops, expr: unknown): Promise<number>;
 export function tan(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10677,6 +11606,8 @@ export function tan(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->tanh()
+ *
+ * Return type: `Float`
  */
 export function tanh(denops: Denops, expr: unknown): Promise<number>;
 export function tanh(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10697,6 +11628,8 @@ export function tanh(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * For MS-Windows forward slashes are used when the 'shellslash'
  * option is set, or when 'shellcmdflag' starts with '-' and
  * 'shell' does not contain powershell or pwsh.
+ *
+ * Return type: `String`
  */
 export function tempname(denops: Denops): Promise<string>;
 export function tempname(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10724,6 +11657,8 @@ export function tempname(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  *     GetTimer()->timer_info()
  *
+ * Return type: list<dict<any>> or list<any>
+ *
  * *only available when compiled with the `+timers` feature*
  */
 export function timer_info(denops: Denops, id?: unknown): Promise<unknown[]>;
@@ -10750,6 +11685,8 @@ export function timer_info(
  * Can also be used as a `method`:
  *
  *     GetTimer()->timer_pause(1)
+ *
+ * Return type: `Number`
  *
  * *only available when compiled with the `+timers` feature*
  */
@@ -10808,6 +11745,9 @@ export function timer_pause(
  *     GetMsec()->timer_start(callback)
  *
  * Not available in the `sandbox`.
+ *
+ * Return type: `Number`
+ *
  * *only available when compiled with the `+timers` feature*
  */
 export function timer_start(
@@ -10832,6 +11772,8 @@ export function timer_start(
  *
  *     GetTimer()->timer_stop()
  *
+ * Return type: `Number`
+ *
  * *only available when compiled with the `+timers` feature*
  */
 export function timer_stop(denops: Denops, timer: unknown): Promise<void>;
@@ -10846,6 +11788,8 @@ export function timer_stop(
  * Stop all timers.  The timer callbacks will no longer be
  * invoked.  Useful if a timer is misbehaving.  If there are no
  * timers there is no error.
+ *
+ * Return type: `Number`
  *
  * *only available when compiled with the `+timers` feature*
  */
@@ -10865,6 +11809,8 @@ export function timer_stopall(
  * Can also be used as a `method`:
  *
  *     GetText()->tolower()
+ *
+ * Return type: `String`
  */
 export function tolower(denops: Denops, expr: unknown): Promise<string>;
 export function tolower(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10879,6 +11825,8 @@ export function tolower(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->toupper()
+ *
+ * Return type: `String`
  */
 export function toupper(denops: Denops, expr: unknown): Promise<string>;
 export function toupper(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -10908,6 +11856,8 @@ export function toupper(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->tr(from, to)
+ *
+ * Return type: `String`
  */
 export function tr(
   denops: Denops,
@@ -10958,6 +11908,8 @@ export function tr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->trim()
+ *
+ * Return type: `String`
  */
 export function trim(
   denops: Denops,
@@ -10991,6 +11943,8 @@ export function trim(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     Compute()->trunc()
+ *
+ * Return type: `Float`
  */
 export function trunc(denops: Denops, expr: unknown): Promise<number>;
 export function trunc(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11017,6 +11971,7 @@ export function trunc(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         Typealias: 14  `v:t_typealias`
  *         Enum:      15  `v:t_enum`
  *         EnumValue: 16  `v:t_enumvalue`
+ *         Tuple:     17  `v:t_tuple`
  * For backward compatibility, this method can be used:
  *
  *     :if type(myvar) == type(0)
@@ -11035,6 +11990,8 @@ export function trunc(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mylist->type()
+ *
+ * Return type: `Number`
  */
 export function type(denops: Denops, expr: unknown): Promise<number>;
 export function type(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11057,6 +12014,8 @@ export function type(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetFilename()->undofile()
+ *
+ * Return type: `String`
  */
 export function undofile(denops: Denops, name: unknown): Promise<string>;
 export function undofile(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11106,6 +12065,8 @@ export function undofile(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *   "alt"         Alternate entry.  This is again a List of undo
  *                 blocks.  Each item may again have an "alt"
  *                 item.
+ *
+ * Return type: dict<any>
  */
 export function undotree(denops: Denops, buf?: unknown): Promise<unknown[]>;
 export function undotree(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11121,12 +12082,15 @@ export function undotree(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * The default compare function uses the string representation of
  * each item.  For the use of **{func}** and **{dict}** see `sort()`.
+ * For deduplicating text in the current buffer see `:uniq`.
  *
  * Returns zero if **{list}** is not a `List`.
  *
  * Can also be used as a `method`:
  *
  *     mylist->uniq()
+ *
+ * Return type: list<**{type}**>
  */
 export function uniq(
   denops: Denops,
@@ -11169,6 +12133,8 @@ export function uniq(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetName()->utf16idx(idx)
+ *
+ * Return type: `Number`
  */
 export function utf16idx(
   denops: Denops,
@@ -11189,6 +12155,8 @@ export function utf16idx(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     mydict->values()
+ *
+ * Return type: list<any>
  */
 export function values(denops: Denops, dict: unknown): Promise<unknown[]>;
 export function values(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11220,6 +12188,8 @@ export function values(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetWinid()->virtcol2col(lnum, col)
+ *
+ * Return type: `Number`
  */
 export function virtcol2col(
   denops: Denops,
@@ -11253,6 +12223,8 @@ export function virtcol2col(
  * If **{expr}** is supplied and it evaluates to a non-zero Number or
  * a non-empty String, then the Visual mode will be cleared and
  * the old value is returned.  See `non-zero-arg`.
+ *
+ * Return type: `String`
  */
 export function visualmode(denops: Denops, expr?: unknown): Promise<string>;
 export function visualmode(
@@ -11272,7 +12244,9 @@ export function visualmode(
  *
  *     :cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
  *
- * (Note, this needs the 'wildcharm' option set appropriately).
+ * (Note: this needs the 'wildcharm' option set appropriately).
+ *
+ * Return type: `Number`
  */
 export function wildmenumode(denops: Denops): Promise<number>;
 export function wildmenumode(
@@ -11303,6 +12277,8 @@ export function wildmenumode(
  * second argument:
  *
  *     GetCommand()->win_execute(winid)
+ *
+ * Return type: `String`
  */
 export function win_execute(
   denops: Denops,
@@ -11324,6 +12300,8 @@ export function win_execute(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->win_findbuf()
+ *
+ * Return type: list<number> or list<any>
  */
 export function win_findbuf(denops: Denops, bufnr: unknown): Promise<unknown[]>;
 export function win_findbuf(
@@ -11345,6 +12323,8 @@ export function win_findbuf(
  * Can also be used as a `method`:
  *
  *     GetWinnr()->win_getid()
+ *
+ * Return type: `Number`
  */
 export function win_getid(
   denops: Denops,
@@ -11381,6 +12361,8 @@ export function win_getid(
  * Can also be used as a `method`:
  *
  *     GetWinid()->win_gettype()
+ *
+ * Return type: `String`
  */
 export function win_gettype(denops: Denops, nr?: unknown): Promise<string>;
 export function win_gettype(
@@ -11398,6 +12380,8 @@ export function win_gettype(
  * Can also be used as a `method`:
  *
  *     GetWinid()->win_gotoid()
+ *
+ * Return type: `Number`
  */
 export function win_gotoid(denops: Denops, expr: unknown): Promise<number>;
 export function win_gotoid(
@@ -11415,6 +12399,8 @@ export function win_gotoid(
  * Can also be used as a `method`:
  *
  *     GetWinid()->win_id2tabwin()
+ *
+ * Return type: list<number>
  */
 export function win_id2tabwin(
   denops: Denops,
@@ -11434,6 +12420,8 @@ export function win_id2tabwin(
  * Can also be used as a `method`:
  *
  *     GetWinid()->win_id2win()
+ *
+ * Return type: `Number`
  */
 export function win_id2win(denops: Denops, expr: unknown): Promise<number>;
 export function win_id2win(
@@ -11461,6 +12449,8 @@ export function win_id2win(
  * Can also be used as a `method`:
  *
  *     GetWinnr()->win_move_separator(offset)
+ *
+ * Return type: `Number`
  */
 export function win_move_separator(
   denops: Denops,
@@ -11489,6 +12479,8 @@ export function win_move_separator(
  * Can also be used as a `method`:
  *
  *     GetWinnr()->win_move_statusline(offset)
+ *
+ * Return type: `Number`
  */
 export function win_move_statusline(
   denops: Denops,
@@ -11513,6 +12505,8 @@ export function win_move_statusline(
  * Can also be used as a `method`:
  *
  *     GetWinid()->win_screenpos()
+ *
+ * Return type: list<number>
  */
 export function win_screenpos(denops: Denops, nr: unknown): Promise<unknown[]>;
 export function win_screenpos(
@@ -11545,6 +12539,8 @@ export function win_screenpos(
  * Can also be used as a `method`:
  *
  *     GetWinid()->win_splitmove(target)
+ *
+ * Return type: `Number`
  */
 export function win_splitmove(
   denops: Denops,
@@ -11573,6 +12569,8 @@ export function win_splitmove(
  * Can also be used as a `method`:
  *
  *     FindWindow()->winbufnr()->bufname()
+ *
+ * Return type: `Number`
  */
 export function winbufnr(denops: Denops, nr: unknown): Promise<number>;
 export function winbufnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11584,6 +12582,8 @@ export function winbufnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
  * Windows XP is "5.1".  For non-MS-Windows systems the result is
  * an empty string.
+ *
+ * Return type: `String`
  */
 export function windowsversion(denops: Denops): Promise<string>;
 export function windowsversion(
@@ -11607,6 +12607,8 @@ export function windowsversion(
  * Can also be used as a `method`:
  *
  *     GetWinid()->winheight()
+ *
+ * Return type: `Number`
  */
 export function winheight(denops: Denops, nr: unknown): Promise<number>;
 export function winheight(
@@ -11650,6 +12652,8 @@ export function winheight(
  * Can also be used as a `method`:
  *
  *     GetTabnr()->winlayout()
+ *
+ * Return type: list<any>
  */
 export function winlayout(denops: Denops, tabnr?: unknown): Promise<unknown[]>;
 export function winlayout(
@@ -11694,6 +12698,8 @@ export function winlayout(
  * Can also be used as a `method`:
  *
  *     GetWinval()->winnr()
+ *
+ * Return type: `Number`
  */
 export function winnr(denops: Denops, arg?: unknown): Promise<number>;
 export function winnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11710,6 +12716,8 @@ export function winnr(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :let cmd = winrestcmd()
  *     :call MessWithWindowSizes()
  *     :exe cmd
+ *
+ * Return type: `String`
  */
 export function winrestcmd(denops: Denops): Promise<string>;
 export function winrestcmd(
@@ -11739,6 +12747,8 @@ export function winrestcmd(
  * Can also be used as a `method`:
  *
  *     GetView()->winrestview()
+ *
+ * Return type: `Number`
  */
 export function winrestview(denops: Denops, dict: unknown): Promise<void>;
 export function winrestview(
@@ -11774,6 +12784,8 @@ export function winrestview(
  *                         'wrap' is off
  *         skipcol         columns skipped
  * Note that no option values are saved.
+ *
+ * Return type: dict<number>
  */
 export function winsaveview(denops: Denops): Promise<Record<string, unknown>>;
 export function winsaveview(
@@ -11802,6 +12814,8 @@ export function winsaveview(
  * Can also be used as a `method`:
  *
  *     GetWinid()->winwidth()
+ *
+ * Return type: `Number`
  */
 export function winwidth(denops: Denops, nr: unknown): Promise<number>;
 export function winwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -11828,6 +12842,8 @@ export function winwidth(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *                         (only in Visual mode)
  *         visual_words    Number of words visually selected
  *                         (only in Visual mode)
+ *
+ * Return type: dict<number>
  */
 export function wordcount(denops: Denops): Promise<Record<string, unknown>>;
 export function wordcount(
@@ -11890,6 +12906,8 @@ export function wordcount(
  * Can also be used as a `method`:
  *
  *     GetText()->writefile("thefile")
+ *
+ * Return type: `Number`
  */
 export function writefile(
   denops: Denops,
@@ -11915,6 +12933,8 @@ export function writefile(
  * Can also be used as a `method`:
  *
  *     :let bits = bits->xor(0x80)
+ *
+ * Return type: `Number`
  */
 export function xor(
   denops: Denops,
@@ -11938,6 +12958,7 @@ export function xor(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *    icon         full path to the bitmap file for the sign.
  *    linehl       highlight group used for the whole line the
  *                 sign is placed in.
+ *    priority     default priority value of the sign
  *    numhl        highlight group used for the line number where
  *                 the sign is placed.
  *    text         text that is displayed when there is no icon
@@ -11974,6 +12995,8 @@ export function xor(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetSignList()->sign_define()
+ *
+ * Return type: `Number`
  */
 export function sign_define(
   denops: Denops,
@@ -12002,6 +13025,7 @@ export function sign_define(
  *    linehl       highlight group used for the whole line the
  *                 sign is placed in; not present if not set
  *    name         name of the sign
+ *    priority     default priority value of the sign
  *    numhl        highlight group used for the line number where
  *                 the sign is placed; not present if not set
  *    text         text that is displayed when there is no icon
@@ -12027,6 +13051,8 @@ export function sign_define(
  * Can also be used as a `method`:
  *
  *     GetSignList()->sign_getdefined()
+ *
+ * Return type: list<dict<string>> or list<any>
  */
 export function sign_getdefined(
   denops: Denops,
@@ -12103,6 +13129,8 @@ export function sign_getdefined(
  * Can also be used as a `method`:
  *
  *     GetBufname()->sign_getplaced()
+ *
+ * Return type: list<dict<any>>
  */
 export function sign_getplaced(
   denops: Denops,
@@ -12135,6 +13163,8 @@ export function sign_getplaced(
  * Can also be used as a `method`:
  *
  *     GetSignid()->sign_jump()
+ *
+ * Return type: `Number`
  */
 export function sign_jump(
   denops: Denops,
@@ -12201,6 +13231,8 @@ export function sign_jump(
  * Can also be used as a `method`:
  *
  *     GetSignid()->sign_place(group, name, expr)
+ *
+ * Return type: `Number`
  */
 export function sign_place(
   denops: Denops,
@@ -12241,7 +13273,8 @@ export function sign_place(
  *     priority    Priority of the sign. When multiple signs are
  *                 placed on a line, the sign with the highest
  *                 priority is used. If not specified, the
- *                 default value of 10 is used. See
+ *                 default value of 10 is used, unless specified
+ *                 otherwise by the sign definition. See
  *                 `sign-priority` for more information.
  *
  * If **{id}** refers to an existing sign, then the existing sign is
@@ -12279,6 +13312,8 @@ export function sign_place(
  * Can also be used as a `method`:
  *
  *     GetSignlist()->sign_placelist()
+ *
+ * Return type: `Number`
  */
 export function sign_placelist(
   denops: Denops,
@@ -12317,6 +13352,8 @@ export function sign_placelist(
  * Can also be used as a `method`:
  *
  *     GetSignlist()->sign_undefine()
+ *
+ * Return type: `Number`
  */
 export function sign_undefine(
   denops: Denops,
@@ -12379,6 +13416,8 @@ export function sign_undefine(
  * Can also be used as a `method`:
  *
  *     GetSigngroup()->sign_unplace()
+ *
+ * Return type: `Number`
  */
 export function sign_unplace(
   denops: Denops,
@@ -12424,6 +13463,8 @@ export function sign_unplace(
  * Can also be used as a `method`:
  *
  *     GetSignlist()->sign_unplacelist()
+ *
+ * Return type: list<number> or list<any>
  */
 export function sign_unplacelist(
   denops: Denops,
@@ -12437,12 +13478,14 @@ export function sign_unplacelist(
 }
 
 /**
- * Like garbagecollect(), but executed right away.  This must
+ * Like `garbagecollect()`, but executed right away.  This must
  * only be called directly to avoid any structure to exist
  * internally, and `v:testing` must have been set before calling
  * any function.
  * This will not work when called from a :def function, because
  * variables on the stack will be freed.
+ *
+ * Return type: `Number`
  */
 export function test_garbagecollect_now(denops: Denops): Promise<void>;
 export function test_garbagecollect_now(
@@ -12461,6 +13504,8 @@ export function test_garbagecollect_now(
  * Can also be used as a `method`:
  *
  *     GetCmd()->assert_beeps()
+ *
+ * Return type: `Number`
  */
 export function assert_beeps(denops: Denops, cmd: unknown): Promise<number>;
 export function assert_beeps(
@@ -12475,7 +13520,8 @@ export function assert_beeps(
  * added to `v:errors` and 1 is returned.  Otherwise zero is
  * returned. `assert-return`
  * The error is in the form "Expected **{expected}** but got
- * **{actual}**".  When **{msg}** is present it is prefixed to that.
+ * **{actual}**".  When **{msg}** is present it is prefixed to that,
+ * along with the location of the assert when run from a script.
  *
  * There is no automatic conversion, the String "4" is different
  * from the Number 4.  And the number 4 is different from the
@@ -12483,15 +13529,17 @@ export function assert_beeps(
  * always matters.
  * Example:
  *
- *     assert_equal('foo', 'bar')
+ *     call assert_equal('foo', 'bar', 'baz')
  *
- * Will result in a string to be added to `v:errors`:
- *         test.vim line 12: Expected 'foo' but got 'bar'
+ * Will add the following to `v:errors`:
+ *         test.vim line 12: baz: Expected 'foo' but got 'bar'
  *
  * Can also be used as a `method`, the base is passed as the
  * second argument:
  *
  *     mylist->assert_equal([1, 2, 3])
+ *
+ * Return type: `Number`
  */
 export function assert_equal(
   denops: Denops,
@@ -12517,6 +13565,8 @@ export function assert_equal(
  * Can also be used as a `method`:
  *
  *     GetLog()->assert_equalfile('expected.log')
+ *
+ * Return type: `Number`
  */
 export function assert_equalfile(
   denops: Denops,
@@ -12544,6 +13594,8 @@ export function assert_equalfile(
  *     catch
  *       call assert_exception('E492:')
  *     endtry
+ *
+ * Return type: `Number`
  */
 export function assert_exception(
   denops: Denops,
@@ -12566,13 +13618,13 @@ export function assert_exception(
  * first reported error. Most often this will be the error code,
  * including the colon, e.g. "E123:".
  *
- *     assert_fails('bad cmd', 'E987:')
+ *     call assert_fails('bad cmd', 'E987:')
  *
  * When **{error}** is a `List` with one or two strings, these are
  * used as patterns.  The first pattern is matched against the
  * first reported error:
  *
- *     assert_fails('cmd', ['E987:.*expected bool'])
+ *     call assert_fails('cmd', ['E987:.*expected bool'])
  *
  * The second pattern, if present, is matched against the last
  * reported error.
@@ -12581,7 +13633,7 @@ export function assert_exception(
  * To only match the last error use an empty string for the first
  * error:
  *
- *     assert_fails('cmd', ['', 'E987:'])
+ *     call assert_fails('cmd', ['', 'E987:'])
  *
  * If **{msg}** is empty then it is not used.  Do this to get the
  * default message when passing the **{lnum}** argument.
@@ -12601,6 +13653,8 @@ export function assert_exception(
  * Can also be used as a `method`:
  *
  *     GetCmd()->assert_fails('E99:')
+ *
+ * Return type: `Number`
  */
 export function assert_fails(
   denops: Denops,
@@ -12621,7 +13675,8 @@ export function assert_fails(
  * When **{actual}** is not false an error message is added to
  * `v:errors`, like with `assert_equal()`.
  * The error is in the form "Expected False but got **{actual}**".
- * When **{msg}** is present it is prepended to that.
+ * When **{msg}** is present it is prefixed to that, along with the
+ * location of the assert when run from a script.
  * Also see `assert-return`.
  *
  * A value is false when it is zero. When **{actual}** is not a
@@ -12630,6 +13685,8 @@ export function assert_fails(
  * Can also be used as a `method`:
  *
  *     GetResult()->assert_false()
+ *
+ * Return type: `Number`
  */
 export function assert_false(
   denops: Denops,
@@ -12650,6 +13707,8 @@ export function assert_false(
  * The error is in the form "Expected range **{lower}** - **{upper}**,
  * but got **{actual}**".  When **{msg}** is present it is prefixed to
  * that.
+ *
+ * Return type: `Number`
  */
 export function assert_inrange(
   denops: Denops,
@@ -12669,7 +13728,8 @@ export function assert_inrange(
  * When **{pattern}** does not match **{actual}** an error message is
  * added to `v:errors`.  Also see `assert-return`.
  * The error is in the form "Pattern **{pattern}** does not match
- * **{actual}**".  When **{msg}** is present it is prefixed to that.
+ * **{actual}**".  When **{msg}** is present it is prefixed to that,
+ * along with the location of the assert when run from a script.
  *
  * **{pattern}** is used as with `=~`: The matching is always done
  * like 'magic' was set and 'cpoptions' is empty, no matter what
@@ -12681,7 +13741,7 @@ export function assert_inrange(
  *
  * Example:
  *
- *     assert_match('^f.*o$', 'foobar')
+ *     call assert_match('^f.*o$', 'foobar')
  *
  * Will result in a string to be added to `v:errors`:
  *         test.vim line 12: Pattern '^f.*o$' does not match 'foobar'
@@ -12689,6 +13749,8 @@ export function assert_inrange(
  * Can also be used as a `method`:
  *
  *     getFile()->assert_match('foo.*')
+ *
+ * Return type: `Number`
  */
 export function assert_match(
   denops: Denops,
@@ -12711,6 +13773,8 @@ export function assert_match(
  * Can also be used as a `method`:
  *
  *     GetCmd()->assert_nobeep()
+ *
+ * Return type: `Number`
  */
 export function assert_nobeep(denops: Denops, cmd: unknown): Promise<number>;
 export function assert_nobeep(
@@ -12728,6 +13792,8 @@ export function assert_nobeep(
  * Can also be used as a `method`:
  *
  *     mylist->assert_notequal([1, 2, 3])
+ *
+ * Return type: `Number`
  */
 export function assert_notequal(
   denops: Denops,
@@ -12750,6 +13816,8 @@ export function assert_notequal(
  * Can also be used as a `method`:
  *
  *     getFile()->assert_notmatch('bar.*')
+ *
+ * Return type: `Number`
  */
 export function assert_notmatch(
   denops: Denops,
@@ -12771,6 +13839,8 @@ export function assert_notmatch(
  * Can also be used as a `method`:
  *
  *     GetMessage()->assert_report()
+ *
+ * Return type: `Number`
  */
 export function assert_report(denops: Denops, msg: unknown): Promise<number>;
 export function assert_report(
@@ -12786,11 +13856,14 @@ export function assert_report(
  * Also see `assert-return`.
  * A value is TRUE when it is a non-zero number.  When **{actual}**
  * is not a number the assert fails.
- * When **{msg}** is given it precedes the default message.
+ * When **{msg}** is given it is prefixed to the default message,
+ * along with the location of the assert when run from a script.
  *
  * Can also be used as a `method`:
  *
  *     GetResult()->assert_true()
+ *
+ * Return type: `Number`
  */
 export function assert_true(
   denops: Denops,

--- a/function/buffer.ts
+++ b/function/buffer.ts
@@ -77,6 +77,8 @@ export interface GetBufInfoDictArg {
  * passed as the second argument:
  *
  *     mylist->appendbufline(buf, lnum)
+ *
+ * Return type: `Number`
  */
 export async function appendbufline(
   denops: Denops,
@@ -105,6 +107,8 @@ export async function appendbufline(
  * Can also be used as a `method`:
  *
  *     let bufnr = 'somename'->bufadd()
+ *
+ * Return type: `Number`
  */
 export async function bufadd(
   denops: Denops,
@@ -140,6 +144,8 @@ export async function bufadd(
  *
  *     let exists = 'somename'->bufexists()
  *
+ * Return type: `Number`
+ *
  * Obsolete name: buffer_exists().
  */
 export async function bufexists(
@@ -158,6 +164,8 @@ export async function bufexists(
  * Can also be used as a `method`:
  *
  *     let listed = 'somename'->buflisted()
+ *
+ * Return type: `Number`
  */
 export async function buflisted(
   denops: Denops,
@@ -180,6 +188,8 @@ export async function buflisted(
  * Can also be used as a `method`:
  *
  *     eval 'somename'->bufload()
+ *
+ * Return type: `Number`
  */
 export async function bufload(
   denops: Denops,
@@ -196,6 +206,8 @@ export async function bufload(
  * Can also be used as a `method`:
  *
  *     let loaded = 'somename'->bufloaded()
+ *
+ * Return type: `Number`
  */
 export async function bufloaded(
   denops: Denops,
@@ -242,6 +254,8 @@ export async function bufloaded(
  *     bufname("%")            name of current buffer
  *     bufname("file2")        name of buffer where "file2" matches.
  *
+ * Return type: `String`
+ *
  * Obsolete name: buffer_name().
  */
 export async function bufname(
@@ -278,6 +292,8 @@ export async function bufname(
  *
  *     echo bufref->bufnr()
  *
+ * Return type: `Number`
+ *
  * Obsolete name: buffer_number().
  *
  * Obsolete name for bufnr("$"): last_buffer_nr().
@@ -304,6 +320,8 @@ export async function bufnr(
  * Can also be used as a `method`:
  *
  *     FindBuffer()->bufwinid()
+ *
+ * Return type: `Number`
  */
 export async function bufwinid(
   denops: Denops,
@@ -326,6 +344,8 @@ export async function bufwinid(
  * Can also be used as a `method`:
  *
  *     FindBuffer()->bufwinnr()
+ *
+ * Return type: `Number`
  */
 export async function bufwinnr(
   denops: Denops,
@@ -351,6 +371,8 @@ export async function bufwinnr(
  * Can also be used as a `method`:
  *
  *     GetBuffer()->deletebufline(1)
+ *
+ * Return type: `Number`
  */
 export async function deletebufline(
   denops: Denops,
@@ -437,6 +459,8 @@ export async function deletebufline(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->getbufinfo()
+ *
+ * Return type: list<dict<any>>
  */
 export function getbufinfo(
   denops: Denops,
@@ -492,6 +516,8 @@ export async function getbufinfo(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->getbufline(lnum)
+ *
+ * Return type: list<string>
  */
 export async function getbufline(
   denops: Denops,
@@ -527,6 +553,8 @@ export async function getbufline(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->getbufvar(varname)
+ *
+ * Return type: any, depending on **{varname}**
  */
 export function getbufvar(
   denops: Denops,
@@ -566,6 +594,8 @@ export function getbufvar(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->getchangelist()
+ *
+ * Return type: list<any>
  */
 export async function getchangelist(
   denops: Denops,
@@ -596,6 +626,8 @@ export async function getchangelist(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->getmarklist()
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export async function getmarklist(
   denops: Denops,
@@ -635,6 +667,8 @@ export async function getmarklist(
  * third argument:
  *
  *     GetText()->setbufline(buf, lnum)
+ *
+ * Return type: `Number`
  */
 export async function setbufline(
   denops: Denops,
@@ -666,6 +700,8 @@ export async function setbufline(
  * third argument:
  *
  *     GetValue()->setbufvar(buf, varname)
+ *
+ * Return type: `Number`
  */
 export async function setbufvar(
   denops: Denops,
@@ -686,6 +722,8 @@ export async function setbufvar(
  * Can also be used as a `method`:
  *
  *     GetBufname()->swapname()
+ *
+ * Return type: `String`
  */
 export async function swapname(
   denops: Denops,

--- a/function/common.ts
+++ b/function/common.ts
@@ -116,6 +116,8 @@ import type { Denops } from "../mod.ts";
  * Can also be used as a `method`:
  *
  *     Varname()->exists()
+ *
+ * Return type: `String`
  */
 export async function exists(
   denops: Denops,
@@ -168,6 +170,7 @@ export async function exists(
  *         fname_case      Case in file names matters (for Darwin and MS-Windows
  *                         this is not present).
  *         gui_running     Nvim has a GUI.
+ *         hurd            GNU/Hurd system.
  *         iconv           Can use `iconv()` for conversion.
  *         linux           Linux system.
  *         mac             MacOS system.
@@ -196,6 +199,12 @@ export async function exists(
  *         if has("patch-7.4.237")
  *           " ...
  *         endif
+ *
+ * Parameters:
+ *   - **{feature}** (`string`)
+ *
+ * Return:
+ *   (`0|1`)
  */
 export async function has(
   denops: Denops,
@@ -237,6 +246,8 @@ export async function has(
  *
  *     ComputeLnum()->getline()
  *
+ * Return type: list<string> or `String` depending on **{end}**
+ *
  * To get lines from another buffer see `getbufline()` and
  * `getbufoneline()`
  */
@@ -260,7 +271,9 @@ export async function getline(
 /**
  * Set line **{lnum}** of the current buffer to **{text}**.  To insert
  * lines use `append()`. To set lines in another buffer use
- * `setbufline()`.  Any text properties in **{lnum}** are cleared.
+ * `setbufline()`.
+ * Any text properties in **{lnum}** are cleared.  See
+ * `text-prop-cleared`
  *
  * **{lnum}** is used like with `getline()`.
  * When **{lnum}** is just below the last line the **{text}** will be
@@ -294,6 +307,8 @@ export async function getline(
  * second argument:
  *
  *     GetText()->setline(lnum)
+ *
+ * Return type: `Number`
  */
 export async function setline(
   denops: Denops,

--- a/function/cursor.ts
+++ b/function/cursor.ts
@@ -3,27 +3,25 @@ import type { Position, ScreenPos } from "./types.ts";
 
 /**
  * The result is a Number, which is the byte index of the column
- * position given with **{expr}**.  The accepted positions are:
- *     .       the cursor position
- *     $       the end of the cursor line (the result is the
- *             number of bytes in the cursor line plus one)
- *     'x      position of mark x (if the mark is not set, 0 is
- *             returned)
- *     v       In Visual mode: the start of the Visual area (the
- *             cursor is the end).  When not in Visual mode
- *             returns the cursor position.  Differs from `'<` in
- *             that it's updated right away.
+ * position given with **{expr}**.
+ * For accepted positions see `getpos()`.
+ * When **{expr}** is "$", it means the end of the cursor line, so
+ * the result is the number of bytes in the cursor line plus one.
  * Additionally **{expr}** can be [lnum, col]: a `List` with the line
  * and column number. Most useful when the column is "$", to get
  * the last column of a specific line.  When "lnum" or "col" is
  * out of range then col() returns zero.
+ *
  * With the optional **{winid}** argument the values are obtained for
  * that window instead of the current window.
+ *
  * To get the line number use `line()`.  To get both use
  * `getpos()`.
  * For the screen column position use `virtcol()`.  For the
  * character position use `charcol()`.
+ *
  * Note that only marks in the current file can be used.
+ *
  * Examples:
  *
  *     col(".")                column of cursor
@@ -45,6 +43,8 @@ import type { Position, ScreenPos } from "./types.ts";
  * Can also be used as a `method`:
  *
  *     GetPos()->col()
+ *
+ * Return type: `Number`
  */
 export async function col(
   denops: Denops,
@@ -65,7 +65,9 @@ export async function col(
  * set to 8, it returns 8. `conceal` is ignored.
  * For the byte position use `col()`.
  *
- * For the use of **{expr}** see `col()`.
+ * For the use of **{expr}** see `getpos()` and `col()`.
+ * When **{expr}** is "$", it means the end of the cursor line, so
+ * the result is the number of cells in the cursor line plus one.
  *
  * When 'virtualedit' is used **{expr}** can be [lnum, col, off],
  * where "off" is the offset in screen columns from the start of
@@ -73,19 +75,7 @@ export async function col(
  * last character.  When "off" is omitted zero is used.  When
  * Virtual editing is active in the current mode, a position
  * beyond the end of the line can be returned.  Also see
- * `'virtualedit'`
- *
- * The accepted positions are:
- *     .       the cursor position
- *     $       the end of the cursor line (the result is the
- *             number of displayed characters in the cursor line
- *             plus one)
- *     'x      position of mark x (if the mark is not set, 0 is
- *             returned)
- *     v       In Visual mode: the start of the Visual area (the
- *             cursor is the end).  When not in Visual mode
- *             returns the cursor position.  Differs from `'<` in
- *             that it's updated right away.
+ * 'virtualedit'
  *
  * If **{list}** is present and non-zero then virtcol() returns a
  * List with the first and last screen position occupied by the
@@ -95,6 +85,7 @@ export async function col(
  * that window instead of the current window.
  *
  * Note that only marks in the current file can be used.
+ *
  * Examples:
  *
  *     " With text "foo^Lbar" and cursor on the "^L":
@@ -108,6 +99,7 @@ export async function col(
  *     virtcol("'t")   " returns 6
  *
  * The first column is 1.  0 or [0, 0] is returned for an error.
+ *
  * A more advanced example that echoes the maximum length of
  * all lines:
  *
@@ -116,6 +108,8 @@ export async function col(
  * Can also be used as a `method`:
  *
  *     GetPos()->virtcol()
+ *
+ * Return type: `Number`
  */
 export async function virtcol(
   denops: Denops,
@@ -133,26 +127,16 @@ export async function virtcol(
 /**
  * The result is a Number, which is the line number of the file
  * position given with **{expr}**.  The **{expr}** argument is a string.
- * The accepted positions are:
- *     .       the cursor position
- *     $       the last line in the current buffer
- *     'x      position of mark x (if the mark is not set, 0 is
- *             returned)
- *     w0      first line visible in current window (one if the
- *             display isn't updated, e.g. in silent Ex mode)
- *     w$      last line visible in current window (this is one
- *             less than "w0" if no lines are visible)
- *     v       In Visual mode: the start of the Visual area (the
- *             cursor is the end).  When not in Visual mode
- *             returns the cursor position.  Differs from `'<` in
- *             that it's updated right away.
- * Note that a mark in another file can be used.  The line number
- * then applies to another buffer.
+ * See `getpos()` for accepted positions.
+ *
  * To get the column number use `col()`.  To get both use
  * `getpos()`.
+ *
  * With the optional **{winid}** argument the values are obtained for
  * that window instead of the current window.
+ *
  * Returns 0 for invalid values of **{expr}** and **{winid}**.
+ *
  * Examples:
  *
  *     line(".")               line number of the cursor
@@ -166,6 +150,8 @@ export async function virtcol(
  * Can also be used as a `method`:
  *
  *     GetValue()->line()
+ *
+ * Return type: `Number`
  */
 export async function line(
   denops: Denops,
@@ -179,6 +165,8 @@ export async function line(
  * The result is a Number, which is the virtual column of the
  * cursor in the window.  This is counting screen cells from the
  * left side of the window.  The leftmost column is one.
+ *
+ * Return type: `Number`
  */
 export async function wincol(denops: Denops): Promise<number> {
   return await denops.call("wincol") as number;
@@ -190,6 +178,8 @@ export async function wincol(denops: Denops): Promise<number> {
  * the window.  The first line is one.
  * If the cursor was moved the view on the file will be updated
  * first, this may cause a scroll.
+ *
+ * Return type: `Number`
  */
 export async function winline(denops: Denops): Promise<number> {
   return await denops.call("winline") as number;
@@ -230,6 +220,8 @@ export async function winline(denops: Denops): Promise<number> {
  * Can also be used as a `method`:
  *
  *     GetCursorPos()->cursor()
+ *
+ * Return type: `Number`
  */
 export async function cursor(
   denops: Denops,
@@ -282,6 +274,8 @@ export async function cursor(
  * Can also be used as a `method`:
  *
  *     GetWinid()->screenpos(lnum, col)
+ *
+ * Return type: dict<number> or dict<any>
  */
 export async function screenpos(
   denops: Denops,
@@ -322,6 +316,8 @@ export async function screenpos(
  * Can also be used as a `method`:
  *
  *     GetWinid()->getcurpos()
+ *
+ * Return type: list<number>
  */
 export async function getcurpos(
   denops: Denops,
@@ -331,9 +327,34 @@ export async function getcurpos(
 }
 
 /**
- * Get the position for String **{expr}**.  For possible values of
- * **{expr}** see `line()`.  For getting the cursor position see
- * `getcurpos()`.
+ * Get the position for String **{expr}**.
+ * The accepted values for **{expr}** are:
+ *     .       The cursor position.
+ *     $       The last line in the current buffer.
+ *     'x      Position of mark x (if the mark is not set, 0 is
+ *             returned for all values).
+ *     w0      First line visible in current window (one if the
+ *             display isn't updated, e.g. in silent Ex mode).
+ *     w$      Last line visible in current window (this is one
+ *             less than "w0" if no lines are visible).
+ *     v       When not in Visual mode, returns the cursor
+ *             position.  In Visual mode, returns the other end
+ *             of the Visual area.  A good way to think about
+ *             this is that in Visual mode "v" and "." complement
+ *             each other.  While "." refers to the cursor
+ *             position, "v" refers to where `v_o` would move the
+ *             cursor.  As a result, you can use "v" and "."
+ *             together to work on all of a selection in
+ *             characterwise Visual mode.  If the cursor is at
+ *             the end of a characterwise Visual area, "v" refers
+ *             to the start of the same Visual area.  And if the
+ *             cursor is at the start of a characterwise Visual
+ *             area, "v" refers to the end of the same Visual
+ *             area.  "v" differs from `'<` and `'>` in that it's
+ *             updated right away.
+ * Note that a mark in another file can be used.  The line number
+ * then applies to another buffer.
+ *
  * The result is a `List` with four numbers:
  *     [bufnum, lnum, col, off]
  * "bufnum" is zero, unless a mark like '0 or 'A is used, then it
@@ -344,15 +365,19 @@ export async function getcurpos(
  * it is the offset in screen columns from the start of the
  * character.  E.g., a position within a `<Tab>` or after the last
  * character.
- * Note that for '< and '> Visual mode matters: when it is "V"
- * (visual line mode) the column of '< is zero and the column of
- * '> is a large number equal to `v:maxcol`.
+ *
+ * For getting the cursor position see `getcurpos()`.
  * The column number in the returned List is the byte position
  * within the line. To get the character position in the line,
  * use `getcharpos()`.
+ *
+ * Note that for '< and '> Visual mode matters: when it is "V"
+ * (visual line mode) the column of '< is zero and the column of
+ * '> is a large number equal to `v:maxcol`.
  * A very large column number equal to `v:maxcol` can be returned,
  * in which case it means "after the end of the line".
  * If **{expr}** is invalid, returns a list with all zeros.
+ *
  * This can be used to save and restore the position of a mark:
  *
  *     let save_a_mark = getpos("'a")
@@ -364,6 +389,8 @@ export async function getcurpos(
  * Can also be used as a `method`:
  *
  *     GetMark()->getpos()
+ *
+ * Return type: list<number>
  */
 export async function getpos(denops: Denops, expr: string): Promise<Position> {
   return await denops.call("getpos", expr) as Position;
@@ -421,6 +448,8 @@ export async function getpos(denops: Denops, expr: string): Promise<Position> {
  * Can also be used as a `method`:
  *
  *     GetPosition()->setpos('.')
+ *
+ * Return type: `Number`
  */
 export async function setpos(
   denops: Denops,
@@ -443,6 +472,8 @@ export async function setpos(
  * Can also be used as a `method`:
  *
  *     GetOffset()->byte2line()
+ *
+ * Return type: `Number`
  *
  * *not available when compiled without the `+byte_offset`
  * feature*
@@ -470,6 +501,8 @@ export async function byte2line(denops: Denops, byte: number): Promise<number> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->line2byte()
+ *
+ * Return type: `Number`
  */
 export async function line2byte(denops: Denops, lnum: number): Promise<number> {
   return await denops.call("line2byte", lnum) as number;
@@ -487,6 +520,8 @@ export async function line2byte(denops: Denops, lnum: number): Promise<number> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->diff_filler()
+ *
+ * Return type: `Number`
  */
 // deno-lint-ignore camelcase
 export async function diff_filler(

--- a/function/getreginfo.ts
+++ b/function/getreginfo.ts
@@ -61,6 +61,8 @@ export type GetreginfoResult = {
  * Can also be used as a `method`:
  *
  *     GetRegname()->getreginfo()
+ *
+ * Return type: dict<any>
  */
 export function getreginfo(
   denops: Denops,

--- a/function/input.ts
+++ b/function/input.ts
@@ -53,6 +53,8 @@ import { type BuiltinCompletion, isValidBuiltinCompletion } from "./types.ts";
  * Can also be used as a `method`:
  *
  *     GetPrompt()->input()
+ *
+ * Return type: `String`
  */
 export function input(
   denops: Denops,
@@ -91,6 +93,8 @@ export function input(
  * Can also be used as a `method`:
  *
  *     GetChoices()->inputlist()
+ *
+ * Return type: `Number`
  */
 export function inputlist(denops: Denops, textlist: string[]): Promise<number> {
   return denops.call("inputlist", textlist) as Promise<number>;
@@ -101,6 +105,8 @@ export function inputlist(denops: Denops, textlist: string[]): Promise<number> {
  * Should be called the same number of times inputsave() is
  * called.  Calling it more often is harmless though.
  * Returns TRUE when there is nothing to restore, FALSE otherwise.
+ *
+ * Return type: `Number`
  */
 export async function inputrestore(denops: Denops): Promise<boolean> {
   const result = await denops.call("inputrestore") as number;
@@ -114,6 +120,8 @@ export async function inputrestore(denops: Denops): Promise<boolean> {
  * be used several times, in which case there must be just as
  * many inputrestore() calls.
  * Returns TRUE when out of memory, FALSE otherwise.
+ *
+ * Return type: `Number`
  */
 export async function inputsave(denops: Denops): Promise<boolean> {
   const result = await denops.call("inputsave") as number;
@@ -134,6 +142,8 @@ export async function inputsave(denops: Denops): Promise<boolean> {
  * Can also be used as a `method`:
  *
  *     GetPrompt()->inputsecret()
+ *
+ * Return type: `String`
  */
 export function inputsecret(
   denops: Denops,

--- a/function/nvim/_generated.ts
+++ b/function/nvim/_generated.ts
@@ -15,6 +15,7 @@ import type { Denops } from "@denops/core";
  * Attributes:
  *     `RPC` only
  *     Lua `vim.api` only
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - **{chan}**  id of the channel
@@ -35,6 +36,9 @@ export function nvim_chan_send(
 /**
  * Creates a new, empty, unnamed buffer.
  *
+ * Attributes:
+ *     Since: 0.4.0
+ *
  * Parameters:
  *   - **{listed}**   Sets 'buflisted'
  *   - **{scratch}**  Creates a "throwaway" `scratch-buffer` for temporary work
@@ -42,7 +46,7 @@ export function nvim_chan_send(
  *                buffer.
  *
  * Return:
- *     Buffer handle, or 0 on error
+ *     Buffer id, or 0 on error
  *
  * See also:
  *   - buf_open_scratch
@@ -64,6 +68,7 @@ export function nvim_create_buf(
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.1.0
  */
 export function nvim_del_current_line(denops: Denops): Promise<unknown>;
 export function nvim_del_current_line(
@@ -77,6 +82,9 @@ export function nvim_del_current_line(
  * Unmaps a global `mapping` for the given mode.
  *
  * To unmap a buffer-local mapping, use `nvim_buf_del_keymap()`.
+ *
+ * Attributes:
+ *     Since: 0.4.0
  *
  * See also:
  *   - `nvim_set_keymap()`
@@ -99,6 +107,9 @@ export function nvim_del_keymap(
  * Note:
  *   - Lowercase name (or other buffer-local mark) is an error.
  *
+ * Attributes:
+ *     Since: 0.6.0
+ *
  * Parameters:
  *   - **{name}**  Mark name
  *
@@ -120,6 +131,9 @@ export function nvim_del_mark(
 /**
  * Removes a global (g:) variable.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
  *   - **{name}**  Variable name
  */
@@ -132,18 +146,25 @@ export function nvim_del_var(
 }
 
 /**
- * Echo a message.
+ * Prints a message given by a list of `[text, hl_group]` "chunks".
+ *
+ * Example:
+ *
+ *     vim.api.nvim_echo({ { 'chunk1-line1\nchunk1-line2\n' }, { 'chunk2-line1' } }, true, {})
+ *
+ * Attributes:
+ *     Since: 0.5.0
  *
  * Parameters:
- *   - **{chunks}**   A list of `[text, hl_group]` arrays, each representing a
- *                text chunk with specified highlight. `hl_group` element can
- *                be omitted for no highlight.
+ *   - **{chunks}**   List of `[text, hl_group]` pairs, where each is a `text`
+ *                string highlighted by the (optional) name or ID `hl_group`.
  *   - **{history}**  if true, add to `message-history`.
  *   - **{opts}**     Optional parameters.
- *                - verbose: Message was printed as a result of 'verbose'
- *                  option if Nvim was invoked with -V3log_file, the message
- *                  will be redirected to the log_file and suppressed from
- *                  direct output.
+ *                - err: Treat the message like `:echoerr`. Sets `hl_group`
+ *                  to `hl-ErrorMsg` by default.
+ *                - verbose: Message is controlled by the 'verbose' option.
+ *                  Nvim invoked with `-V3log` will write the message to the
+ *                  "log" file instead of standard output.
  */
 export function nvim_echo(
   denops: Denops,
@@ -159,46 +180,11 @@ export function nvim_echo(
 }
 
 /**
- * Writes a message to the Vim error buffer. Does not append "\n", the
- * message is buffered (won't display) until a linefeed is written.
- *
- * Parameters:
- *   - **{str}**  Message
- */
-export function nvim_err_write(denops: Denops, str: unknown): Promise<unknown>;
-export function nvim_err_write(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_err_write", ...args);
-}
-
-/**
- * Writes a message to the Vim error buffer. Appends "\n", so the buffer is
- * flushed (and displayed).
- *
- * Parameters:
- *   - **{str}**  Message
- *
- * See also:
- *   - nvim_err_write()
- */
-export function nvim_err_writeln(
-  denops: Denops,
-  str: unknown,
-): Promise<unknown>;
-export function nvim_err_writeln(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_err_writeln", ...args);
-}
-
-/**
  * Evaluates statusline string.
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.6.0
  *
  * Parameters:
  *   - **{str}**   Statusline string (see 'statusline').
@@ -218,15 +204,17 @@ export function nvim_err_writeln(
  *               line number instead of statusline.
  *
  * Return:
- *     Dictionary containing statusline information, with these keys:
+ *     Dict containing statusline information, with these keys:
  *     - str: (string) Characters that will be displayed on the statusline.
  *     - width: (number) Display width of the statusline.
  *     - highlights: Array containing highlight information of the
  *       statusline. Only included when the "highlights" key in **{opts}** is
- *       true. Each element of the array is a `Dictionary` with these keys:
+ *       true. Each element of the array is a `Dict` with these keys:
  *       - start: (number) Byte index (0-based) of first character that uses
  *         the highlight.
- *       - group: (string) Name of highlight group.
+ *       - group: (string) Deprecated. Use `groups` instead.
+ *       - groups: (array) Names of stacked highlight groups (highest
+ *         priority last).
  */
 export function nvim_eval_statusline(
   denops: Denops,
@@ -249,6 +237,7 @@ export function nvim_eval_statusline(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - **{code}**  Lua code to execute
@@ -284,6 +273,9 @@ export function nvim_exec_lua(
  *     :let key = nvim_replace_termcodes("<C-o>", v:true, v:false, v:true)
  *     :call nvim_feedkeys(key, 'n', v:false)
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
  *   - **{keys}**       to be typed
  *   - **{mode}**       behavior flags, see `feedkeys()`
@@ -310,11 +302,12 @@ export function nvim_feedkeys(
 
 /**
  * Returns a 2-tuple (Array), where item 0 is the current channel id and item
- * 1 is the `api-metadata` map (Dictionary).
+ * 1 is the `api-metadata` map (Dict).
  *
  * Attributes:
  *     `api-fast`
  *     `RPC` only
+ *     Since: 0.1.0
  *
  * Return:
  *     2-tuple `[{channel-id}, {api-metadata}]`
@@ -330,11 +323,16 @@ export function nvim_get_api_info(
 /**
  * Gets information about a channel.
  *
+ * See `nvim_list_uis()` for an example of how to get channel info.
+ *
+ * Attributes:
+ *     Since: 0.3.0
+ *
  * Parameters:
  *   - **{chan}**  channel_id, or 0 for current channel
  *
  * Return:
- *     Dictionary describing a channel, with these keys:
+ *     Channel info dict with these keys:
  *     - "id" Channel id.
  *     - "argv" (optional) Job arguments list.
  *     - "stream" Stream underlying the channel.
@@ -347,11 +345,11 @@ export function nvim_get_api_info(
  *       - "terminal" `terminal` instance interprets ASCII sequences.
  *       - "rpc" `RPC` communication on the channel is active.
  *     - "pty" (optional) Name of pseudoterminal. On a POSIX system this is a
- *       device path like "/dev/pts/1". If the name is unknown, the key will
- *       still be present if a pty is used (e.g. for conpty on Windows).
- *     - "buffer" (optional) Buffer with connected `terminal` instance.
+ *       device path like "/dev/pts/1". If unknown, the key will still be
+ *       present if a pty is used (e.g. for conpty on Windows).
+ *     - "buffer" (optional) Buffer connected to `terminal` instance.
  *     - "client" (optional) Info about the peer (client on the other end of
- *       the RPC channel), if provided by it via `nvim_set_client_info()`.
+ *       the channel), as set by `nvim_set_client_info()`.
  */
 export function nvim_get_chan_info(
   denops: Denops,
@@ -372,6 +370,9 @@ export function nvim_get_chan_info(
  *
  *     :echo nvim_get_color_by_name("Pink")
  *     :echo nvim_get_color_by_name("#cbcbcb")
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{name}**  Color name or "#rrggbb" string
@@ -396,6 +397,9 @@ export function nvim_get_color_by_name(
  * Keys are color names (e.g. "Aqua") and values are 24-bit RGB color values
  * (e.g. 65535).
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Return:
  *     Map of color names and RGB values.
  */
@@ -409,6 +413,9 @@ export function nvim_get_color_map(
 
 /**
  * Gets a map of the current editor state.
+ *
+ * Attributes:
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{opts}**  Optional parameters.
@@ -432,8 +439,11 @@ export function nvim_get_context(
 /**
  * Gets the current buffer.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Return:
- *     Buffer handle
+ *     Buffer id
  */
 export function nvim_get_current_buf(denops: Denops): Promise<unknown>;
 export function nvim_get_current_buf(
@@ -445,6 +455,9 @@ export function nvim_get_current_buf(
 
 /**
  * Gets the current line.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Return:
  *     Current line string
@@ -460,8 +473,11 @@ export function nvim_get_current_line(
 /**
  * Gets the current tabpage.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Return:
- *     Tabpage handle
+ *     `tab-ID`
  */
 export function nvim_get_current_tabpage(denops: Denops): Promise<unknown>;
 export function nvim_get_current_tabpage(
@@ -474,8 +490,11 @@ export function nvim_get_current_tabpage(
 /**
  * Gets the current window.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Return:
- *     Window handle
+ *     `window-ID`
  */
 export function nvim_get_current_win(denops: Denops): Promise<unknown>;
 export function nvim_get_current_win(
@@ -491,6 +510,9 @@ export function nvim_get_current_win(
  * Note:
  *   - When the `link` attribute is defined in the highlight definition map,
  *     other attributes will not be taking effect (see `:hi-link`).
+ *
+ * Attributes:
+ *     Since: 0.9.0
  *
  * Parameters:
  *   - {ns_id}  Get highlight groups for namespace ns_id
@@ -525,6 +547,9 @@ export function nvim_get_hl(
  * Gets a highlight group by name
  *
  * similar to `hlID()`, but allocates a new ID if not present.
+ *
+ * Attributes:
+ *     Since: 0.5.0
  */
 export function nvim_get_hl_id_by_name(
   denops: Denops,
@@ -539,6 +564,9 @@ export function nvim_get_hl_id_by_name(
 
 /**
  * Gets the active highlight namespace.
+ *
+ * Attributes:
+ *     Since: 0.10.0
  *
  * Parameters:
  *   - **{opts}**  Optional parameters
@@ -560,6 +588,9 @@ export function nvim_get_hl_ns(
 
 /**
  * Gets a list of global (non-buffer-local) `mapping` definitions.
+ *
+ * Attributes:
+ *     Since: 0.2.1
  *
  * Parameters:
  *   - **{mode}**  Mode short-name ("n", "i", "v", ...)
@@ -588,6 +619,9 @@ export function nvim_get_keymap(
  *
  * Note:
  *   - Lowercase name (or other buffer-local mark) is an error.
+ *
+ * Attributes:
+ *     Since: 0.6.0
  *
  * Parameters:
  *   - **{name}**  Mark name
@@ -619,9 +653,10 @@ export function nvim_get_mark(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.2.0
  *
  * Return:
- *     Dictionary { "mode": String, "blocking": Boolean }
+ *     Dict { "mode": String, "blocking": Boolean }
  */
 export function nvim_get_mode(denops: Denops): Promise<unknown>;
 export function nvim_get_mode(
@@ -633,6 +668,9 @@ export function nvim_get_mode(
 
 /**
  * Gets info describing process `pid`.
+ *
+ * Attributes:
+ *     Since: 0.3.0
  *
  * Return:
  *     Map of process properties, or NIL if process not found.
@@ -647,6 +685,9 @@ export function nvim_get_proc(
 
 /**
  * Gets the immediate children of process `pid`.
+ *
+ * Attributes:
+ *     Since: 0.3.0
  *
  * Return:
  *     Array of child process ids, empty if process not found.
@@ -663,17 +704,18 @@ export function nvim_get_proc_children(
 }
 
 /**
- * Find files in runtime directories
+ * Finds files in runtime directories, in 'runtimepath' order.
  *
  * "name" can contain wildcards. For example
- * nvim_get_runtime_file("colors/*.vim", true) will return all color scheme
- * files. Always use forward slashes (/) in the search pattern for
+ * `nvim_get_runtime_file("colors/*.{vim,lua}", true)` will return all color
+ * scheme files. Always use forward slashes (/) in the search pattern for
  * subdirectories regardless of platform.
  *
  * It is not an error to not find any files. An empty array is returned then.
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - **{name}**  pattern of files to search for
@@ -697,6 +739,9 @@ export function nvim_get_runtime_file(
 /**
  * Gets a global (g:) variable.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
  *   - **{name}**  Variable name
  *
@@ -713,6 +758,9 @@ export function nvim_get_var(
 
 /**
  * Gets a v: variable.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{name}**  Variable name
@@ -733,6 +781,9 @@ export function nvim_get_vvar(
  * input buffer and the call is non-blocking (input is processed
  * asynchronously by the eventloop).
  *
+ * To input blocks of text, `nvim_paste()` is much faster and should be
+ * preferred.
+ *
  * On execution error: does not fail, but updates v:errmsg.
  *
  * Note:
@@ -743,6 +794,7 @@ export function nvim_get_vvar(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{keys}**  to be typed
@@ -774,6 +826,7 @@ export function nvim_input(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{button}**    Mouse button: one of "left", "right", "middle", "wheel",
@@ -806,13 +859,16 @@ export function nvim_input_mouse(
 }
 
 /**
- * Gets the current list of buffer handles
+ * Gets the current list of buffers.
  *
  * Includes unlisted (unloaded/deleted) buffers, like `:ls!`. Use
  * `nvim_buf_is_loaded()` to check if a buffer is loaded.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Return:
- *     List of buffer handles
+ *     List of buffer ids
  */
 export function nvim_list_bufs(denops: Denops): Promise<unknown>;
 export function nvim_list_bufs(
@@ -824,6 +880,9 @@ export function nvim_list_bufs(
 
 /**
  * Get information about all open channels.
+ *
+ * Attributes:
+ *     Since: 0.3.0
  *
  * Return:
  *     Array of Dictionaries, each describing a channel with the format
@@ -840,6 +899,9 @@ export function nvim_list_chans(
 /**
  * Gets the paths contained in `runtime-search-path`.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Return:
  *     List of paths
  */
@@ -852,10 +914,13 @@ export function nvim_list_runtime_paths(
 }
 
 /**
- * Gets the current list of tabpage handles.
+ * Gets the current list of `tab-ID`s.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Return:
- *     List of tabpage handles
+ *     List of `tab-ID`s
  */
 export function nvim_list_tabpages(denops: Denops): Promise<unknown>;
 export function nvim_list_tabpages(
@@ -867,6 +932,15 @@ export function nvim_list_tabpages(
 
 /**
  * Gets a list of dictionaries representing attached UIs.
+ *
+ * Example: The Nvim builtin `TUI` sets its channel info as described in
+ * `startup-tui`. In particular, it sets `client.name` to "nvim-tui". So you
+ * can check if the TUI is running by inspecting the client name of each UI:
+ *
+ *     vim.print(vim.api.nvim_get_chan_info(vim.api.nvim_list_uis()[1].chan).client.name)
+ *
+ * Attributes:
+ *     Since: 0.3.0
  *
  * Return:
  *     Array of UI dictionaries, each with these keys:
@@ -885,10 +959,13 @@ export function nvim_list_uis(
 }
 
 /**
- * Gets the current list of window handles.
+ * Gets the current list of all `window-ID`s in all tabpages.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Return:
- *     List of window handles
+ *     List of `window-ID`s
  */
 export function nvim_list_wins(denops: Denops): Promise<unknown>;
 export function nvim_list_wins(
@@ -900,6 +977,9 @@ export function nvim_list_wins(
 
 /**
  * Sets the current editor state from the given `context` map.
+ *
+ * Attributes:
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{dict}**  `Context` map.
@@ -916,34 +996,10 @@ export function nvim_load_context(
 }
 
 /**
- * Notify the user with a message
- *
- * Relays the call to vim.notify . By default forwards your message in the
- * echo area but can be overridden to trigger desktop notifications.
- *
- * Parameters:
- *   - **{msg}**        Message to display to the user
- *   - {log_level}  The log level
- *   - **{opts}**       Reserved for future use.
- */
-export function nvim_notify(
-  denops: Denops,
-  msg: unknown,
-  log_level: unknown,
-  opts: unknown,
-): Promise<unknown>;
-export function nvim_notify(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_notify", ...args);
-}
-
-/**
  * Open a terminal instance in a buffer
  *
  * By default (and currently the only option) the terminal will not be
- * connected to an external process. Instead, input send on the channel will
+ * connected to an external process. Instead, input sent on the channel will
  * be echoed directly by the terminal. This is useful to display ANSI
  * terminal sequences returned as part of a rpc message, or similar.
  *
@@ -954,8 +1010,17 @@ export function nvim_notify(
  * `nvim_chan_send()` can be called immediately to process sequences in a
  * virtual terminal having the intended size.
  *
+ * Example: this `TermHl` command can be used to display and highlight raw
+ * ANSI termcodes, so you can use Nvim as a "scrollback pager" (for terminals
+ * like kitty):
+ *
+ *     vim.api.nvim_create_user_command('TermHl', function()
+ *       vim.api.nvim_open_term(0, {})
+ *     end, { desc = 'Highlights ANSI termcodes in curbuf' })
+ *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - **{buffer}**  the buffer to use (expected to be empty)
@@ -985,36 +1050,36 @@ export function nvim_open_term(
 }
 
 /**
- * Writes a message to the Vim output buffer. Does not append "\n", the
- * message is buffered (won't display) until a linefeed is written.
+ * Pastes at cursor (in any mode), and sets "redo" so dot (`.`) will repeat
+ * the input. UIs call this to implement "paste", but it's also intended for
+ * use by scripts to input large, dot-repeatable blocks of text (as opposed
+ * to `nvim_input()` which is subject to mappings/events and is thus much
+ * slower).
  *
- * Parameters:
- *   - **{str}**  Message
- */
-export function nvim_out_write(denops: Denops, str: unknown): Promise<unknown>;
-export function nvim_out_write(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_out_write", ...args);
-}
-
-/**
- * Pastes at cursor, in any mode.
- *
- * Invokes the `vim.paste` handler, which handles each mode appropriately.
- * Sets redo/undo. Faster than `nvim_input()`. Lines break at LF ("\n").
+ * Invokes the `vim.paste()` handler, which handles each mode appropriately.
  *
  * Errors ('nomodifiable', `vim.paste()` failure, …) are reflected in `err`
  * but do not affect the return value (which is strictly decided by
- * `vim.paste()`). On error, subsequent calls are ignored ("drained") until
- * the next paste is initiated (phase 1 or -1).
+ * `vim.paste()`). On error or cancel, subsequent calls are ignored
+ * ("drained") until the next paste is initiated (phase 1 or -1).
+ *
+ * Useful in mappings and scripts to insert multiline text. Example:
+ *
+ *     vim.keymap.set('n', 'x', function()
+ *       vim.api.nvim_paste([[
+ *         line1
+ *         line2
+ *         line3
+ *       ]], false, -1)
+ *     end, { buffer = true })
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.4.0
  *
  * Parameters:
- *   - **{data}**   Multiline input. May be binary (containing NUL bytes).
+ *   - **{data}**   Multiline input. Lines break at LF ("\n"). May be binary
+ *              (containing NUL bytes).
  *   - **{crlf}**   Also break lines at CR and CRLF.
  *   - **{phase}**  -1: paste in a single call (i.e. without streaming). To
  *              "stream" a paste, call `nvim_paste` sequentially with these
@@ -1025,7 +1090,7 @@ export function nvim_out_write(
  *
  * Return:
  *     - true: Client may continue pasting.
- *     - false: Client must cancel the paste.
+ *     - false: Client should cancel the paste.
  */
 export function nvim_paste(
   denops: Denops,
@@ -1041,12 +1106,14 @@ export function nvim_paste(
 }
 
 /**
- * Puts text at cursor, in any mode.
+ * Puts text at cursor, in any mode. For dot-repeatable input, use
+ * `nvim_paste()`.
  *
  * Compare `:put` and `p` which are always linewise.
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{lines}**   `readfile()`-style list of lines. `channel-lines`
@@ -1073,6 +1140,9 @@ export function nvim_put(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Replaces terminal codes and `keycodes` (`<CR>`, `<Esc>`, ...) in a string with
  * the internal representation.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{str}**        String to be converted.
@@ -1107,6 +1177,9 @@ export function nvim_replace_termcodes(
  * in a mapping; use `<Cmd>` `:map-cmd` or a Lua mapping to ensure the mapping
  * doesn't end completion mode.
  *
+ * Attributes:
+ *     Since: 0.4.0
+ *
  * Parameters:
  *   - **{item}**    Index (zero-based) of the item to select. Value of -1
  *               selects nothing and restores the original text.
@@ -1131,27 +1204,25 @@ export function nvim_select_popupmenu_item(
 }
 
 /**
- * Self-identifies the client.
+ * Self-identifies the client, and sets optional flags on the channel.
+ * Defines the `client` object returned by `nvim_get_chan_info()`.
  *
- * The client/plugin/application should call this after connecting, to
- * provide hints about its identity and purpose, for debugging and
- * orchestration.
+ * Clients should call this just after connecting, to provide hints for
+ * debugging and orchestration. (Note: Something is better than nothing!
+ * Fields are optional, but at least set `name`.)
  *
  * Can be called more than once; the caller should merge old info if
  * appropriate. Example: library first identifies the channel, then a plugin
  * using that library later identifies itself.
  *
- * Note:
- *   - "Something is better than nothing". You don't need to include all the
- *     fields.
- *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.3.0
  *
  * Parameters:
- *   - **{name}**        Short name for the connected client
- *   - **{version}**     Dictionary describing the version, with these (optional)
- *                   keys:
+ *   - **{name}**        Client short-name. Sets the `client.name` field of
+ *                   `nvim_get_chan_info()`.
+ *   - **{version}**     Dict describing the version, with these (optional) keys:
  *                   - "major" major version (defaults to 0 if not set, for
  *                     no release yet)
  *                   - "minor" minor version
@@ -1186,6 +1257,7 @@ export function nvim_select_popupmenu_item(
  *                     inclusive.
  *   - **{attributes}**  Arbitrary string:string map of informal client
  *                   properties. Suggested keys:
+ *                   - "pid": Process id.
  *                   - "website": Client homepage URL (e.g. GitHub
  *                     repository)
  *                   - "license": License description ("Apache 2", "GPLv3",
@@ -1209,13 +1281,14 @@ export function nvim_set_client_info(
 }
 
 /**
- * Sets the current buffer.
+ * Sets the current window's buffer to `buffer`.
  *
  * Attributes:
  *     not allowed when `textlock` is active or in the `cmdwin`
+ *     Since: 0.1.0
  *
  * Parameters:
- *   - **{buffer}**  Buffer handle
+ *   - **{buffer}**  Buffer id
  */
 export function nvim_set_current_buf(
   denops: Denops,
@@ -1230,6 +1303,9 @@ export function nvim_set_current_buf(
 
 /**
  * Changes the global working directory.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{dir}**  Directory path
@@ -1246,10 +1322,11 @@ export function nvim_set_current_dir(
 }
 
 /**
- * Sets the current line.
+ * Sets the text on the current line.
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{line}**  Line contents
@@ -1270,9 +1347,10 @@ export function nvim_set_current_line(
  *
  * Attributes:
  *     not allowed when `textlock` is active or in the `cmdwin`
+ *     Since: 0.1.0
  *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle
+ *   - **{tabpage}**  `tab-ID` to focus
  */
 export function nvim_set_current_tabpage(
   denops: Denops,
@@ -1286,13 +1364,14 @@ export function nvim_set_current_tabpage(
 }
 
 /**
- * Sets the current window.
+ * Sets the current window (and tabpage, implicitly).
  *
  * Attributes:
  *     not allowed when `textlock` is active or in the `cmdwin`
+ *     Since: 0.1.0
  *
  * Parameters:
- *   - **{window}**  Window handle
+ *   - **{window}**  `window-ID` to focus
  */
 export function nvim_set_current_win(
   denops: Denops,
@@ -1319,6 +1398,9 @@ export function nvim_set_current_win(
  *     using these values results in an error.
  *   - If `link` is used in combination with other attributes; only the
  *     `link` will take effect (see `:hi-link`).
+ *
+ * Attributes:
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - {ns_id}  Namespace id for this highlight `nvim_create_namespace()`.
@@ -1371,6 +1453,9 @@ export function nvim_set_hl(
  * Set active namespace for highlights defined with `nvim_set_hl()`. This can
  * be set for a single window, see `nvim_win_set_hl_ns()`.
  *
+ * Attributes:
+ *     Since: 0.8.0
+ *
  * Parameters:
  *   - {ns_id}  the namespace to use
  */
@@ -1395,6 +1480,7 @@ export function nvim_set_hl_ns(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.8.0
  *
  * Parameters:
  *   - {ns_id}  the namespace to activate
@@ -1425,6 +1511,9 @@ export function nvim_set_hl_ns_fast(
  * is equivalent to:
  *
  *     nmap <nowait> <Space><NL> <Nop>
+ *
+ * Attributes:
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{mode}**  Mode short-name (map command prefix: "n", "i", "v", "x", …)
@@ -1460,6 +1549,9 @@ export function nvim_set_keymap(
 /**
  * Sets a global (g:) variable.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
  *   - **{name}**   Variable name
  *   - **{value}**  Variable value
@@ -1478,6 +1570,9 @@ export function nvim_set_var(
 
 /**
  * Sets a v: variable, if it is not readonly.
+ *
+ * Attributes:
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{name}**   Variable name
@@ -1499,6 +1594,9 @@ export function nvim_set_vvar(
  * Calculates the number of display cells occupied by `text`. Control
  * characters including `<Tab>` count as one cell.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
  *   - **{text}**  Some text
  *
@@ -1514,46 +1612,6 @@ export function nvim_strwidth(
 }
 
 /**
- * Subscribes to event broadcasts.
- *
- * Attributes:
- *     `RPC` only
- *
- * Parameters:
- *   - **{event}**  Event type string
- */
-export function nvim_subscribe(
-  denops: Denops,
-  event: unknown,
-): Promise<unknown>;
-export function nvim_subscribe(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_subscribe", ...args);
-}
-
-/**
- * Unsubscribes to event broadcasts.
- *
- * Attributes:
- *     `RPC` only
- *
- * Parameters:
- *   - **{event}**  Event type string
- */
-export function nvim_unsubscribe(
-  denops: Denops,
-  event: unknown,
-): Promise<unknown>;
-export function nvim_unsubscribe(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_unsubscribe", ...args);
-}
-
-/**
  * EXPERIMENTAL: this API may change in the future.
  *
  * Sets info for the completion item at the given index. If the info text was
@@ -1566,7 +1624,7 @@ export function nvim_unsubscribe(
  *              - info: (string) info text.
  *
  * Return:
- *     Dictionary containing these keys:
+ *     Dict containing these keys:
  *     - winid: (number) floating window id
  *     - bufnr: (number) buffer id in floating window
  */
@@ -1587,6 +1645,7 @@ export function nvim__complete_set(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.6.0
  *
  * Parameters:
  *   - **{pat}**   pattern of files to search for
@@ -1647,26 +1706,23 @@ export function nvim__id_array(
 }
 
 /**
- * Returns dictionary given as argument.
+ * Returns dict given as argument.
  *
  * This API function is used for testing. One should not rely on its presence
  * in plugins.
  *
  * Parameters:
- *   - **{dct}**  Dictionary to return.
+ *   - **{dct}**  Dict to return.
  *
  * Return:
  *     its argument.
  */
-export function nvim__id_dictionary(
-  denops: Denops,
-  dct: unknown,
-): Promise<unknown>;
-export function nvim__id_dictionary(
+export function nvim__id_dict(denops: Denops, dct: unknown): Promise<unknown>;
+export function nvim__id_dict(
   denops: Denops,
   ...args: unknown[]
 ): Promise<unknown> {
-  return denops.call("nvim__id_dictionary", ...args);
+  return denops.call("nvim__id_dict", ...args);
 }
 
 /**
@@ -1723,6 +1779,9 @@ export function nvim__invalidate_glyph_cache(
  *
  * Instruct Nvim to redraw various components.
  *
+ * Attributes:
+ *     Since: 0.10.0
+ *
  * Parameters:
  *   - **{opts}**  Optional parameters.
  *             - win: Target a specific `window-ID` as described below.
@@ -1774,8 +1833,11 @@ export function nvim__stats(
  *
  * On execution error: fails with Vimscript error, updates v:errmsg.
  *
+ * Attributes:
+ *     Since: 0.3.0
+ *
  * Parameters:
- *   - **{dict}**  Dictionary, or String evaluating to a Vimscript `self` dict
+ *   - **{dict}**  Dict, or String evaluating to a Vimscript `self` dict
  *   - **{fn}**    Name of the function defined on the Vimscript dict
  *   - **{args}**  Function arguments packed in an Array
  *
@@ -1799,6 +1861,9 @@ export function nvim_call_dict_function(
  * Calls a Vimscript function with the given arguments.
  *
  * On execution error: fails with Vimscript error, updates v:errmsg.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{fn}**    Function to call
@@ -1824,11 +1889,12 @@ export function nvim_call_function(
  *
  * On execution error: fails with Vimscript error, updates v:errmsg.
  *
- * Prefer using `nvim_cmd()` or `nvim_exec2()` over this. To evaluate
- * multiple lines of Vim script or an Ex command directly, use
- * `nvim_exec2()`. To construct an Ex command using a structured format and
- * then execute it, use `nvim_cmd()`. To modify an Ex command before
- * evaluating it, use `nvim_parse_cmd()` in conjunction with `nvim_cmd()`.
+ * Prefer `nvim_cmd()` or `nvim_exec2()` instead. To modify an Ex command in
+ * a structured way before executing it, modify the result of
+ * `nvim_parse_cmd()` then pass it to `nvim_cmd()`.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{command}**  Ex command string
@@ -1845,10 +1911,13 @@ export function nvim_command(
 }
 
 /**
- * Evaluates a Vimscript `expression`. Dictionaries and Lists are recursively
+ * Evaluates a Vimscript `expression`. Dicts and Lists are recursively
  * expanded.
  *
  * On execution error: fails with Vimscript error, updates v:errmsg.
+ *
+ * Attributes:
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{expr}**  Vimscript expression string
@@ -1873,6 +1942,9 @@ export function nvim_eval(
  *
  * On execution error: fails with Vimscript error, updates v:errmsg.
  *
+ * Attributes:
+ *     Since: 0.9.0
+ *
  * Parameters:
  *   - **{src}**   Vimscript code
  *   - **{opts}**  Optional parameters.
@@ -1880,7 +1952,7 @@ export function nvim_eval(
  *               return all (non-error, non-shell `:!`) output.
  *
  * Return:
- *     Dictionary containing information about execution, with these keys:
+ *     Dict containing information about execution, with these keys:
  *     - output: (string|nil) Output if `opts.output` is true.
  *
  * See also:
@@ -1905,6 +1977,7 @@ export function nvim_exec2(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.3.0
  *
  * Parameters:
  *   - **{expr}**       Expression to parse. Always treated as a single line.
@@ -1928,9 +2001,9 @@ export function nvim_exec2(
  *                  region [start_col, end_col)).
  *
  * Return:
- *     - AST: top-level dictionary with these keys:
- *       - "error": Dictionary with error, present only if parser saw some
- *         error. Contains the following keys:
+ *     - AST: top-level dict with these keys:
+ *       - "error": Dict with error, present only if parser saw some error.
+ *         Contains the following keys:
  *         - "message": String, error message in printf format, translated.
  *           Must contain exactly one "%.*s".
  *         - "arg": String, error message argument.
@@ -1938,7 +2011,7 @@ export function nvim_exec2(
  *         that should be equal to the length of expr string. ("Successfully
  *         parsed" here means "participated in AST creation", not "till the
  *         first error".)
- *       - "ast": AST, either nil or a dictionary with these keys:
+ *       - "ast": AST, either nil or a dict with these keys:
  *         - "type": node type, one of the value names from ExprASTNodeType
  *           stringified without "kExprNode" prefix.
  *         - "start": a pair `[line, column]` describing where node is
@@ -1992,8 +2065,11 @@ export function nvim_parse_expression(
 /**
  * Creates a buffer-local command `user-commands`.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
- *   - **{buffer}**   Buffer handle, or 0 for current buffer.
+ *   - **{buffer}**   Buffer id, or 0 for current buffer.
  *
  * See also:
  *   - nvim_create_user_command
@@ -2018,8 +2094,11 @@ export function nvim_buf_create_user_command(
  * Only commands created with `:command-buffer` or
  * `nvim_buf_create_user_command()` can be deleted with this function.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer.
+ *   - **{buffer}**  Buffer id, or 0 for current buffer.
  *   - **{name}**    Name of the command to delete.
  */
 export function nvim_buf_del_user_command(
@@ -2037,8 +2116,11 @@ export function nvim_buf_del_user_command(
 /**
  * Gets a map of buffer-local `user-commands`.
  *
+ * Attributes:
+ *     Since: 0.3.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{opts}**    Optional parameters. Currently not used.
  *
  * Return:
@@ -2059,8 +2141,8 @@ export function nvim_buf_get_commands(
 /**
  * Executes an Ex command.
  *
- * Unlike `nvim_command()` this command takes a structured Dictionary instead
- * of a String. This allows for easier construction and manipulation of an Ex
+ * Unlike `nvim_command()` this command takes a structured Dict instead of a
+ * String. This allows for easier construction and manipulation of an Ex
  * command. This also allows for things such as having spaces inside a
  * command argument, expanding filenames in a command that otherwise doesn't
  * expand filenames, etc. Command arguments may also be Number, Boolean or
@@ -2073,9 +2155,12 @@ export function nvim_buf_get_commands(
  *
  * On execution error: fails with Vimscript error, updates v:errmsg.
  *
+ * Attributes:
+ *     Since: 0.8.0
+ *
  * Parameters:
- *   - **{cmd}**   Command to execute. Must be a Dictionary that can contain the
- *             same values as the return value of `nvim_parse_cmd()` except
+ *   - **{cmd}**   Command to execute. Must be a Dict that can contain the same
+ *             values as the return value of `nvim_parse_cmd()` except
  *             "addr", "nargs" and "nextcmd" which are ignored if provided.
  *             All values except for "cmd" are optional.
  *   - **{opts}**  Optional parameters.
@@ -2109,6 +2194,9 @@ export function nvim_cmd(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     :call nvim_create_user_command('SayHello', 'echo "Hello world!"', {'bang': v:true})
  *     :SayHello
  *     Hello world!
+ *
+ * Attributes:
+ *     Since: 0.7.0
  *
  * Parameters:
  *   - **{name}**     Name of the new user command. Must begin with an uppercase
@@ -2168,6 +2256,9 @@ export function nvim_create_user_command(
 /**
  * Delete a user-defined command.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{name}**  Name of the command to delete.
  */
@@ -2186,6 +2277,9 @@ export function nvim_del_user_command(
  * Gets a map of global (non-buffer-local) Ex commands.
  *
  * Currently only `user-commands` are supported, not builtin Ex commands.
+ *
+ * Attributes:
+ *     Since: 0.3.0
  *
  * Parameters:
  *   - **{opts}**  Optional parameters. Currently only supports **{"builtin":false}**
@@ -2214,13 +2308,14 @@ export function nvim_get_commands(
  *
  * Attributes:
  *     `api-fast`
+ *     Since: 0.8.0
  *
  * Parameters:
  *   - **{str}**   Command line string to parse. Cannot contain "\n".
  *   - **{opts}**  Optional parameters. Reserved for future use.
  *
  * Return:
- *     Dictionary containing command information, with these keys:
+ *     Dict containing command information, with these keys:
  *     - cmd: (string) Command name.
  *     - range: (array) (optional) Command range (`<line1>` `<line2>`). Omitted
  *       if command doesn't accept a range. Otherwise, has no elements if no
@@ -2237,15 +2332,15 @@ export function nvim_get_commands(
  *     - nargs: (string) Value of `:command-nargs`.
  *     - nextcmd: (string) Next command if there are multiple commands
  *       separated by a `:bar`. Empty if there isn't a next command.
- *     - magic: (dictionary) Which characters have special meaning in the
- *       command arguments.
+ *     - magic: (dict) Which characters have special meaning in the command
+ *       arguments.
  *       - file: (boolean) The command expands filenames. Which means
  *         characters such as "%", "#" and wildcards are expanded.
  *       - bar: (boolean) The "|" character is treated as a command separator
  *         and the double quote character (") is treated as the start of a
  *         comment.
- *     - mods: (dictionary) `:command-modifiers`.
- *       - filter: (dictionary) `:filter`.
+ *     - mods: (dict) `:command-modifiers`.
+ *       - filter: (dict) `:filter`.
  *         - pattern: (string) Filter pattern. Empty string if there is no
  *           filter.
  *         - force: (boolean) Whether filter is inverted or not.
@@ -2290,11 +2385,14 @@ export function nvim_parse_cmd(
 /**
  * Gets the option information for all options.
  *
- * The dictionary has the full option names as keys and option metadata
- * dictionaries as detailed at `nvim_get_option_info2()`.
+ * The dict has the full option names as keys and option metadata dicts as
+ * detailed at `nvim_get_option_info2()`.
+ *
+ * Attributes:
+ *     Since: 0.5.0
  *
  * Return:
- *     dictionary of all options
+ *     dict of all options
  *
  * See also:
  *   - `nvim_get_commands()`
@@ -2310,7 +2408,7 @@ export function nvim_get_all_options_info(
 /**
  * Gets the option information for one option from arbitrary buffer or window
  *
- * Resulting dictionary has keys:
+ * Resulting dict has keys:
  * - name: Name of the option (like 'filetype')
  * - shortname: Shortened name of the option (like 'ft')
  * - type: type of option ("string", "number" or "boolean")
@@ -2328,6 +2426,9 @@ export function nvim_get_all_options_info(
  * local value in the current buffer or window if it is available, otherwise
  * the global value information is returned. This behavior can be disabled by
  * explicitly specifying **{scope}** in the **{opts}** table.
+ *
+ * Attributes:
+ *     Since: 0.9.0
  *
  * Parameters:
  *   - **{name}**  Option name
@@ -2358,6 +2459,9 @@ export function nvim_get_option_info2(
  * `:set`: the local value of an option is returned if it exists; otherwise,
  * the global value is returned. Local values always correspond to the
  * current buffer or window, unless "buf" or "win" is set in **{opts}**.
+ *
+ * Attributes:
+ *     Since: 0.7.0
  *
  * Parameters:
  *   - **{name}**  Option name
@@ -2394,6 +2498,9 @@ export function nvim_get_option_value(
  *
  * Note the options **{win}** and **{buf}** cannot be used together.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{name}**   Option name
  *   - **{value}**  New option value
@@ -2429,8 +2536,11 @@ export function nvim_set_option_value(
  *       end,
  *     })
  *
+ * Attributes:
+ *     Since: 0.3.0
+ *
  * Parameters:
- *   - **{buffer}**       Buffer handle, or 0 for current buffer
+ *   - **{buffer}**       Buffer id, or 0 for current buffer
  *   - {send_buffer}  True if the initial notification should contain the
  *                    whole buffer: first notification will be
  *                    `nvim_buf_lines_event`. Else the first notification
@@ -2440,7 +2550,7 @@ export function nvim_set_option_value(
  *                    - on_lines: Lua callback invoked on change. Return a
  *                      truthy value (not `false` or `nil`) to detach. Args:
  *                      - the string "lines"
- *                      - buffer handle
+ *                      - buffer id
  *                      - b:changedtick
  *                      - first line that changed (zero-indexed)
  *                      - last line that was changed
@@ -2453,7 +2563,7 @@ export function nvim_set_option_value(
  *                      change compared to on_lines. Return a truthy value
  *                      (not `false` or `nil`) to detach. Args:
  *                      - the string "bytes"
- *                      - buffer handle
+ *                      - buffer id
  *                      - b:changedtick
  *                      - start row of the changed text (zero-indexed)
  *                      - start column of the changed text
@@ -2472,15 +2582,15 @@ export function nvim_set_option_value(
  *                    - on_changedtick: Lua callback invoked on changedtick
  *                      increment without text change. Args:
  *                      - the string "changedtick"
- *                      - buffer handle
+ *                      - buffer id
  *                      - b:changedtick
  *                    - on_detach: Lua callback invoked on detach. Args:
  *                      - the string "detach"
- *                      - buffer handle
+ *                      - buffer id
  *                    - on_reload: Lua callback invoked on reload. The entire
  *                      buffer content should be considered changed. Args:
  *                      - the string "reload"
- *                      - buffer handle
+ *                      - buffer id
  *                    - utf_sizes: include UTF-32 and UTF-16 size of the
  *                      replaced region, as args to `on_lines`.
  *                    - preview: also attach to command preview (i.e.
@@ -2508,23 +2618,24 @@ export function nvim_buf_attach(
 }
 
 /**
- * call a function with buffer as temporary current buffer
+ * Call a function with buffer as temporary current buffer.
  *
  * This temporarily switches current buffer to "buffer". If the current
- * window already shows "buffer", the window is not switched If a window
- * inside the current tabpage (including a float) already shows the buffer
- * One of these windows will be set as current window temporarily. Otherwise
- * a temporary scratch window (called the "autocmd window" for historical
- * reasons) will be used.
+ * window already shows "buffer", the window is not switched. If a window
+ * inside the current tabpage (including a float) already shows the buffer,
+ * then one of those windows will be set as current window temporarily.
+ * Otherwise a temporary scratch window (called the "autocmd window" for
+ * historical reasons) will be used.
  *
  * This is useful e.g. to call Vimscript functions that only work with the
- * current buffer/window currently, like `termopen()`.
+ * current buffer/window currently, like `jobstart(…, {'term': v:true})`.
  *
  * Attributes:
  *     Lua `vim.api` only
+ *     Since: 0.5.0
  *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{fun}**     Function to call inside the buffer (currently Lua callable
  *               only)
  *
@@ -2546,8 +2657,11 @@ export function nvim_buf_call(
 /**
  * Unmaps a buffer-local `mapping` for the given mode.
  *
+ * Attributes:
+ *     Since: 0.4.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * See also:
  *   - `nvim_del_keymap()`
@@ -2571,6 +2685,9 @@ export function nvim_buf_del_keymap(
  * Note:
  *   - only deletes marks set in the buffer, if the mark is not set in the
  *     buffer it will return false.
+ *
+ * Attributes:
+ *     Since: 0.6.0
  *
  * Parameters:
  *   - **{buffer}**  Buffer to set the mark on
@@ -2598,8 +2715,11 @@ export function nvim_buf_del_mark(
 /**
  * Removes a buffer-scoped (b:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{name}**    Variable name
  */
 export function nvim_buf_del_var(
@@ -2619,9 +2739,10 @@ export function nvim_buf_del_var(
  *
  * Attributes:
  *     not allowed when `textlock` is active or in the `cmdwin`
+ *     Since: 0.5.0
  *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{opts}**    Optional parameters. Keys:
  *               - force: Force deletion and ignore unsaved changes.
  *               - unload: Unloaded only, do not delete. See `:bunload`
@@ -2643,9 +2764,10 @@ export function nvim_buf_delete(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.3.0
  *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * Return:
  *     False if detach failed (because the buffer isn't loaded); otherwise
@@ -2669,8 +2791,11 @@ export function nvim_buf_detach(
 /**
  * Gets a changed tick of a buffer
  *
+ * Attributes:
+ *     Since: 0.2.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * Return:
  *     `b:changedtick` value.
@@ -2689,13 +2814,16 @@ export function nvim_buf_get_changedtick(
 /**
  * Gets a list of buffer-local `mapping` definitions.
  *
+ * Attributes:
+ *     Since: 0.2.1
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{mode}**    Mode short-name ("n", "i", "v", ...)
  *
  * Return:
  *     Array of `maparg()`-like dictionaries describing mappings. The
- *     "buffer" key holds the associated buffer handle.
+ *     "buffer" key holds the associated buffer id.
  */
 export function nvim_buf_get_keymap(
   denops: Denops,
@@ -2719,14 +2847,20 @@ export function nvim_buf_get_keymap(
  * Out-of-bounds indices are clamped to the nearest valid value, unless
  * `strict_indexing` is set.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**           Buffer handle, or 0 for current buffer
+ *   - **{buffer}**           Buffer id, or 0 for current buffer
  *   - **{start}**            First line index
  *   - **{end}**              Last line index, exclusive
  *   - {strict_indexing}  Whether out-of-bounds should be an error.
  *
  * Return:
  *     Array of lines, or empty array for unloaded buffer.
+ *
+ * See also:
+ *   - `nvim_buf_get_text()`
  */
 export function nvim_buf_get_lines(
   denops: Denops,
@@ -2749,8 +2883,11 @@ export function nvim_buf_get_lines(
  *
  * Marks are (1,0)-indexed. `api-indexing`
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{name}**    Mark name
  *
  * Return:
@@ -2776,8 +2913,11 @@ export function nvim_buf_get_mark(
 /**
  * Gets the full file name for the buffer
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * Return:
  *     Buffer name
@@ -2804,8 +2944,11 @@ export function nvim_buf_get_name(
  * Unlike `line2byte()`, throws error for out-of-bounds indexing. Returns -1
  * for unloaded buffer.
  *
+ * Attributes:
+ *     Since: 0.3.2
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{index}**   Line index
  *
  * Return:
@@ -2824,18 +2967,19 @@ export function nvim_buf_get_offset(
 }
 
 /**
- * Gets a range from the buffer.
- *
- * This differs from `nvim_buf_get_lines()` in that it allows retrieving only
- * portions of a line.
+ * Gets a range from the buffer (may be partial lines, unlike
+ * `nvim_buf_get_lines()`).
  *
  * Indexing is zero-based. Row indices are end-inclusive, and column indices
  * are end-exclusive.
  *
  * Prefer `nvim_buf_get_lines()` when retrieving entire lines.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
- *   - **{buffer}**     Buffer handle, or 0 for current buffer
+ *   - **{buffer}**     Buffer id, or 0 for current buffer
  *   - {start_row}  First line index
  *   - {start_col}  Starting column (byte offset) on first line
  *   - {end_row}    Last line index, inclusive
@@ -2864,8 +3008,11 @@ export function nvim_buf_get_text(
 /**
  * Gets a buffer-scoped (b:) variable.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{name}**    Variable name
  *
  * Return:
@@ -2887,8 +3034,11 @@ export function nvim_buf_get_var(
  * Checks if a buffer is valid and loaded. See `api-buffer` for more info
  * about unloaded buffers.
  *
+ * Attributes:
+ *     Since: 0.3.2
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * Return:
  *     true if the buffer is valid and loaded, false otherwise.
@@ -2911,8 +3061,11 @@ export function nvim_buf_is_loaded(
  *   - Even if a buffer is valid it may have been unloaded. See `api-buffer`
  *     for more info about unloaded buffers.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * Return:
  *     true if the buffer is valid, false otherwise.
@@ -2931,8 +3084,11 @@ export function nvim_buf_is_valid(
 /**
  * Returns the number of lines in the given buffer.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * Return:
  *     Line count, or 0 for unloaded buffer. `api-buffer`
@@ -2951,8 +3107,11 @@ export function nvim_buf_line_count(
 /**
  * Sets a buffer-local `mapping` for the given mode.
  *
+ * Attributes:
+ *     Since: 0.4.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *
  * See also:
  *   - `nvim_set_keymap()`
@@ -2977,7 +3136,7 @@ export function nvim_buf_set_keymap(
  *
  * Indexing is zero-based, end-exclusive. Negative indices are interpreted as
  * length+1+index: -1 refers to the index past the end. So to change or
- * delete the last element use start=-2 and end=-1.
+ * delete the last line use start=-2 and end=-1.
  *
  * To insert lines at a given index, set `start` and `end` to the same index.
  * To delete a range of lines, set `replacement` to an empty array.
@@ -2987,9 +3146,10 @@ export function nvim_buf_set_keymap(
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.1.0
  *
  * Parameters:
- *   - **{buffer}**           Buffer handle, or 0 for current buffer
+ *   - **{buffer}**           Buffer id, or 0 for current buffer
  *   - **{start}**            First line index
  *   - **{end}**              Last line index, exclusive
  *   - {strict_indexing}  Whether out-of-bounds should be an error.
@@ -3021,6 +3181,9 @@ export function nvim_buf_set_lines(
  *
  * Note:
  *   - Passing 0 as line deletes the mark
+ *
+ * Attributes:
+ *     Since: 0.6.0
  *
  * Parameters:
  *   - **{buffer}**  Buffer to set the mark on
@@ -3054,8 +3217,11 @@ export function nvim_buf_set_mark(
 /**
  * Sets the full file name for a buffer, like `:file_f`
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{name}**    Buffer name
  */
 export function nvim_buf_set_name(
@@ -3084,25 +3250,23 @@ export function nvim_buf_set_name(
  * `start_row = end_row = row` and `start_col = end_col = col`. To delete the
  * text in a range, use `replacement = {}`.
  *
- * Prefer `nvim_buf_set_lines()` if you are only adding or deleting entire
- * lines.
- *
- * Prefer `nvim_put()` if you want to insert text at the cursor position.
+ * Note:
+ *   - Prefer `nvim_buf_set_lines()` (for performance) to add or delete
+ *     entire lines.
+ *   - Prefer `nvim_paste()` or `nvim_put()` to insert (instead of replace)
+ *     text at cursor.
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.5.0
  *
  * Parameters:
- *   - **{buffer}**       Buffer handle, or 0 for current buffer
+ *   - **{buffer}**       Buffer id, or 0 for current buffer
  *   - {start_row}    First line index
  *   - {start_col}    Starting column (byte offset) on first line
  *   - {end_row}      Last line index, inclusive
  *   - {end_col}      Ending column (byte offset) on last line, exclusive
  *   - **{replacement}**  Array of lines to use as replacement
- *
- * See also:
- *   - `nvim_buf_set_lines()`
- *   - `nvim_put()`
  */
 export function nvim_buf_set_text(
   denops: Denops,
@@ -3123,8 +3287,11 @@ export function nvim_buf_set_text(
 /**
  * Sets a buffer-scoped (b:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - **{name}**    Variable name
  *   - **{value}**   Variable value
  */
@@ -3142,64 +3309,17 @@ export function nvim_buf_set_var(
 }
 
 /**
- * Adds a highlight to buffer.
- *
- * Useful for plugins that dynamically generate highlights to a buffer (like
- * a semantic highlighter or linter). The function adds a single highlight to
- * a buffer. Unlike `matchaddpos()` highlights follow changes to line
- * numbering (as lines are inserted/removed above the highlighted line), like
- * signs and marks do.
- *
- * Namespaces are used for batch deletion/updating of a set of highlights. To
- * create a namespace, use `nvim_create_namespace()` which returns a
- * namespace id. Pass it in to this function as `ns_id` to add highlights to
- * the namespace. All highlights in the same namespace can then be cleared
- * with single call to `nvim_buf_clear_namespace()`. If the highlight never
- * will be deleted by an API call, pass `ns_id = -1`.
- *
- * As a shorthand, `ns_id = 0` can be used to create a new namespace for the
- * highlight, the allocated id is then returned. If `hl_group` is the empty
- * string no highlight is added, but a new `ns_id` is still returned. This is
- * supported for backwards compatibility, new code should use
- * `nvim_create_namespace()` to create a new empty namespace.
- *
- * Parameters:
- *   - **{buffer}**     Buffer handle, or 0 for current buffer
- *   - {ns_id}      namespace to use or -1 for ungrouped highlight
- *   - {hl_group}   Name of the highlight group to use
- *   - **{line}**       Line to highlight (zero-indexed)
- *   - {col_start}  Start of (byte-indexed) column range to highlight
- *   - {col_end}    End of (byte-indexed) column range to highlight, or -1 to
- *                  highlight to end of line
- *
- * Return:
- *     The ns_id that was used
- */
-export function nvim_buf_add_highlight(
-  denops: Denops,
-  buffer: unknown,
-  ns_id: unknown,
-  hl_group: unknown,
-  line: unknown,
-  col_start: unknown,
-  col_end: unknown,
-): Promise<unknown>;
-export function nvim_buf_add_highlight(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim_buf_add_highlight", ...args);
-}
-
-/**
  * Clears `namespace`d objects (highlights, `extmarks`, virtual text) from a
  * region.
  *
  * Lines are 0-indexed. `api-indexing` To clear the namespace in the entire
  * buffer, specify line_start=0 and line_end=-1.
  *
+ * Attributes:
+ *     Since: 0.3.2
+ *
  * Parameters:
- *   - **{buffer}**      Buffer handle, or 0 for current buffer
+ *   - **{buffer}**      Buffer id, or 0 for current buffer
  *   - {ns_id}       Namespace to clear, or -1 to clear all namespaces.
  *   - {line_start}  Start of range of lines to clear
  *   - {line_end}    End of range of lines to clear (exclusive) or -1 to
@@ -3222,8 +3342,11 @@ export function nvim_buf_clear_namespace(
 /**
  * Removes an `extmark`.
  *
+ * Attributes:
+ *     Since: 0.5.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - {ns_id}   Namespace id from `nvim_create_namespace()`
  *   - **{id}**      Extmark id
  *
@@ -3246,8 +3369,11 @@ export function nvim_buf_del_extmark(
 /**
  * Gets the position (0-indexed) of an `extmark`.
  *
+ * Attributes:
+ *     Since: 0.5.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - {ns_id}   Namespace id from `nvim_create_namespace()`
  *   - **{id}**      Extmark id
  *   - **{opts}**    Optional parameters. Keys:
@@ -3283,8 +3409,11 @@ export function nvim_buf_get_extmark_by_id(
  *     vim.api.nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
  *     vim.api.nvim_buf_get_extmarks(0, my_ns, {0,0}, {-1,-1}, {})
  *
- * If `end` is less than `start`, traversal works backwards. (Useful with
- * `limit`, to get the first marks prior to a given position.)
+ * If `end` is less than `start`, marks are returned in reverse order.
+ * (Useful with `limit`, to get the first marks prior to a given position.)
+ *
+ * Note: For a reverse range, `limit` does not actually affect the traversed
+ * range, just how many marks are returned
  *
  * Note: when using extmark ranges (marks with a end_row/end_col position)
  * the `overlap` option might be useful. Otherwise only the start position of
@@ -3309,8 +3438,11 @@ export function nvim_buf_get_extmark_by_id(
  *     local all = api.nvim_buf_get_extmarks(0, ns, 0, -1, {})
  *     vim.print(ms)
  *
+ * Attributes:
+ *     Since: 0.5.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - {ns_id}   Namespace id from `nvim_create_namespace()` or -1 for all
  *               namespaces
  *   - **{start}**   Start of range: a 0-indexed (row, col) or valid extmark id
@@ -3363,8 +3495,11 @@ export function nvim_buf_get_extmarks(
  * earlier end position is not an error, but then it behaves like an empty
  * range (no highlighting).
  *
+ * Attributes:
+ *     Since: 0.5.0
+ *
  * Parameters:
- *   - **{buffer}**  Buffer handle, or 0 for current buffer
+ *   - **{buffer}**  Buffer id, or 0 for current buffer
  *   - {ns_id}   Namespace id from `nvim_create_namespace()`
  *   - **{line}**    Line where to place the mark, 0-based. `api-indexing`
  *   - **{col}**     Column where to place the mark, 0-based. `api-indexing`
@@ -3372,8 +3507,12 @@ export function nvim_buf_get_extmarks(
  *               - id : id of the extmark to edit.
  *               - end_row : ending line of the mark, 0-based inclusive.
  *               - end_col : ending col of the mark, 0-based exclusive.
- *               - hl_group : name of the highlight group used to highlight
- *                 this mark.
+ *               - hl_group : highlight group used for the text range. This
+ *                 and below highlight groups can be supplied either as a
+ *                 string or as an integer, the latter of which can be
+ *                 obtained using `nvim_get_hl_id_by_name()`.
+ *                 Multiple highlight groups can be stacked by passing an
+ *                 array (highest priority last).
  *               - hl_eol : when true, for a multiline highlight covering the
  *                 EOL of a line, continue the highlight for the rest of the
  *                 screen line (just like for diff and cursorline highlight).
@@ -3382,11 +3521,16 @@ export function nvim_buf_get_extmarks(
  *                 with specified highlight. `highlight` element can either
  *                 be a single highlight group, or an array of multiple
  *                 highlight groups that will be stacked (highest priority
- *                 last). A highlight group can be supplied either as a
- *                 string or as an integer, the latter which can be obtained
- *                 using `nvim_get_hl_id_by_name()`.
+ *                 last).
  *               - virt_text_pos : position of virtual text. Possible values:
  *                 - "eol": right after eol character (default).
+ *                 - "eol_right_align": display right aligned in the window
+ *                   unless the virtual text is longer than the space
+ *                   available. If the virtual text is too long, it is
+ *                   truncated to fit in the window after the EOL character.
+ *                   If the line is wrapped, the virtual text is shown after
+ *                   the end of the line rather than the previous screen
+ *                   line.
  *                 - "overlay": display over the specified column, without
  *                   shifting the underlying text.
  *                 - "right_align": display right aligned in the window.
@@ -3420,12 +3564,17 @@ export function nvim_buf_get_extmarks(
  *                 lines are placed below the buffer line containing the
  *                 mark.
  *               - virt_lines_above: place virtual lines above instead.
- *               - virt_lines_leftcol: Place extmarks in the leftmost column
- *                 of the window, bypassing sign and number columns.
+ *               - virt_lines_leftcol: Place virtual lines in the leftmost
+ *                 column of the window, bypassing sign and number columns.
+ *               - virt_lines_overflow: controls how to handle virtual lines
+ *                 wider than the window. Currently takes the one of the
+ *                 following values:
+ *                 - "trunc": truncate virtual lines on the right (default).
+ *                 - "scroll": virtual lines can scroll horizontally with
+ *                   'nowrap', otherwise the same as "trunc".
  *               - ephemeral : for use with `nvim_set_decoration_provider()`
  *                 callbacks. The mark will only be used for the current
- *                 redraw cycle, and not be permantently stored in the
- *                 buffer.
+ *                 redraw cycle, and not be permanently stored in the buffer.
  *               - right_gravity : boolean that indicates the direction the
  *                 extmark will be shifted in when new text is inserted (true
  *                 for right, false for left). Defaults to true.
@@ -3450,20 +3599,23 @@ export function nvim_buf_get_extmarks(
  *                 buffer or end of the line respectively. Defaults to true.
  *               - sign_text: string of length 1-2 used to display in the
  *                 sign column.
- *               - sign_hl_group: name of the highlight group used to
- *                 highlight the sign column text.
- *               - number_hl_group: name of the highlight group used to
- *                 highlight the number column.
- *               - line_hl_group: name of the highlight group used to
- *                 highlight the whole line.
- *               - cursorline_hl_group: name of the highlight group used to
- *                 highlight the sign column text when the cursor is on the
- *                 same line as the mark and 'cursorline' is enabled.
+ *               - sign_hl_group: highlight group used for the sign column
+ *                 text.
+ *               - number_hl_group: highlight group used for the number
+ *                 column.
+ *               - line_hl_group: highlight group used for the whole line.
+ *               - cursorline_hl_group: highlight group used for the sign
+ *                 column text when the cursor is on the same line as the
+ *                 mark and 'cursorline' is enabled.
  *               - conceal: string which should be either empty or a single
  *                 character. Enable concealing similar to `:syn-conceal`.
  *                 When a character is supplied it is used as `:syn-cchar`.
  *                 "hl_group" is used as highlight for the cchar if provided,
  *                 otherwise it defaults to `hl-Conceal`.
+ *               - conceal_lines: string which should be empty. When
+ *                 provided, lines in the range are not drawn at all
+ *                 (according to 'conceallevel'); the next unconcealed line
+ *                 is drawn instead.
  *               - spell: boolean indicating that spell checking should be
  *                 performed within this extmark
  *               - ui_watched: boolean that indicates the mark should be
@@ -3473,8 +3625,6 @@ export function nvim_buf_get_extmarks(
  *               - url: A URL to associate with this extmark. In the TUI, the
  *                 OSC 8 control sequence is used to generate a clickable
  *                 hyperlink to this URL.
- *               - scoped: boolean (EXPERIMENTAL) enables "scoping" for the
- *                 extmark. See `nvim__win_add_ns()`
  *
  * Return:
  *     Id of the created/updated extmark
@@ -3498,11 +3648,14 @@ export function nvim_buf_set_extmark(
  * Creates a new namespace or gets an existing one.
  *
  * Namespaces are used for buffer highlights and virtual text, see
- * `nvim_buf_add_highlight()` and `nvim_buf_set_extmark()`.
+ * `nvim_buf_set_extmark()`.
  *
  * Namespaces can be named or anonymous. If `name` matches an existing
  * namespace, the associated id is returned. If `name` is an empty string a
  * new, anonymous namespace is created.
+ *
+ * Attributes:
+ *     Since: 0.3.2
  *
  * Parameters:
  *   - **{name}**  Namespace name or empty string
@@ -3523,6 +3676,9 @@ export function nvim_create_namespace(
 
 /**
  * Gets existing, non-anonymous `namespace`s.
+ *
+ * Attributes:
+ *     Since: 0.3.2
  *
  * Return:
  *     dict that maps from names to namespace ids.
@@ -3550,7 +3706,7 @@ export function nvim_get_namespaces(
  * Note: this function should not be called often. Rather, the callbacks
  * themselves can be used to throttle unneeded callbacks. the `on_start`
  * callback can return `false` to disable the provider until the next redraw.
- * Similarly, return `false` in `on_win` will skip the `on_lines` calls for
+ * Similarly, return `false` in `on_win` will skip the `on_line` calls for
  * that window (but any extmarks set in `on_win` will still be used). A
  * plugin managing multiple sources of decoration should ideally only set one
  * provider, and merge the sources internally. You can use multiple `ns_id`
@@ -3559,14 +3715,15 @@ export function nvim_get_namespaces(
  * Note: doing anything other than setting extmarks is considered
  * experimental. Doing things like changing options are not explicitly
  * forbidden, but is likely to have unexpected consequences (such as 100% CPU
- * consumption). doing `vim.rpcnotify` should be OK, but `vim.rpcrequest` is
+ * consumption). Doing `vim.rpcnotify` should be OK, but `vim.rpcrequest` is
  * quite dubious for the moment.
  *
- * Note: It is not allowed to remove or update extmarks in 'on_line'
+ * Note: It is not allowed to remove or update extmarks in `on_line`
  * callbacks.
  *
  * Attributes:
  *     Lua `vim.api` only
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - {ns_id}  Namespace id from `nvim_create_namespace()`
@@ -3575,14 +3732,14 @@ export function nvim_get_namespaces(
  *
  *                  ["start", tick]
  *
- *              - on_buf: called for each buffer being redrawn (before window
- *                callbacks)
+ *              - on_buf: called for each buffer being redrawn (once per
+ *                edit, before window callbacks)
  *
  *                    ["buf", bufnr, tick]
  *
  *              - on_win: called when starting to redraw a specific window.
  *
- *                  ["win", winid, bufnr, topline, botline]
+ *                  ["win", winid, bufnr, toprow, botrow]
  *
  *              - on_line: called for each buffer line being redrawn. (The
  *                interaction with fold lines is subject to change)
@@ -3608,72 +3765,42 @@ export function nvim_set_decoration_provider(
 /**
  * EXPERIMENTAL: this API will change in the future.
  *
- * Scopes a namespace to the a window, so extmarks in the namespace will be
- * active only in the given window.
+ * Get the properties for namespace
  *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
- *   - {ns_id}   Namespace
+ *   - {ns_id}  Namespace
  *
  * Return:
- *     true if the namespace was added, else false
+ *     Map defining the namespace properties, see `nvim__ns_set()`
  */
-export function nvim__win_add_ns(
-  denops: Denops,
-  window: unknown,
-  ns_id: unknown,
-): Promise<unknown>;
-export function nvim__win_add_ns(
+export function nvim__ns_get(denops: Denops, ns_id: unknown): Promise<unknown>;
+export function nvim__ns_get(
   denops: Denops,
   ...args: unknown[]
 ): Promise<unknown> {
-  return denops.call("nvim__win_add_ns", ...args);
+  return denops.call("nvim__ns_get", ...args);
 }
 
 /**
  * EXPERIMENTAL: this API will change in the future.
  *
- * Unscopes a namespace (un-binds it from the given scope).
+ * Set some properties for namespace
  *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
- *   - {ns_id}   the namespace to remove
- *
- * Return:
- *     true if the namespace was removed, else false
+ *   - {ns_id}  Namespace
+ *   - **{opts}**   Optional parameters to set:
+ *              - wins: a list of windows to be scoped in
  */
-export function nvim__win_del_ns(
+export function nvim__ns_set(
   denops: Denops,
-  window: unknown,
   ns_id: unknown,
+  opts: unknown,
 ): Promise<unknown>;
-export function nvim__win_del_ns(
+export function nvim__ns_set(
   denops: Denops,
   ...args: unknown[]
 ): Promise<unknown> {
-  return denops.call("nvim__win_del_ns", ...args);
-}
-
-/**
- * EXPERIMENTAL: this API will change in the future.
- *
- * Gets the namespace scopes for a given window.
- *
- * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
- *
- * Return:
- *     a list of namespaces ids
- */
-export function nvim__win_get_ns(
-  denops: Denops,
-  window: unknown,
-): Promise<unknown>;
-export function nvim__win_get_ns(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("nvim__win_get_ns", ...args);
+  return denops.call("nvim__ns_set", ...args);
 }
 
 /**
@@ -3681,9 +3808,10 @@ export function nvim__win_get_ns(
  *
  * Attributes:
  *     Lua `vim.api` only
+ *     Since: 0.5.0
  *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{fun}**     Function to call inside the window (currently Lua callable
  *               only)
  *
@@ -3711,9 +3839,10 @@ export function nvim_win_call(
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.4.0
  *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{force}**   Behave like `:close!` The last window of a buffer with
  *               unwritten changes can be closed. The buffer will become
  *               hidden, even if 'hidden' is not set.
@@ -3733,8 +3862,11 @@ export function nvim_win_close(
 /**
  * Removes a window-scoped (w:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{name}**    Variable name
  */
 export function nvim_win_del_var(
@@ -3752,11 +3884,14 @@ export function nvim_win_del_var(
 /**
  * Gets the current buffer in a window
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
- *     Buffer handle
+ *     Buffer id
  */
 export function nvim_win_get_buf(
   denops: Denops,
@@ -3774,8 +3909,11 @@ export function nvim_win_get_buf(
  * (different windows showing the same buffer have independent cursor
  * positions). `api-indexing`
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     (row, col) tuple
@@ -3797,8 +3935,11 @@ export function nvim_win_get_cursor(
 /**
  * Gets the window height
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     Height as a count of rows
@@ -3817,8 +3958,11 @@ export function nvim_win_get_height(
 /**
  * Gets the window number
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     Window number
@@ -3837,8 +3981,11 @@ export function nvim_win_get_number(
 /**
  * Gets the window position in display cells. First position is zero.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     (row, col) tuple with the window position
@@ -3857,8 +4004,11 @@ export function nvim_win_get_position(
 /**
  * Gets the window tabpage
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     Tabpage that contains the window
@@ -3877,8 +4027,11 @@ export function nvim_win_get_tabpage(
 /**
  * Gets a window-scoped (w:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{name}**    Variable name
  *
  * Return:
@@ -3899,8 +4052,11 @@ export function nvim_win_get_var(
 /**
  * Gets the window width
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     Width as a count of columns
@@ -3926,9 +4082,10 @@ export function nvim_win_get_width(
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.5.0
  *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  */
 export function nvim_win_hide(
   denops: Denops,
@@ -3944,8 +4101,11 @@ export function nvim_win_hide(
 /**
  * Checks if a window is valid
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     true if the window is valid, false otherwise
@@ -3966,10 +4126,11 @@ export function nvim_win_is_valid(
  *
  * Attributes:
  *     not allowed when `textlock` is active
+ *     Since: 0.3.2
  *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
- *   - **{buffer}**  Buffer handle
+ *   - **{window}**  `window-ID`, or 0 for current window
+ *   - **{buffer}**  Buffer id
  */
 export function nvim_win_set_buf(
   denops: Denops,
@@ -3987,8 +4148,11 @@ export function nvim_win_set_buf(
  * Sets the (1,0)-indexed cursor position in the window. `api-indexing` This
  * scrolls the window even if it is not the current one.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{pos}**     (row, col) tuple representing the new position
  */
 export function nvim_win_set_cursor(
@@ -4006,8 +4170,11 @@ export function nvim_win_set_cursor(
 /**
  * Sets the window height.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{height}**  Height as a count of rows
  */
 export function nvim_win_set_height(
@@ -4029,6 +4196,9 @@ export function nvim_win_set_height(
  *
  * This takes precedence over the 'winhighlight' option.
  *
+ * Attributes:
+ *     Since: 0.8.0
+ *
  * Parameters:
  *   - {ns_id}   the namespace to use
  */
@@ -4047,8 +4217,11 @@ export function nvim_win_set_hl_ns(
 /**
  * Sets a window-scoped (w:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{name}**    Variable name
  *   - **{value}**   Variable value
  */
@@ -4069,8 +4242,11 @@ export function nvim_win_set_var(
  * Sets the window width. This will only succeed if the screen is split
  * vertically.
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{width}**   Width as a count of columns
  */
 export function nvim_win_set_width(
@@ -4097,8 +4273,11 @@ export function nvim_win_set_width(
  *
  * Line indexing is similar to `nvim_buf_get_text()`.
  *
+ * Attributes:
+ *     Since: 0.10.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window.
+ *   - **{window}**  `window-ID`, or 0 for current window.
  *   - **{opts}**    Optional parameters:
  *               - start_row: Starting line index, 0-based inclusive. When
  *                 omitted start at the very top.
@@ -4112,7 +4291,7 @@ export function nvim_win_set_width(
  *                 omitted include the whole line.
  *
  * Return:
- *     Dictionary containing text height information, with these keys:
+ *     Dict containing text height information, with these keys:
  *     - all: The total number of screen lines occupied by the range.
  *     - fill: The number of diff filler or virtual lines among them.
  *
@@ -4134,8 +4313,11 @@ export function nvim_win_text_height(
 /**
  * Removes a tab-scoped (t:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *   - **{name}**     Variable name
  */
 export function nvim_tabpage_del_var(
@@ -4153,8 +4335,11 @@ export function nvim_tabpage_del_var(
 /**
  * Gets the tabpage number
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *
  * Return:
  *     Tabpage number
@@ -4173,8 +4358,11 @@ export function nvim_tabpage_get_number(
 /**
  * Gets a tab-scoped (t:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *   - **{name}**     Variable name
  *
  * Return:
@@ -4195,11 +4383,14 @@ export function nvim_tabpage_get_var(
 /**
  * Gets the current window in a tabpage
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *
  * Return:
- *     Window handle
+ *     `window-ID`
  */
 export function nvim_tabpage_get_win(
   denops: Denops,
@@ -4215,8 +4406,11 @@ export function nvim_tabpage_get_win(
 /**
  * Checks if a tabpage is valid
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *
  * Return:
  *     true if the tabpage is valid, false otherwise
@@ -4235,8 +4429,11 @@ export function nvim_tabpage_is_valid(
 /**
  * Gets the windows in a tabpage
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *
  * Return:
  *     List of windows in `tabpage`
@@ -4255,8 +4452,11 @@ export function nvim_tabpage_list_wins(
 /**
  * Sets a tab-scoped (t:) variable
  *
+ * Attributes:
+ *     Since: 0.1.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
  *   - **{name}**     Variable name
  *   - **{value}**    Variable value
  */
@@ -4276,9 +4476,12 @@ export function nvim_tabpage_set_var(
 /**
  * Sets the current window in a tabpage
  *
+ * Attributes:
+ *     Since: 0.10.0
+ *
  * Parameters:
- *   - **{tabpage}**  Tabpage handle, or 0 for current tabpage
- *   - **{win}**      Window handle, must already belong to **{tabpage}**
+ *   - **{tabpage}**  `tab-ID`, or 0 for current tabpage
+ *   - **{win}**      `window-ID`, must already belong to **{tabpage}**
  */
 export function nvim_tabpage_set_win(
   denops: Denops,
@@ -4295,6 +4498,9 @@ export function nvim_tabpage_set_win(
 /**
  * Clears all autocommands selected by **{opts}**. To delete autocmds see
  * `nvim_del_autocmd()`.
+ *
+ * Attributes:
+ *     Since: 0.7.0
  *
  * Parameters:
  *   - **{opts}**  Parameters
@@ -4332,13 +4538,16 @@ export function nvim_clear_autocmds(
  *
  * To get an existing group id, do:
  *
- *     local id = vim.api.nvim_create_augroup("MyGroup", {
+ *     local id = vim.api.nvim_create_augroup('my.lsp.config', {
  *         clear = false
  *     })
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{name}**  String: The name of the group
- *   - **{opts}**  Dictionary Parameters
+ *   - **{opts}**  Dict Parameters
  *             - clear (bool) optional: defaults to true. Clear existing
  *               commands if the group already exists `autocmd-groups`.
  *
@@ -4367,8 +4576,8 @@ export function nvim_create_augroup(
  *
  * Example using Lua callback:
  *
- *     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
- *       pattern = {"*.c", "*.h"},
+ *     vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
+ *       pattern = {'*.c', '*.h'},
  *       callback = function(ev)
  *         print(string.format('event fired: %s', vim.inspect(ev)))
  *       end
@@ -4376,15 +4585,18 @@ export function nvim_create_augroup(
  *
  * Example using an Ex command as the handler:
  *
- *     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
- *       pattern = {"*.c", "*.h"},
+ *     vim.api.nvim_create_autocmd({'BufEnter', 'BufWinEnter'}, {
+ *       pattern = {'*.c', '*.h'},
  *       command = "echo 'Entering a C or C++ file'",
  *     })
  *
  * Note: `pattern` is NOT automatically expanded (unlike with `:autocmd`),
  * thus names like "$HOME" and `"~"` must be expanded explicitly:
  *
- *     pattern = vim.fn.expand("~") .. "/some/path/*.py"
+ *     pattern = vim.fn.expand('~') .. '/some/path/*.py'
+ *
+ * Attributes:
+ *     Since: 0.7.0
  *
  * Parameters:
  *   - **{event}**  (string|array) Event(s) that will trigger the handler
@@ -4402,16 +4614,16 @@ export function nvim_create_augroup(
  *              - callback (function|string) optional: Lua function (or
  *                Vimscript function name, if string) called when the
  *                event(s) is triggered. Lua callback can return a truthy
- *                value (not `false` or `nil`) to delete the autocommand.
- *                Receives one argument, a table with these keys:
+ *                value (not `false` or `nil`) to delete the autocommand, and
+ *                receives one argument, a table with these keys:
  *
  *                - id: (number) autocommand id
  *                - event: (string) name of the triggered event
  *                  `autocmd-events`
  *                - group: (number|nil) autocommand group id, if any
- *                - match: (string) expanded value of `<amatch>`
- *                - buf: (number) expanded value of `<abuf>`
- *                - file: (string) expanded value of `<afile>`
+ *                - file: (string) `<afile>` (not expanded to a full path)
+ *                - match: (string) `<amatch>` (expanded to a full path)
+ *                - buf: (number) `<abuf>`
  *                - data: (any) arbitrary data passed from
  *                  `nvim_exec_autocmds()`
  *              - command (string) optional: Vim command to execute on event.
@@ -4449,6 +4661,9 @@ export function nvim_create_autocmd(
  * autocommands contained in this group will also be deleted and cleared.
  * This group will no longer exist.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{id}**  Integer The id of the group.
  *
@@ -4474,6 +4689,9 @@ export function nvim_del_augroup_by_id(
  * autocommands contained in this group will also be deleted and cleared.
  * This group will no longer exist.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{name}**  String The name of the group.
  *
@@ -4494,6 +4712,9 @@ export function nvim_del_augroup_by_name(
 /**
  * Deletes an autocommand by id.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{id}**  Integer Autocommand id returned by `nvim_create_autocmd()`
  */
@@ -4509,9 +4730,12 @@ export function nvim_del_autocmd(
  * Execute all autocommands for **{event}** that match the corresponding **{opts}**
  * `autocmd-execute`.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
  *   - **{event}**  (String|Array) The event or events to execute
- *   - **{opts}**   Dictionary of autocommand options:
+ *   - **{opts}**   Dict of autocommand options:
  *              - group (string|integer) optional: the autocommand group name
  *                or id to match against. `autocmd-groups`.
  *              - pattern (string|array) optional: defaults to "*"
@@ -4545,48 +4769,53 @@ export function nvim_exec_autocmds(
  *
  *     -- Matches all criteria
  *     autocommands = vim.api.nvim_get_autocmds({
- *       group = "MyGroup",
- *       event = {"BufEnter", "BufWinEnter"},
- *       pattern = {"*.c", "*.h"}
+ *       group = 'MyGroup',
+ *       event = {'BufEnter', 'BufWinEnter'},
+ *       pattern = {'*.c', '*.h'}
  *     })
  *
  *     -- All commands from one group
  *     autocommands = vim.api.nvim_get_autocmds({
- *       group = "MyGroup",
+ *       group = 'MyGroup',
  *     })
  *
  * NOTE: When multiple patterns or events are provided, it will find all the
  * autocommands that match any combination of them.
  *
+ * Attributes:
+ *     Since: 0.7.0
+ *
  * Parameters:
- *   - **{opts}**  Dictionary with at least one of the following:
- *             - group (string|integer): the autocommand group name or id to
- *               match against.
- *             - event (string|array): event or events to match against
+ *   - **{opts}**  Dict with at least one of the following:
+ *             - buffer: (integer) Buffer number or list of buffer numbers
+ *               for buffer local autocommands `autocmd-buflocal`. Cannot be
+ *               used with **{pattern}**
+ *             - event: (string|table) event or events to match against
  *               `autocmd-events`.
- *             - pattern (string|array): pattern or patterns to match against
+ *             - id: (integer) Autocommand ID to match.
+ *             - group: (string|table) the autocommand group name or id to
+ *               match against.
+ *             - pattern: (string|table) pattern or patterns to match against
  *               `autocmd-pattern`. Cannot be used with **{buffer}**
- *             - buffer: Buffer number or list of buffer numbers for buffer
- *               local autocommands `autocmd-buflocal`. Cannot be used with
- *               **{pattern}**
  *
  * Return:
  *     Array of autocommands matching the criteria, with each item containing
  *     the following fields:
- *     - id (number): the autocommand id (only when defined with the API).
- *     - group (integer): the autocommand group id.
- *     - group_name (string): the autocommand group name.
- *     - desc (string): the autocommand description.
- *     - event (string): the autocommand event.
- *     - command (string): the autocommand command. Note: this will be empty
+ *     - buffer: (integer) the buffer number.
+ *     - buflocal: (boolean) true if the autocommand is buffer local.
+ *     - command: (string) the autocommand command. Note: this will be empty
  *       if a callback is set.
- *     - callback (function|string|nil): Lua function or name of a Vim script
- *       function which is executed when this autocommand is triggered.
- *     - once (boolean): whether the autocommand is only run once.
- *     - pattern (string): the autocommand pattern. If the autocommand is
+ *     - callback: (function|string|nil): Lua function or name of a Vim
+ *       script function which is executed when this autocommand is
+ *       triggered.
+ *     - desc: (string) the autocommand description.
+ *     - event: (string) the autocommand event.
+ *     - id: (integer) the autocommand id (only when defined with the API).
+ *     - group: (integer) the autocommand group id.
+ *     - group_name: (string) the autocommand group name.
+ *     - once: (boolean) whether the autocommand is only run once.
+ *     - pattern: (string) the autocommand pattern. If the autocommand is
  *       buffer local `autocmd-buffer-local`:
- *     - buflocal (boolean): true if the autocommand is buffer local.
- *     - buffer (number): the buffer number.
  */
 export function nvim_get_autocmds(
   denops: Denops,
@@ -4613,6 +4842,7 @@ export function nvim_get_autocmds(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.1.0
  *
  * Parameters:
  *   - **{width}**    Requested screen columns
@@ -4639,6 +4869,7 @@ export function nvim_ui_attach(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.1.0
  */
 export function nvim_ui_detach(denops: Denops): Promise<unknown>;
 export function nvim_ui_detach(
@@ -4661,6 +4892,7 @@ export function nvim_ui_detach(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.5.0
  *
  * Parameters:
  *   - **{width}**   Popupmenu width.
@@ -4688,6 +4920,7 @@ export function nvim_ui_pum_set_bounds(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{height}**  Popupmenu height, must be greater than zero.
@@ -4708,6 +4941,7 @@ export function nvim_ui_pum_set_height(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.9.0
  */
 export function nvim_ui_set_focus(
   denops: Denops,
@@ -4723,6 +4957,7 @@ export function nvim_ui_set_focus(
 /**
  * Attributes:
  *     `RPC` only
+ *     Since: 0.1.0
  */
 export function nvim_ui_set_option(
   denops: Denops,
@@ -4746,6 +4981,7 @@ export function nvim_ui_set_option(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.10.0
  *
  * Parameters:
  *   - **{event}**  Event name
@@ -4766,6 +5002,7 @@ export function nvim_ui_term_event(
 /**
  * Attributes:
  *     `RPC` only
+ *     Since: 0.1.0
  */
 export function nvim_ui_try_resize(
   denops: Denops,
@@ -4787,6 +5024,7 @@ export function nvim_ui_try_resize(
  *
  * Attributes:
  *     `RPC` only
+ *     Since: 0.4.0
  *
  * Parameters:
  *   - **{grid}**    The handle of the grid to be changed.
@@ -4812,6 +5050,9 @@ export function nvim_ui_try_resize_grid(
  * View it in a nice human-readable format:
  *
  *     lua vim.print(vim.fn.api_info())
+ *
+ * Return:
+ *   (`table`)
  */
 export function api_info(denops: Denops): Promise<unknown>;
 export function api_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4827,6 +5068,13 @@ export function api_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * pty master, sending SIGHUP to the job process.
  * For a socket, there is only one stream, and **{stream}** should be
  * omitted.
+ *
+ * Parameters:
+ *   - **{id}** (`integer`)
+ *   - **{stream}** (`string?`)
+ *
+ * Return:
+ *   (`0|1`)
  */
 export function chanclose(
   denops: Denops,
@@ -4859,6 +5107,13 @@ export function chanclose(
  * chansend() writes raw data, not RPC messages.  If the channel
  * was created with `"rpc":v:true` then the channel expects RPC
  * messages, use `rpcnotify()` and `rpcrequest()` instead.
+ *
+ * Parameters:
+ *   - **{id}** (`number`)
+ *   - **{data}** (`string|string[]`)
+ *
+ * Return:
+ *   (`0|1`)
  */
 export function chansend(
   denops: Denops,
@@ -4873,6 +5128,12 @@ export function chansend(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Returns a `Dictionary` representing the `context` at **{index}**
  * from the top of the `context-stack` (see `context-dict`).
  * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
+ *
+ * Parameters:
+ *   - **{index}** (`integer?`)
+ *
+ * Return:
+ *   (`table`)
  */
 export function ctxget(denops: Denops, index?: unknown): Promise<unknown>;
 export function ctxget(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4882,6 +5143,9 @@ export function ctxget(denops: Denops, ...args: unknown[]): Promise<unknown> {
 /**
  * Pops and restores the `context` at the top of the
  * `context-stack`.
+ *
+ * Return:
+ *   (`any`)
  */
 export function ctxpop(denops: Denops): Promise<unknown>;
 export function ctxpop(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4894,6 +5158,12 @@ export function ctxpop(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * If **{types}** is given and is a `List` of `String`s, it specifies
  * which `context-types` to include in the pushed context.
  * Otherwise, all context types are included.
+ *
+ * Parameters:
+ *   - **{types}** (`string[]?`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function ctxpush(denops: Denops, types?: unknown): Promise<unknown>;
 export function ctxpush(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4905,6 +5175,13 @@ export function ctxpush(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * `context-stack` to that represented by **{context}**.
  * **{context}** is a Dictionary with context data (`context-dict`).
  * If **{index}** is not given, it is assumed to be 0 (i.e.: top).
+ *
+ * Parameters:
+ *   - **{context}** (`table`)
+ *   - **{index}** (`integer?`)
+ *
+ * Return:
+ *   (`integer`)
  */
 export function ctxset(
   denops: Denops,
@@ -4917,6 +5194,9 @@ export function ctxset(denops: Denops, ...args: unknown[]): Promise<unknown> {
 
 /**
  * Returns the size of the `context-stack`.
+ *
+ * Return:
+ *   (`any`)
  */
 export function ctxsize(denops: Denops): Promise<unknown>;
 export function ctxsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -4963,6 +5243,14 @@ export function ctxsize(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * This function can be used by plugins to implement options with
  * validation and parsing logic.
+ *
+ * Parameters:
+ *   - **{dict}** (`table`)
+ *   - **{pattern}** (`string`)
+ *   - **{callback}** (`function`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function dictwatcheradd(
   denops: Denops,
@@ -4981,6 +5269,14 @@ export function dictwatcheradd(
  * Removes a watcher added  with `dictwatcheradd()`. All three
  * arguments must match the ones passed to `dictwatcheradd()` in
  * order for the watcher to be successfully deleted.
+ *
+ * Parameters:
+ *   - **{dict}** (`any`)
+ *   - **{pattern}** (`string`)
+ *   - **{callback}** (`function`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function dictwatcherdel(
   denops: Denops,
@@ -4996,29 +5292,13 @@ export function dictwatcherdel(
 }
 
 /**
- * Returns a `String` which is a unique identifier of the
- * container type (`List`, `Dict`, `Blob` and `Partial`). It is
- * guaranteed that for the mentioned types `id(v1) ==# id(v2)`
- * returns true iff `type(v1) == type(v2) && v1 is v2`.
- * Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
- * `v:_null_blob` have the same `id()` with different types
- * because they are internally represented as NULL pointers.
- * `id()` returns a hexadecimal representanion of the pointers to
- * the containers (i.e. like `0x994a40`), same as `printf("%p",
- * {expr})`, but it is advised against counting on the exact
- * format of the return value.
- *
- * It is not guaranteed that `id(no_longer_existing_container)`
- * will not be equal to some other `id()`: new containers may
- * reuse identifiers of the garbage-collected ones.
- */
-export function id(denops: Denops, expr: unknown): Promise<unknown>;
-export function id(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("id", ...args);
-}
-
-/**
  * Return the PID (process id) of `job-id` **{job}**.
+ *
+ * Parameters:
+ *   - **{job}** (`integer`)
+ *
+ * Return:
+ *   (`integer`)
  */
 export function jobpid(denops: Denops, job: unknown): Promise<unknown>;
 export function jobpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -5029,6 +5309,14 @@ export function jobpid(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Resize the pseudo terminal window of `job-id` **{job}** to **{width}**
  * columns and **{height}** rows.
  * Fails if the job was not started with `"pty":v:true`.
+ *
+ * Parameters:
+ *   - **{job}** (`integer`)
+ *   - **{width}** (`integer`)
+ *   - **{height}** (`integer`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function jobresize(
   denops: Denops,
@@ -5044,7 +5332,7 @@ export function jobresize(
 }
 
 /**
- * Note: Prefer `vim.system()` in Lua (unless using the `pty` option).
+ * Note: Prefer `vim.system()` in Lua (unless using `rpc`, `pty`, or `term`).
  *
  * Spawns **{cmd}** as a job.
  * If **{cmd}** is a List it runs directly (no 'shell').
@@ -5054,9 +5342,13 @@ export function jobresize(
  *
  * (See `shell-unquoting` for details.)
  *
- * Example:
+ * Example: start a job and handle its output:
  *
- *     call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
+ *     call jobstart(['nvim', '-h'], {'on_stdout':{j,d,e->append(line('.'),d)}})
+ *
+ * Example: start a job in a `terminal` connected to the current buffer:
+ *
+ *     call jobstart(['nvim', '-h'], {'term':v:true})
  *
  * Returns `job-id` on success, 0 on invalid arguments (or job
  * table is full), -1 if **{cmd}**[0] or 'shell' is not executable.
@@ -5123,6 +5415,10 @@ export function jobresize(
  *   stdin:      (string) Either "pipe" (default) to connect the
  *               job's stdin to a channel or "null" to disconnect
  *               stdin.
+ *   term:     (boolean) Spawns **{cmd}** in a new pseudo-terminal session
+ *           connected to the current (unmodified) buffer. Implies "pty".
+ *           Default "height" and "width" are set to the current window
+ *           dimensions. `jobstart()`. Defaults $TERM to "xterm-256color".
  *   width:      (number) Width of the `pty` terminal.
  *
  * **{opts}** is passed as `self` dictionary to the callback; the
@@ -5133,6 +5429,13 @@ export function jobresize(
  *   - 0 on invalid arguments
  *   - -1 if **{cmd}**[0] is not executable.
  * See also `job-control`, `channel`, `msgpack-rpc`.
+ *
+ * Parameters:
+ *   - **{cmd}** (`string|string[]`)
+ *   - **{opts}** (`table?`)
+ *
+ * Return:
+ *   (`integer`)
  */
 export function jobstart(
   denops: Denops,
@@ -5152,6 +5455,12 @@ export function jobstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *
  * Returns 1 for valid job id, 0 for invalid id, including jobs have
  * exited or stopped.
+ *
+ * Parameters:
+ *   - **{id}** (`integer`)
+ *
+ * Return:
+ *   (`integer`)
  */
 export function jobstop(denops: Denops, id: unknown): Promise<unknown>;
 export function jobstop(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -5179,6 +5488,13 @@ export function jobstop(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         -1 if the timeout was exceeded
  *         -2 if the job was interrupted (by `CTRL-C`)
  *         -3 if the job-id is invalid
+ *
+ * Parameters:
+ *   - **{jobs}** (`integer[]`)
+ *   - **{timeout}** (`integer?`)
+ *
+ * Return:
+ *   (`integer[]`)
  */
 export function jobwait(
   denops: Denops,
@@ -5235,6 +5551,13 @@ export function jobwait(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         "shortcut": 0
  *       } ]
  *     } ]
+ *
+ * Parameters:
+ *   - **{path}** (`string`)
+ *   - **{modes}** (`string?`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function menu_get(
   denops: Denops,
@@ -5266,6 +5589,13 @@ export function menu_get(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * 3. Dictionary keys are always dumped as STR strings.
  * 4. Other strings and `Blob`s are always dumped as BIN strings.
  * 5. Points 3. and 4. do not apply to `msgpack-special-dict`s.
+ *
+ * Parameters:
+ *   - **{list}** (`any`)
+ *   - **{type}** (`any?`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function msgpackdump(
   denops: Denops,
@@ -5334,12 +5664,7 @@ export function msgpackdump(
  *            C parser does not support such values.
  * float   `Float`. This value cannot possibly appear in
  *         `msgpackparse()` output.
- * string  `readfile()`-style list of strings. This value will
- *         appear in `msgpackparse()` output if string contains
- *         zero byte or if string is a mapping key and mapping is
- *         being represented as special dictionary for other
- *         reasons.
- * binary  `String`, or `Blob` if binary string contains zero
+ * string  `String`, or `Blob` if binary string contains zero
  *         byte. This value cannot appear in `msgpackparse()`
  *         output since blobs were introduced.
  * array   `List`. This value cannot appear in `msgpackparse()`
@@ -5355,6 +5680,12 @@ export function msgpackdump(
  * ext     `List` with two values: first is a signed integer
  *         representing extension type. Second is
  *         `readfile()`-style list of strings.
+ *
+ * Parameters:
+ *   - **{data}** (`any`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function msgpackparse(denops: Denops, data: unknown): Promise<unknown>;
 export function msgpackparse(
@@ -5368,6 +5699,9 @@ export function msgpackparse(
  * Returns the single letter name of the last recorded register.
  * Returns an empty string when nothing was recorded yet.
  * See `q` and `Q`.
+ *
+ * Return:
+ *   (`any`)
  */
 export function reg_recorded(denops: Denops): Promise<unknown>;
 export function reg_recorded(
@@ -5383,6 +5717,14 @@ export function reg_recorded(
  * Example:
  *
  *     au VimLeave call rpcnotify(0, "leaving")
+ *
+ * Parameters:
+ *   - **{channel}** (`integer`)
+ *   - **{event}** (`string`)
+ *   - **{...}** (`any`)
+ *
+ * Return:
+ *   (`integer`)
  */
 export function rpcnotify(
   denops: Denops,
@@ -5403,6 +5745,14 @@ export function rpcnotify(
  * Example:
  *
  *     let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
+ *
+ * Parameters:
+ *   - **{channel}** (`integer`)
+ *   - **{method}** (`string`)
+ *   - **{...}** (`any`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function rpcrequest(
   denops: Denops,
@@ -5415,24 +5765,6 @@ export function rpcrequest(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("rpcrequest", ...args);
-}
-
-/**
- * Deprecated. Replace
- *
- *     let id = rpcstart('prog', ['arg1', 'arg2'])
- *
- * with
- *
- *     let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
- */
-export function rpcstart(
-  denops: Denops,
-  prog: unknown,
-  argv?: unknown,
-): Promise<unknown>;
-export function rpcstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("rpcstart", ...args);
 }
 
 /**
@@ -5473,6 +5805,12 @@ export function rpcstart(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Example TCP/IP address:
  *
  *     echo serverstart('::1:12345')
+ *
+ * Parameters:
+ *   - **{address}** (`string?`)
+ *
+ * Return:
+ *   (`string`)
  */
 export function serverstart(
   denops: Denops,
@@ -5490,6 +5828,12 @@ export function serverstart(
  * Returns TRUE if **{address}** is valid, else FALSE.
  * If `v:servername` is stopped it is set to the next available
  * address in `serverlist()`.
+ *
+ * Parameters:
+ *   - **{address}** (`string`)
+ *
+ * Return:
+ *   (`integer`)
  */
 export function serverstop(denops: Denops, address: unknown): Promise<unknown>;
 export function serverstop(
@@ -5523,6 +5867,14 @@ export function serverstop(
  * Returns:
  *   - The channel ID on success (greater than zero)
  *   - 0 on invalid arguments or connection failure.
+ *
+ * Parameters:
+ *   - **{mode}** (`string`)
+ *   - **{address}** (`string`)
+ *   - **{opts}** (`table?`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function sockconnect(
   denops: Denops,
@@ -5557,6 +5909,12 @@ export function sockconnect(
  * Returns:
  *   - `channel-id` on success (value is always 1)
  *   - 0 on invalid arguments
+ *
+ * Parameters:
+ *   - **{opts}** (`table`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function stdioopen(denops: Denops, opts: unknown): Promise<unknown>;
 export function stdioopen(
@@ -5568,7 +5926,9 @@ export function stdioopen(
 
 /**
  * Returns `standard-path` locations of various default files and
- * directories.
+ * directories. The locations are driven by `base-directories`
+ * which you can configure via `$NVIM_APPNAME` or the `$XDG_…`
+ * environment variables.
  *
  * **{what}**       Type    Description
  * cache        String  Cache directory: arbitrary temporary
@@ -5587,34 +5947,17 @@ export function stdioopen(
  * Example:
  *
  *     echo stdpath("config")
+ *
+ * Parameters:
+ *   - **{what}**
+ *     (`'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'`)
+ *
+ * Return:
+ *   (`string|string[]`)
  */
 export function stdpath(denops: Denops, what: unknown): Promise<unknown>;
 export function stdpath(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("stdpath", ...args);
-}
-
-/**
- * Spawns **{cmd}** in a new pseudo-terminal session connected
- * to the current (unmodified) buffer. Parameters and behavior
- * are the same as `jobstart()` except "pty", "width", "height",
- * and "TERM" are ignored: "height" and "width" are taken from
- * the current window. Note that termopen() implies a "pty" arg
- * to jobstart(), and thus has the implications documented at
- * `jobstart()`.
- *
- * Returns the same values as jobstart().
- *
- * Terminal environment is initialized as in `jobstart-env`,
- * except $TERM is set to "xterm-256color". Full behavior is
- * described in `terminal`.
- */
-export function termopen(
-  denops: Denops,
-  cmd: unknown,
-  opts?: unknown,
-): Promise<unknown>;
-export function termopen(denops: Denops, ...args: unknown[]): Promise<unknown> {
-  return denops.call("termopen", ...args);
 }
 
 /**
@@ -5632,6 +5975,14 @@ export function termopen(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *         -1 if the timeout was exceeded
  *         -2 if the function was interrupted (by `CTRL-C`)
  *         -3 if an error occurred
+ *
+ * Parameters:
+ *   - **{timeout}** (`integer`)
+ *   - **{condition}** (`any`)
+ *   - **{interval}** (`number?`)
+ *
+ * Return:
+ *   (`any`)
  */
 export function wait(
   denops: Denops,

--- a/function/nvim/nvim_win_get_config.ts
+++ b/function/nvim/nvim_win_get_config.ts
@@ -8,8 +8,11 @@ import type { NvimOpenWinConfig } from "./nvim_open_win.ts";
  *
  * `relative` is empty for normal windows.
  *
+ * Attributes:
+ *     Since: 0.4.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *
  * Return:
  *     Map defining the window configuration, see `nvim_open_win()`

--- a/function/nvim/nvim_win_set_config.ts
+++ b/function/nvim/nvim_win_set_config.ts
@@ -9,8 +9,11 @@ import type { NvimOpenWinConfig } from "./nvim_open_win.ts";
  * When reconfiguring a window, absent option keys will not be changed.
  * `row`/`col` and `relative` must be reconfigured together.
  *
+ * Attributes:
+ *     Since: 0.4.0
+ *
  * Parameters:
- *   - **{window}**  Window handle, or 0 for current window
+ *   - **{window}**  `window-ID`, or 0 for current window
  *   - **{config}**  Map defining the window configuration, see `nvim_open_win()`
  *
  * See also:

--- a/function/various.ts
+++ b/function/various.ts
@@ -58,6 +58,8 @@ import type { Denops } from "../mod.ts";
  * Can also be used as a `method`:
  *
  *     DoFull()->mode()
+ *
+ * Return type: `String`
  */
 export function mode(denops: Denops, expr?: number | string): Promise<string> {
   return denops.call("mode", expr) as Promise<string>;

--- a/function/vim/_generated.ts
+++ b/function/vim/_generated.ts
@@ -48,6 +48,8 @@ import type { Denops } from "@denops/core";
  * Can also be used as a `method`:
  *
  *     GetAutocmdList()->autocmd_add()
+ *
+ * Return type: `vim9-boolean`
  */
 export function autocmd_add(denops: Denops, acmds: unknown): Promise<boolean>;
 export function autocmd_add(
@@ -107,6 +109,8 @@ export function autocmd_add(
  * Can also be used as a `method`:
  *
  *     GetAutocmdList()->autocmd_delete()
+ *
+ * Return type: `vim9-boolean`
  */
 export function autocmd_delete(
   denops: Denops,
@@ -177,6 +181,8 @@ export function autocmd_delete(
  * Can also be used as a `method`:
  *
  *     Getopts()->autocmd_get()
+ *
+ * Return type: list<dict<any>>
  */
 export function autocmd_get(denops: Denops, opts?: unknown): Promise<unknown[]>;
 export function autocmd_get(
@@ -190,6 +196,8 @@ export function autocmd_get(
  * Return the current text in the balloon.  Only for the string,
  * not used for the List.  Returns an empty string if balloon
  * is not present.
+ *
+ * Return type: `String`
  */
 export function balloon_gettext(denops: Denops): Promise<string>;
 export function balloon_gettext(
@@ -232,6 +240,8 @@ export function balloon_gettext(
  * no error message is given.
  * *only available when compiled with the `+balloon_eval` or
  * `+balloon_eval_term` feature*
+ *
+ * Return type: `Number`
  */
 export function balloon_show(denops: Denops, expr: unknown): Promise<void>;
 export function balloon_show(
@@ -253,6 +263,8 @@ export function balloon_show(
  *
  * *only available when compiled with the `+balloon_eval_term`
  * feature*
+ *
+ * Return type: list<any> or list<string>
  */
 export function balloon_split(denops: Denops, msg: unknown): Promise<unknown[]>;
 export function balloon_split(
@@ -260,6 +272,227 @@ export function balloon_split(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("balloon_split", ...args);
+}
+
+/**
+ * Return a Blob containing the bytes decoded from the base64
+ * encoded characters in **{string}**.
+ *
+ * The **{string}** argument should contain only base64-encoded
+ * characters and should have a length that is a multiple of 4.
+ *
+ * Returns an empty blob on error.
+ *
+ * Examples:
+ *
+ *     " Write the decoded contents to a binary file
+ *     call writefile(base64_decode(s), 'tools.bmp')
+ *     " Decode a base64-encoded string
+ *     echo blob2str(base64_decode(encodedstr))
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetEncodedString()->base64_decode()
+ *
+ * Return type: `Blob`
+ */
+export function base64_decode(
+  denops: Denops,
+  string: unknown,
+): Promise<unknown>;
+export function base64_decode(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("base64_decode", ...args);
+}
+
+/**
+ * Return a base64-encoded String representing the bytes in
+ * **{blob}**.  The base64 alphabet defined in RFC 4648 is used.
+ *
+ * Examples:
+ *
+ *     " Encode the contents of a binary file
+ *     echo base64_encode(readblob('somefile.bin'))
+ *     " Encode a string
+ *     echo base64_encode(str2blob(somestr->split("\n")))
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetBinaryData()->base64_encode()
+ *
+ * Return type: `String`
+ */
+export function base64_encode(denops: Denops, blob: unknown): Promise<string>;
+export function base64_encode(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("base64_encode", ...args);
+}
+
+/**
+ * Bind a specific **{package}** to a **{path}** so that the
+ * `gettext()` function can be used to get language-specific
+ * translations for a package.  **{path}** is the directory name
+ * for the translations.  See `package-translation`.
+ *
+ * Returns v:true on success and v:false on failure (out of
+ * memory).
+ *
+ * Return type: `vim9-boolean`
+ */
+export function bindtextdomain(
+  denops: Denops,
+  package_: unknown,
+  path: unknown,
+): Promise<boolean>;
+export function bindtextdomain(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("bindtextdomain", ...args);
+}
+
+/**
+ * Return a List of Strings in the current 'encoding' by
+ * converting the bytes in **{blob}** into characters.
+ *
+ * Each `<NL>` byte in the blob is interpreted as the end of a
+ * string and a new list item is added.  Each `<NUL>` byte in the
+ * blob is converted into a `<NL>` character.
+ *
+ * If **{options}** is not supplied, the current 'encoding' value is
+ * used to decode the bytes in **{blob}**.
+ *
+ * The argument **{options}** is a `Dict` and supports the following
+ * items:
+ *     encoding    Decode the bytes in **{blob}** using this
+ *                 encoding.  The value is a `String`.  See
+ *                 `encoding-names` for the supported values
+ *                 (plus the special value "none").
+ *
+ * When current 'encoding' is "utf-8", an error is given and an
+ * empty List is returned if an invalid byte sequence is
+ * encountered in **{blob}**.  To suppress this validation and get
+ * potentially invalid string, set "encoding" in **{options}** to
+ * "none".
+ *
+ * Returns an empty List if blob is empty.
+ *
+ * See also `str2blob()`
+ *
+ * Examples:
+ *
+ *     blob2str(0z6162)            returns ['ab']
+ *     blob2str(0zC2ABC2BB)        returns ['«»']
+ *     blob2str(0z610A62)          returns ['a', 'b']
+ *     blob2str(0z610062)          returns ['a\nb']
+ *     blob2str(0zABBB, {'encoding': 'latin1'}) returns ['«»']
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetBlob()->blob2str()
+ *
+ * Return type: list<string>
+ */
+export function blob2str(
+  denops: Denops,
+  blob: unknown,
+  options?: unknown,
+): Promise<unknown[]>;
+export function blob2str(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("blob2str", ...args);
+}
+
+/**
+ * Returns a `Dictionary` with information about cmdline
+ * completion.  See `cmdline-completion`.
+ * The items are:
+ *    cmdline_orig The original command-line string before
+ *                 completion began.
+ *    pum_visible  `TRUE` if popup menu is visible.
+ *                 See `pumvisible()`.
+ *    matches      List of all completion candidates. Each item
+ *                 is a string.
+ *    selected     Selected item index.  First index is zero.
+ *                 Index is -1 if no item is selected (showing
+ *                 typed text only, or the last completion after
+ *                 no item is selected when using the `<Up>` or
+ *                 `<Down>` keys)
+ *
+ * Returns an empty `Dictionary` if no completion was attempted,
+ * if there was only one candidate and it was fully completed, or
+ * if an error occurred.
+ *
+ * Return type: dict<any>
+ */
+export function cmdcomplete_info(
+  denops: Denops,
+): Promise<Record<string, unknown>>;
+export function cmdcomplete_info(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("cmdcomplete_info", ...args);
+}
+
+/**
+ * Searches backward from the given position and returns a List
+ * of matches according to the 'isexpand' option. When no
+ * arguments are provided, uses the current cursor position.
+ *
+ * Each match is represented as a List containing
+ * [startcol, trigger_text] where:
+ * - startcol: column position where completion should start,
+ *   or -1 if no trigger position is found. For multi-character
+ *   triggers, returns the column of the first character.
+ * - trigger_text: the matching trigger string from 'isexpand',
+ *   or empty string if no match was found or when using the
+ *   default 'iskeyword' pattern.
+ *
+ * When 'isexpand' is empty, uses the 'iskeyword' pattern "\k\+$"
+ * to find the start of the current keyword.
+ *
+ * Examples:
+ *
+ *     set isexpand=.,->,/,/*,abc
+ *     func CustomComplete()
+ *       let res = complete_match()
+ *       if res->len() == 0 | return | endif
+ *       let [col, trigger] = res[0]
+ *       let items = []
+ *       if trigger == '/*'
+ *         let items = ['/** * /']
+ *       elseif trigger == '/'
+ *         let items = ['/*! * /', '// TODO:', '// fixme:']
+ *       elseif trigger == '.'
+ *         let items = ['length()']
+ *       elseif trigger =~ '^\->'
+ *         let items = ['map()', 'reduce()']
+ *       elseif trigger =~ '^\abc'
+ *         let items = ['def', 'ghk']
+ *       endif
+ *       if items->len() > 0
+ *         let startcol = trigger =~ '^/' ? col : col + len(trigger)
+ *         call complete(startcol, items)
+ *       endif
+ *     endfunc
+ *     inoremap <Tab> <Cmd>call CustomComplete()<CR>
+ *
+ * Return type: list<list<any>>
+ */
+export function complete_match(
+  denops: Denops,
+  lnum?: unknown,
+  col?: unknown,
+): Promise<unknown[]>;
+export function complete_match(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("complete_match", ...args);
 }
 
 /**
@@ -302,6 +535,8 @@ export function balloon_split(
  *     cscope_connection(4, "out")                             0
  *     cscope_connection(4, "out", "local")                    0
  *     cscope_connection(4, "cscope.out", "/usr/local")        1
+ *
+ * Return type: `Number`
  */
 export function cscope_connection(
   denops: Denops,
@@ -382,6 +617,9 @@ export function cscope_connection(
  * Can also be used as a `method`:
  *
  *     GetFromList->diff(to_list)
+ *
+ * Return type: `String` or list<dict<number>> or list<any>
+ * depending on **{options}**
  */
 export function diff(
   denops: Denops,
@@ -405,6 +643,8 @@ export function diff(denops: Denops, ...args: unknown[]): Promise<unknown> {
  *     call echoraw(&t_TI)
  *
  * Use with care, you can mess up the terminal this way.
+ *
+ * Return type: `Number`
  */
 export function echoraw(denops: Denops, string: unknown): Promise<void>;
 export function echoraw(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -417,6 +657,8 @@ export function echoraw(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * If **{expr}** is present and it is TRUE error 503 is given,
  * indicating that coffee is temporarily not available.
  * If **{expr}** is present it must be a String.
+ *
+ * Return type: `Number`
  */
 export function err_teapot(denops: Denops, expr?: unknown): Promise<void>;
 export function err_teapot(
@@ -441,6 +683,8 @@ export function err_teapot(
  * **{expr}** must be a literal string.
  * Can only be used in a `:def` function.
  * This does not work to check for arguments or local variables.
+ *
+ * Return type: `String`
  */
 export function exists_compiled(denops: Denops, expr: unknown): Promise<number>;
 export function exists_compiled(
@@ -456,6 +700,8 @@ export function exists_compiled(
  * On Win32 systems this might not work, the OS does not always
  * allow a window to bring itself to the foreground.  Use
  * `remote_foreground()` instead.
+ *
+ * Return type: `Number`
  * *only in the Win32, Motif and GTK GUI versions and the
  * Win32 console version*
  */
@@ -468,9 +714,52 @@ export function foreground(
 }
 
 /**
+ * Returns a `List` of terminal cell pixel size.
+ * List format is [xpixel, ypixel].
+ *
+ * Only works on Unix (terminal and gVim) and Windows (gVim only).
+ * Returns [] on other systems or on failure.
+ * Note that there could be variations across different terminals.
+ * On macOS, system Terminal.app returns sizes in points (before
+ * Retina scaling), whereas third-party terminals return raw pixel
+ * sizes (post Retina scaling).
+ *
+ * Return type: list<any>
+ */
+export function getcellpixels(denops: Denops): Promise<unknown[]>;
+export function getcellpixels(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("getcellpixels", ...args);
+}
+
+/**
+ * Return the type of the command-line completion using **{pat}**.
+ * When no corresponding completion type is found, an empty
+ * string is returned.
+ * To get the current command-line completion type, use
+ * `getcmdcompltype()`.
+ *
+ * Return type: `String`
+ */
+export function getcompletiontype(
+  denops: Denops,
+  pat: unknown,
+): Promise<string>;
+export function getcompletiontype(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("getcompletiontype", ...args);
+}
+
+/**
  * The result is a Number, which is `TRUE` when the IME status is
  * active and `FALSE` otherwise.
  * See 'imstatusfunc'.
+ *
+ * Return type: `Number`
  */
 export function getimstatus(denops: Denops): Promise<number>;
 export function getimstatus(
@@ -485,6 +774,8 @@ export function getimstatus(
  * When the `+mouseshape` feature is not supported or the shape
  * is unknown an empty string is returned.
  * This function is mainly intended for testing.
+ *
+ * Return type: `String`
  */
 export function getmouseshape(denops: Denops): Promise<string>;
 export function getmouseshape(
@@ -492,56 +783,6 @@ export function getmouseshape(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("getmouseshape", ...args);
-}
-
-/**
- * Same as `getregion()`, but returns a list of positions
- * describing the buffer text segments bound by **{pos1}** and
- * **{pos2}**.
- * The segments are a pair of positions for every line:
- *
- *     [[{start_pos}, {end_pos}], ...]
- *
- * The position is a `List` with four numbers:
- *     [bufnum, lnum, col, off]
- * "bufnum" is the buffer number.
- * "lnum" and "col" are the position in the buffer.  The first
- * column is 1.
- * If the "off" number of a starting position is non-zero, it is
- * the offset in screen columns from the start of the character.
- * E.g., a position within a `<Tab>` or after the last character.
- * If the "off" number of an ending position is non-zero, it is
- * the offset of the character's first cell not included in the
- * selection, otherwise all its cells are included.
- *
- * Apart from the options supported by `getregion()`, **{opts}** also
- * supports the following:
- *
- *         eol             If `TRUE`, indicate positions beyond
- *                         the end of a line with "col" values
- *                         one more than the length of the line.
- *                         If `FALSE`, positions are limited
- *                         within their lines, and if a line is
- *                         empty or the selection is entirely
- *                         beyond the end of a line, a "col"
- *                         value of 0 is used for both positions.
- *                         (default: `FALSE`)
- *
- * Can also be used as a `method`:
- *
- *     getpos('.')->getregionpos(getpos("'a"))
- */
-export function getregionpos(
-  denops: Denops,
-  pos1: unknown,
-  pos2: unknown,
-  opts?: unknown,
-): Promise<unknown[]>;
-export function getregionpos(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("getregionpos", ...args);
 }
 
 /**
@@ -596,6 +837,8 @@ export function getregionpos(
  * Can also be used as a `method`:
  *
  *     GetName()->hlget()
+ *
+ * Return type: list<dict<any>>
  */
 export function hlget(
   denops: Denops,
@@ -658,6 +901,8 @@ export function hlget(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetAttrList()->hlset()
+ *
+ * Return type: `Number`
  */
 export function hlset(denops: Denops, list: unknown): Promise<number>;
 export function hlset(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -683,6 +928,8 @@ export function hlset(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetPrompt()->inputdialog()
+ *
+ * Return type: `String`
  */
 export function inputdialog(
   denops: Denops,
@@ -710,6 +957,8 @@ export function inputdialog(
  * Can also be used as a `method`:
  *
  *     myobj->instanceof(mytype)
+ *
+ * Return type: `Number`
  */
 export function instanceof_(
   denops: Denops,
@@ -724,33 +973,6 @@ export function instanceof_(
 }
 
 /**
- * The result is a Number, which is `TRUE` when **{path}** is an
- * absolute path.
- * On Unix, a path is considered absolute when it starts with '/'.
- * On MS-Windows, it is considered absolute when it starts with an
- * optional drive prefix and is followed by a '\' or '/'. UNC paths
- * are always absolute.
- * Example:
- *
- *     echo isabsolutepath('/usr/share/')      " 1
- *     echo isabsolutepath('./foobar')         " 0
- *     echo isabsolutepath('C:\Windows')       " 1
- *     echo isabsolutepath('foobar')           " 0
- *     echo isabsolutepath('\\remote\file')    " 1
- *
- * Can also be used as a `method`:
- *
- *     GetName()->isabsolutepath()
- */
-export function isabsolutepath(denops: Denops, path: unknown): Promise<number>;
-export function isabsolutepath(
-  denops: Denops,
-  ...args: unknown[]
-): Promise<unknown> {
-  return denops.call("isabsolutepath", ...args);
-}
-
-/**
  * This is similar to `json_decode()` with these differences:
  * - Object key names do not have to be in quotes.
  * - Strings can be in single quotes.
@@ -760,6 +982,8 @@ export function isabsolutepath(
  * Can also be used as a `method`:
  *
  *     ReadObject()->js_decode()
+ *
+ * Return type: any, depending on **{varname}**
  */
 export function js_decode(denops: Denops, string: unknown): Promise<unknown>;
 export function js_decode(
@@ -786,6 +1010,8 @@ export function js_decode(
  * Can also be used as a `method`:
  *
  *     GetObject()->js_encode()
+ *
+ * Return type: `String`
  */
 export function js_encode(denops: Denops, expr: unknown): Promise<string>;
 export function js_encode(
@@ -793,6 +1019,35 @@ export function js_encode(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("js_encode", ...args);
+}
+
+/**
+ * Create a Tuple from a shallow copy of the list items.
+ * Examples:
+ *
+ *     list2tuple([1, 2, 3])           returns (1, 2, 3)
+ *
+ * `tuple2list()` does the opposite.
+ *
+ * This function doesn't recursively convert all the List items
+ * in **{list}** to a Tuple.  Note that the items are identical
+ * between the list and the tuple, changing an item changes the
+ * contents of both the tuple and the list.
+ *
+ * Returns an empty tuple on error.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetList()->list2tuple()
+ *
+ * Return type: tuple<**{type}**> (depending on the given `List`)
+ */
+export function list2tuple(denops: Denops, list: unknown): Promise<unknown>;
+export function list2tuple(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("list2tuple", ...args);
 }
 
 /**
@@ -872,6 +1127,8 @@ export function js_encode(
  * second argument:
  *
  *     GetBuffer()->listener_add(callback)
+ *
+ * Return type: `Number`
  */
 export function listener_add(
   denops: Denops,
@@ -896,6 +1153,8 @@ export function listener_add(
  * Can also be used as a `method`:
  *
  *     GetBuffer()->listener_flush()
+ *
+ * Return type: `Number`
  */
 export function listener_flush(denops: Denops, buf?: unknown): Promise<void>;
 export function listener_flush(
@@ -913,6 +1172,8 @@ export function listener_flush(
  * Can also be used as a `method`:
  *
  *     GetListenerId()->listener_remove()
+ *
+ * Return type: `Number`
  */
 export function listener_remove(denops: Denops, id: unknown): Promise<void>;
 export function listener_remove(
@@ -945,11 +1206,39 @@ export function listener_remove(
  *
  *     GetExpr()->mzeval()
  *
+ * Return type: any, depending on **{expr}**
+ *
  * *only available when compiled with the `+mzscheme` feature*
  */
 export function mzeval(denops: Denops, expr: unknown): Promise<unknown>;
 export function mzeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("mzeval", ...args);
+}
+
+/**
+ * Return a string that contains the correct value for a
+ * message based on the rules for plural form(s) in
+ * a language. Examples:
+ *
+ *     ngettext("File", "Files", 2)  # returns "Files"
+ *
+ * Can be used as a `method`:
+ *
+ *     1->ngettext("File", "Files")  # returns "File"
+ *
+ * See `gettext()` for information on the domain parameter.
+ *
+ * Return type: `String`
+ */
+export function ngettext(
+  denops: Denops,
+  single: unknown,
+  plural: unknown,
+  number: unknown,
+  domain?: unknown,
+): Promise<string>;
+export function ngettext(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("ngettext", ...args);
 }
 
 /**
@@ -1013,6 +1302,8 @@ export function mzeval(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetDirName()->readdirex()
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function readdirex(
   denops: Denops,
@@ -1032,10 +1323,10 @@ export function readdirex(
  * string, also see `{server}`.
  *
  * The string is sent as an expression and the result is returned
- * after evaluation.  The result must be a String or a `List`.  A
- * `List` is turned into a String by joining the items with a
- * line break in between (not at the end), like with join(expr,
- * "\n").
+ * after evaluation.  The result must be a String or a `List`
+ * other types will be converted to String.  A `List` is turned
+ * into a String by joining the items with a line break in
+ * between (not at the end), like with join(expr, "\n").
  *
  * If **{idvar}** is present and not empty, it is taken as the name
  * of a variable and a **{serverid}** for later use with
@@ -1063,6 +1354,8 @@ export function readdirex(
  * Can also be used as a `method`:
  *
  *     ServerName()->remote_expr(expr)
+ *
+ * Return type: `String` or list<**{type}**>
  */
 export function remote_expr(
   denops: Denops,
@@ -1096,6 +1389,8 @@ export function remote_expr(
  *
  *     ServerName()->remote_foreground()
  *
+ * Return type: `Number`
+ *
  * *only in the Win32, Motif and GTK GUI versions and the
  * Win32 console version*
  */
@@ -1128,6 +1423,8 @@ export function remote_foreground(
  * Can also be used as a `method`:
  *
  *     ServerId()->remote_peek()
+ *
+ * Return type: `Number`
  */
 export function remote_peek(
   denops: Denops,
@@ -1156,6 +1453,8 @@ export function remote_peek(
  * Can also be used as a `method`:
  *
  *     ServerId()->remote_read()
+ *
+ * Return type: `String`
  */
 export function remote_read(
   denops: Denops,
@@ -1189,8 +1488,8 @@ export function remote_read(
  * up the display.
  * Examples:
  *
- *     :echo remote_send("gvim", ":DropAndReply " .. file, "serverid") ..
- *      \ remote_read(serverid)
+ *     :echo remote_send("gvim", ":DropAndReply " .. file,
+ *      \ "serverid") .. remote_read(serverid)
  *
  *     :autocmd NONE RemoteReply *
  *      \ echo remote_read(expand("<amatch>"))
@@ -1200,6 +1499,8 @@ export function remote_read(
  * Can also be used as a `method`:
  *
  *     ServerName()->remote_send(keys)
+ *
+ * Return type: `String`
  */
 export function remote_send(
   denops: Denops,
@@ -1222,6 +1523,8 @@ export function remote_send(
  * Can also be used as a `method`:
  *
  *     ServerName()->remote_startserver()
+ *
+ * Return type: `Number`
  *
  * *only available when compiled with the `+clientserver` feature*
  */
@@ -1253,6 +1556,8 @@ export function remote_startserver(
  * Can also be used as a `method`:
  *
  *     GetClientId()->server2client(string)
+ *
+ * Return type: `Number`
  */
 export function server2client(
   denops: Denops,
@@ -1271,6 +1576,8 @@ export function server2client(
  *
  * On some Linux systems you may need the libcanberra-pulse
  * package, otherwise sound may not stop.
+ *
+ * Return type: `Number`
  *
  * *only available when compiled with the `+sound` feature*
  */
@@ -1319,6 +1626,8 @@ export function sound_clear(
  *
  *     GetSoundName()->sound_playevent()
  *
+ * Return type: `Number`
+ *
  * *only available when compiled with the `+sound` feature*
  */
 export function sound_playevent(
@@ -1343,6 +1652,8 @@ export function sound_playevent(
  * Can also be used as a `method`:
  *
  *     GetSoundPath()->sound_playfile()
+ *
+ * Return type: `Number`
  *
  * *only available when compiled with the `+sound` feature*
  */
@@ -1372,6 +1683,8 @@ export function sound_playfile(
  *
  *     soundid->sound_stop()
  *
+ * Return type: `Number`
+ *
  * *only available when compiled with the `+sound` feature*
  */
 export function sound_stop(denops: Denops, id: unknown): Promise<void>;
@@ -1380,6 +1693,55 @@ export function sound_stop(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("sound_stop", ...args);
+}
+
+/**
+ * Return a Blob by converting the characters in the List of
+ * strings in **{list}** into bytes.
+ *
+ * A `<NL>` byte is added to the blob after each list item.  A
+ * newline character in the string is translated into a `<NUL>`
+ * byte in the blob.
+ *
+ * If **{options}** is not supplied, the current 'encoding' value is
+ * used to convert the characters into bytes.
+ *
+ * The argument **{options}** is a `Dict` and supports the following
+ * items:
+ *     encoding    Convert the characters using this encoding
+ *                 before making the Blob.
+ *                 The value is a `String`.  See `encoding-names`
+ *                 for the supported values.
+ *
+ * An error is given and an empty blob is returned if the
+ * character encoding fails.
+ *
+ * Returns an empty Blob if **{list}** is empty.
+ *
+ * See also `blob2str()`
+ *
+ * Examples:
+ *
+ *     str2blob(["ab"])            returns 0z6162
+ *     str2blob(["«»"])            returns 0zC2ABC2BB
+ *     str2blob(["a\nb"])          returns 0z610062
+ *     str2blob(["a","b"])         returns 0z610A62
+ *     str2blob(["«»"], {'encoding': 'latin1'}) returns 0zABBB
+ *     str2blob(readfile('myfile.txt'))
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetListOfStrings()->str2blob()
+ *
+ * Return type: `Blob`
+ */
+export function str2blob(
+  denops: Denops,
+  list: unknown,
+  options?: unknown,
+): Promise<unknown>;
+export function str2blob(denops: Denops, ...args: unknown[]): Promise<unknown> {
+  return denops.call("str2blob", ...args);
 }
 
 /**
@@ -1415,6 +1777,8 @@ export function sound_stop(
  * - 'ambiwidth' - detected by using `t_u7`.
  * - `v:termstyleresp` and `v:termblinkresp` for the response to
  *   `t_RS` and `t_RC`.
+ *
+ * Return type: dict<string>
  */
 export function terminalprops(denops: Denops): Promise<Record<string, unknown>>;
 export function terminalprops(
@@ -1425,16 +1789,89 @@ export function terminalprops(
 }
 
 /**
+ * Create a List from a shallow copy of the tuple items.
+ * Examples:
+ *
+ *     tuple2list((1, 2, 3))           returns [1, 2, 3]
+ *
+ * `list2tuple()` does the opposite.
+ *
+ * This function doesn't recursively convert all the Tuple items
+ * in **{tuple}** to a List.  Note that the items are identical
+ * between the list and the tuple, changing an item changes the
+ * contents of both the tuple and the list.
+ *
+ * Returns an empty list on error.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetTuple()->tuple2list()
+ *
+ * Return type: list<**{type}**> (depending on the given `Tuple`)
+ */
+export function tuple2list(denops: Denops, tuple: unknown): Promise<unknown[]>;
+export function tuple2list(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("tuple2list", ...args);
+}
+
+/**
  * Return a string representation of the type of **{expr}**.
  * Example:
  *
  *     echo typename([1, 2, 3])
  *
  *         list<number>
+ *
+ * Return type: `String`
  */
 export function typename(denops: Denops, expr: unknown): Promise<string>;
 export function typename(denops: Denops, ...args: unknown[]): Promise<unknown> {
   return denops.call("typename", ...args);
+}
+
+/**
+ * Start wildcard expansion in the command-line, using the
+ * behavior defined by the 'wildmode' and 'wildoptions' settings.
+ * See `cmdline-completion`.
+ *
+ * This function also enables completion in search patterns such
+ * as `/`, `?`, `:s`, `:g`, `:v` and `:vimgrep`.
+ *
+ * Unlike pressing 'wildchar' manually, this function does not
+ * produce a beep when no matches are found and generally
+ * operates more quietly.  This makes it suitable for triggering
+ * completion automatically, such as from an `:autocmd`.
+ *
+ * Example: To make the completion menu pop up automatically as
+ * you type on the command line, use:
+ *
+ *     autocmd CmdlineChanged [:/\?] call wildtrigger()
+ *     set wildmode=noselect:lastused,full wildoptions=pum
+ *
+ * To retain normal history navigation (up/down keys):
+ *
+ *     cnoremap <Up>   <C-U><Up>
+ *     cnoremap <Down> <C-U><Down>
+ *
+ * To set an option specifically when performing a search, e.g.
+ * to set 'pumheight':
+ *
+ *     autocmd CmdlineEnter [/\?] set pumheight=8
+ *     autocmd CmdlineLeave [/\?] set pumheight&
+ *
+ * Return value is always 0.
+ *
+ * Return type: `Number`
+ */
+export function wildtrigger(denops: Denops): Promise<number>;
+export function wildtrigger(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("wildtrigger", ...args);
 }
 
 /**
@@ -1450,6 +1887,8 @@ export function typename(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_canread()
+ *
+ * Return type: `Number`
  */
 export function ch_canread(denops: Denops, handle: unknown): Promise<number>;
 export function ch_canread(
@@ -1467,6 +1906,8 @@ export function ch_canread(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_close()
+ *
+ * Return type: `Number`
  */
 export function ch_close(denops: Denops, handle: unknown): Promise<void>;
 export function ch_close(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1481,6 +1922,8 @@ export function ch_close(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_close_in()
+ *
+ * Return type: `Number`
  */
 export function ch_close_in(denops: Denops, handle: unknown): Promise<void>;
 export function ch_close_in(
@@ -1512,6 +1955,8 @@ export function ch_close_in(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_evalexpr(expr)
+ *
+ * Return type: dict<any> or `String`
  */
 export function ch_evalexpr(
   denops: Denops,
@@ -1543,6 +1988,8 @@ export function ch_evalexpr(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_evalraw(rawstring)
+ *
+ * Return type: dict<any> or `String`
  */
 export function ch_evalraw(
   denops: Denops,
@@ -1567,6 +2014,8 @@ export function ch_evalraw(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_getbufnr(what)
+ *
+ * Return type: `Number`
  */
 export function ch_getbufnr(
   denops: Denops,
@@ -1588,6 +2037,8 @@ export function ch_getbufnr(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_getjob()
+ *
+ * Return type: `job` or `String`
  */
 export function ch_getjob(denops: Denops, channel: unknown): Promise<unknown>;
 export function ch_getjob(
@@ -1632,6 +2083,8 @@ export function ch_getjob(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_info()
+ *
+ * Return type: dict<any>
  */
 export function ch_info(denops: Denops, handle: unknown): Promise<string>;
 export function ch_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
@@ -1652,6 +2105,8 @@ export function ch_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     'did something'->ch_log()
+ *
+ * Return type: dict<any>
  */
 export function ch_log(
   denops: Denops,
@@ -1689,6 +2144,8 @@ export function ch_log(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     'logfile'->ch_logfile('w')
+ *
+ * Return type: `Number`
  */
 export function ch_logfile(
   denops: Denops,
@@ -1715,6 +2172,8 @@ export function ch_logfile(
  * Can also be used as a `method`:
  *
  *     GetAddress()->ch_open()
+ *
+ * Return type: `channel`
  */
 export function ch_open(
   denops: Denops,
@@ -1735,6 +2194,8 @@ export function ch_open(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_read()
+ *
+ * Return type: `String`
  */
 export function ch_read(
   denops: Denops,
@@ -1752,6 +2213,8 @@ export function ch_read(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_readblob()
+ *
+ * Return type: `Blob`
  */
 export function ch_readblob(
   denops: Denops,
@@ -1774,6 +2237,8 @@ export function ch_readblob(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_readraw()
+ *
+ * Return type: `String`
  */
 export function ch_readraw(
   denops: Denops,
@@ -1808,6 +2273,8 @@ export function ch_readraw(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_sendexpr(expr)
+ *
+ * Return type: dict<any> or `String`
  */
 export function ch_sendexpr(
   denops: Denops,
@@ -1834,6 +2301,8 @@ export function ch_sendexpr(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_sendraw(rawexpr)
+ *
+ * Return type: dict<any> or `String`
  */
 export function ch_sendraw(
   denops: Denops,
@@ -1865,6 +2334,8 @@ export function ch_sendraw(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_setoptions(options)
+ *
+ * Return type: `Number`
  */
 export function ch_setoptions(
   denops: Denops,
@@ -1897,6 +2368,8 @@ export function ch_setoptions(
  * Can also be used as a `method`:
  *
  *     GetChannel()->ch_status()
+ *
+ * Return type: `String`
  */
 export function ch_status(
   denops: Denops,
@@ -1919,6 +2392,8 @@ export function ch_status(
  * Can also be used as a `method`:
  *
  *     GetJob()->job_getchannel()
+ *
+ * Return type: `channel`
  */
 export function job_getchannel(denops: Denops, job: unknown): Promise<unknown>;
 export function job_getchannel(
@@ -1955,6 +2430,9 @@ export function job_getchannel(
  * Can also be used as a `method`:
  *
  *     GetJob()->job_info()
+ *
+ * Return type: dict<any> or list<job> depending on whether **{job}**
+ * was given
  */
 export function job_info(
   denops: Denops,
@@ -1972,6 +2450,8 @@ export function job_info(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetJob()->job_setoptions(options)
+ *
+ * Return type: `Number`
  */
 export function job_setoptions(
   denops: Denops,
@@ -1995,8 +2475,9 @@ export function job_setoptions(
  * invoked.
  *
  * **{command}** can be a String.  This works best on MS-Windows.  On
- * Unix it is split up in white-separated parts to be passed to
- * execvp().  Arguments in double quotes can contain white space.
+ * Unix it is split up in white space separated parts to be
+ * passed to execvp().  Arguments in double quotes can contain
+ * white space.
  *
  * **{command}** can be a List, where the first item is the executable
  * and further items are the arguments.  All items are converted
@@ -2055,6 +2536,8 @@ export function job_setoptions(
  * Can also be used as a `method`:
  *
  *     BuildCommand()->job_start()
+ *
+ * Return type: `job`
  */
 export function job_start(
   denops: Denops,
@@ -2090,6 +2573,8 @@ export function job_start(
  * Can also be used as a `method`:
  *
  *     GetJob()->job_status()
+ *
+ * Return type: `String`
  */
 export function job_status(denops: Denops, job: unknown): Promise<string>;
 export function job_status(
@@ -2144,6 +2629,8 @@ export function job_status(
  * Can also be used as a `method`:
  *
  *     GetJob()->job_stop()
+ *
+ * Return type: `Number`
  */
 export function job_stop(
   denops: Denops,
@@ -2172,6 +2659,8 @@ export function job_stop(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetText()->popup_atcursor({})
+ *
+ * Return type: `Number`
  */
 export function popup_atcursor(
   denops: Denops,
@@ -2203,6 +2692,8 @@ export function popup_atcursor(
  * Can also be used as a `method`:
  *
  *     GetText()->popup_beval({})
+ *
+ * Return type: `Number`
  */
 export function popup_beval(
   denops: Denops,
@@ -2225,6 +2716,8 @@ export function popup_beval(
  * When **{force}** is present and `TRUE` the popup is also closed
  * when it is the current window.  If a terminal is running in a
  * popup it is killed.
+ *
+ * Return type: `Number`
  */
 export function popup_clear(denops: Denops, force?: unknown): Promise<void>;
 export function popup_clear(
@@ -2235,8 +2728,8 @@ export function popup_clear(
 }
 
 /**
- * Close popup **{id}**.  The window and the associated buffer will
- * be deleted.
+ * Close popup **{id}**.  The window will be deleted.  The associated
+ * buffer will be deleted, if the popup created a new buffer.
  *
  * If the popup has a callback it will be called just before the
  * popup window is deleted.  If the optional **{result}** is present
@@ -2246,6 +2739,8 @@ export function popup_clear(
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_close()
+ *
+ * Return type: `Number`
  */
 export function popup_close(
   denops: Denops,
@@ -2285,6 +2780,8 @@ export function popup_close(
  * Can also be used as a `method`:
  *
  *     GetText()->popup_dialog({})
+ *
+ * Return type: `Number`
  */
 export function popup_dialog(
   denops: Denops,
@@ -2317,6 +2814,8 @@ export function popup_dialog(
  *
  * To add shortcut keys, see the example here:
  * `popup_menu-shortcut-example`
+ *
+ * Return type: `Number`
  */
 export function popup_filter_menu(
   denops: Denops,
@@ -2338,6 +2837,8 @@ export function popup_filter_menu(
  * pressing 'n'.  CTRL-C invokes the callback with -1.  Other
  * keys are ignored.
  * See the example here: `popup_dialog-example`
+ *
+ * Return type: `Number`
  */
 export function popup_filter_yesno(
   denops: Denops,
@@ -2355,6 +2856,8 @@ export function popup_filter_yesno(
  * Get the `window-ID` for the popup that shows messages for the
  * `:echowindow` command.  Return zero if there is none.
  * Mainly useful to hide the popup.
+ *
+ * Return type: `Number`
  */
 export function popup_findecho(denops: Denops): Promise<number>;
 export function popup_findecho(
@@ -2371,6 +2874,8 @@ export function popup_findecho(
  * and `popup_close()`.  Use `popup_show()` to reposition it to
  * the item in the popup menu.
  * Returns zero if there is none.
+ *
+ * Return type: `Number`
  */
 export function popup_findinfo(denops: Denops): Promise<number>;
 export function popup_findinfo(
@@ -2383,6 +2888,8 @@ export function popup_findinfo(
 /**
  * Get the `window-ID` for the popup preview window.
  * Return zero if there is none.
+ *
+ * Return type: `Number`
  */
 export function popup_findpreview(denops: Denops): Promise<number>;
 export function popup_findpreview(
@@ -2426,6 +2933,8 @@ export function popup_findpreview(
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_getoptions()
+ *
+ * Return type: dict<any>
  */
 export function popup_getoptions(
   denops: Denops,
@@ -2466,6 +2975,8 @@ export function popup_getoptions(
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_getpos()
+ *
+ * Return type: dict<number> or dict<any>
  */
 export function popup_getpos(
   denops: Denops,
@@ -2489,6 +3000,8 @@ export function popup_getpos(
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_hide()
+ *
+ * Return type: `Number`
  */
 export function popup_hide(denops: Denops, id: unknown): Promise<void>;
 export function popup_hide(
@@ -2500,6 +3013,8 @@ export function popup_hide(
 
 /**
  * Return a List with the `window-ID` of all existing popups.
+ *
+ * Return type: list<number> or list<any>
  */
 export function popup_list(denops: Denops): Promise<unknown[]>;
 export function popup_list(
@@ -2514,6 +3029,8 @@ export function popup_list(
  * and **{col}**.  If there are multiple popups the one with the
  * highest zindex is returned.  If there are no popups at this
  * position then zero is returned.
+ *
+ * Return type: `Number`
  */
 export function popup_locate(
   denops: Denops,
@@ -2546,7 +3063,7 @@ export function popup_locate(
  *             \ })
  *
  * The current line is highlighted with a match using
- * "PopupSelected", or "PmenuSel" if that is not defined.
+ * `hl-PopupSelected` which is linked to "PmenuSel" by default.
  *
  * Use **{options}** to change the properties.  Should at least set
  * "callback" to a function that handles the selected item.
@@ -2562,6 +3079,8 @@ export function popup_locate(
  * Can also be used as a `method`:
  *
  *     GetChoices()->popup_menu({})
+ *
+ * Return type: `Number`
  */
 export function popup_menu(
   denops: Denops,
@@ -2593,6 +3112,8 @@ export function popup_menu(
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_move(options)
+ *
+ * Return type: `Number`
  */
 export function popup_move(
   denops: Denops,
@@ -2624,7 +3145,7 @@ export function popup_move(
  *             \ padding: [0,1,0,1],
  *             \ })
  *
- * The PopupNotification highlight group is used instead of
+ * The `hl-PopupNotification` highlight group is used instead of
  * WarningMsg if it is defined.
  *
  * Without the `+timers` feature the popup will not disappear
@@ -2637,6 +3158,8 @@ export function popup_move(
  * Can also be used as a `method`:
  *
  *     GetText()->popup_notification({})
+ *
+ * Return type: `Number`
  */
 export function popup_notification(
   denops: Denops,
@@ -2651,15 +3174,40 @@ export function popup_notification(
 }
 
 /**
- * Set the text of the buffer in popup win **{id}**. **{text}** is the
- * same as supplied to `popup_create()`, except that a buffer
- * number is not allowed.
+ * Set buffer **{buf}** to be displayed in popup win **{id}**.  For the
+ * use of **{buf}**, see `bufname()` function.
+ * May change window size or position to adjust for the size
+ * of the buffer text.
+ *
+ * Can also be used as a `method`:
+ *
+ *     GetPopup()->popup_setbuf(bufnr('foobar'))
+ *
+ * Return type: `vim9-boolean`
+ */
+export function popup_setbuf(
+  denops: Denops,
+  id: unknown,
+  buf: unknown,
+): Promise<boolean>;
+export function popup_setbuf(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("popup_setbuf", ...args);
+}
+
+/**
+ * Set the text of the buffer in popup win **{id}**. **{text}** is
+ * a string or a list of strings to be displayed in the popup.
  * Does not change the window size or position, other than caused
  * by the different text.
  *
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_settext('hello')
+ *
+ * Return type: `Number`
  */
 export function popup_settext(
   denops: Denops,
@@ -2678,6 +3226,8 @@ export function popup_settext(
  * For **{id}** see `popup_hide()`.
  * If **{id}** is the info popup it will be positioned next to the
  * current popup menu item.
+ *
+ * Return type: `Number`
  */
 export function popup_show(denops: Denops, id: unknown): Promise<void>;
 export function popup_show(
@@ -2741,6 +3291,8 @@ export function popup_show(
  * Can also be used as a `method`:
  *
  *     GetFilename()->term_dumpdiff(otherfile)
+ *
+ * Return type: `Number`
  */
 export function term_dumpdiff(
   denops: Denops,
@@ -2766,6 +3318,8 @@ export function term_dumpdiff(
  * Can also be used as a `method`:
  *
  *     GetFilename()->term_dumpload()
+ *
+ * Return type: `Number`
  */
 export function term_dumpload(
   denops: Denops,
@@ -2796,6 +3350,8 @@ export function term_dumpload(
  * name:
  *
  *     GetFilename()->term_dumpwrite(bufnr)
+ *
+ * Return type: `Number`
  */
 export function term_dumpwrite(
   denops: Denops,
@@ -2818,6 +3374,8 @@ export function term_dumpwrite(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getaltscreen()
+ *
+ * Return type: `Number`
  */
 export function term_getaltscreen(
   denops: Denops,
@@ -2843,6 +3401,8 @@ export function term_getaltscreen(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getansicolors()
+ *
+ * Return type: list<string> or list<any>
  *
  * *only available when compiled with GUI enabled and/or the
  * `+termguicolors` feature*
@@ -2870,6 +3430,8 @@ export function term_getansicolors(
  * Can also be used as a `method`:
  *
  *     GetAttr()->term_getattr()
+ *
+ * Return type: `Number`
  */
 export function term_getattr(
   denops: Denops,
@@ -2907,6 +3469,8 @@ export function term_getattr(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getcursor()
+ *
+ * Return type: list<any>
  */
 export function term_getcursor(
   denops: Denops,
@@ -2922,11 +3486,14 @@ export function term_getcursor(
 /**
  * Get the Job associated with terminal window **{buf}**.
  * **{buf}** is used as with `term_getsize()`.
- * Returns `v:null` when there is no job.
+ * Returns `v:null` when there is no job. In Vim9 script, return
+ * `null_job` when there is no job.
  *
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getjob()
+ *
+ * Return type: `job`
  */
 export function term_getjob(denops: Denops, buf: unknown): Promise<unknown>;
 export function term_getjob(
@@ -2949,6 +3516,8 @@ export function term_getjob(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getline(row)
+ *
+ * Return type: `String`
  */
 export function term_getline(
   denops: Denops,
@@ -2980,6 +3549,8 @@ export function term_getline(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getscrolled()
+ *
+ * Return type: `Number`
  */
 export function term_getscrolled(denops: Denops, buf: unknown): Promise<number>;
 export function term_getscrolled(
@@ -3001,6 +3572,8 @@ export function term_getscrolled(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getsize()
+ *
+ * Return type: list<number> or list<any>
  */
 export function term_getsize(denops: Denops, buf: unknown): Promise<unknown[]>;
 export function term_getsize(
@@ -3025,6 +3598,8 @@ export function term_getsize(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_getstatus()
+ *
+ * Return type: `String`
  */
 export function term_getstatus(denops: Denops, buf: unknown): Promise<string>;
 export function term_getstatus(
@@ -3045,6 +3620,8 @@ export function term_getstatus(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_gettitle()
+ *
+ * Return type: `String`
  */
 export function term_gettitle(denops: Denops, buf: unknown): Promise<string>;
 export function term_gettitle(
@@ -3065,6 +3642,8 @@ export function term_gettitle(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_gettty()
+ *
+ * Return type: `String`
  */
 export function term_gettty(
   denops: Denops,
@@ -3081,6 +3660,8 @@ export function term_gettty(
 /**
  * Return a list with the buffer numbers of all buffers for
  * terminal windows.
+ *
+ * Return type: list<number> or list<any>
  */
 export function term_list(denops: Denops): Promise<unknown[]>;
 export function term_list(
@@ -3111,6 +3692,8 @@ export function term_list(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_scrape(row)
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function term_scrape(
   denops: Denops,
@@ -3134,6 +3717,8 @@ export function term_scrape(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_sendkeys(keys)
+ *
+ * Return type: `Number`
  */
 export function term_sendkeys(
   denops: Denops,
@@ -3180,6 +3765,8 @@ export function term_sendkeys(
  *
  *     GetBufnr()->term_setansicolors(colors)
  *
+ * Return type: `Number`
+ *
  * *only available with GUI enabled and/or the `+termguicolors`
  * feature*
  */
@@ -3208,6 +3795,8 @@ export function term_setansicolors(
  * When used as a method the base is used for **{buf}**:
  *
  *     GetBufnr()->term_setapi({expr})
+ *
+ * Return type: `Number`
  */
 export function term_setapi(
   denops: Denops,
@@ -3236,6 +3825,8 @@ export function term_setapi(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_setkill(how)
+ *
+ * Return type: `Number`
  */
 export function term_setkill(
   denops: Denops,
@@ -3263,6 +3854,8 @@ export function term_setkill(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_setrestore(command)
+ *
+ * Return type: `Number`
  */
 export function term_setrestore(
   denops: Denops,
@@ -3289,6 +3882,8 @@ export function term_setrestore(
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_setsize(rows, cols)
+ *
+ * Return type: `Number`
  */
 export function term_setsize(
   denops: Denops,
@@ -3377,6 +3972,8 @@ export function term_setsize(
  * Can also be used as a `method`:
  *
  *     GetCommand()->term_start()
+ *
+ * Return type: `Number`
  */
 export function term_start(
   denops: Denops,
@@ -3394,11 +3991,14 @@ export function term_start(
  * Wait for pending updates of **{buf}** to be handled.
  * **{buf}** is used as with `term_getsize()`.
  * **{time}** is how long to wait for updates to arrive in msec.  If
- * not set then 10 msec will be used.
+ * not set then 10 msec will be used.  Queued messages will also
+ * be processed similar to `:sleep`.
  *
  * Can also be used as a `method`:
  *
  *     GetBufnr()->term_wait()
+ *
+ * Return type: `Number`
  */
 export function term_wait(
   denops: Denops,
@@ -3421,6 +4021,8 @@ export function term_wait(
  * Can also be used as a `method`:
  *
  *     GetAllocId()->test_alloc_fail()
+ *
+ * Return type: `Number`
  */
 export function test_alloc_fail(
   denops: Denops,
@@ -3438,6 +4040,8 @@ export function test_alloc_fail(
 /**
  * Set a flag to enable the effect of 'autochdir' before Vim
  * startup has finished.
+ *
+ * Return type: `Number`
  */
 export function test_autochdir(denops: Denops): Promise<void>;
 export function test_autochdir(
@@ -3455,6 +4059,8 @@ export function test_autochdir(
  * Can also be used as a `method`:
  *
  *     GetText()->test_feedinput()
+ *
+ * Return type: `Number`
  */
 export function test_feedinput(denops: Denops, string: unknown): Promise<void>;
 export function test_feedinput(
@@ -3467,6 +4073,8 @@ export function test_feedinput(
 /**
  * Set the flag to call the garbagecollector as if in the main
  * loop.  Only to be used in tests.
+ *
+ * Return type: `Number`
  */
 export function test_garbagecollect_soon(denops: Denops): Promise<void>;
 export function test_garbagecollect_soon(
@@ -3484,6 +4092,8 @@ export function test_garbagecollect_soon(
  * Can also be used as a `method`:
  *
  *     GetName()->test_getvalue()
+ *
+ * Return type: `Number`
  */
 export function test_getvalue(denops: Denops, name: unknown): Promise<unknown>;
 export function test_getvalue(
@@ -3621,6 +4231,8 @@ export function test_getvalue(
  * Can also be used as a `method`:
  *
  *     GetEvent()->test_gui_event({args})
+ *
+ * Return type: `vim9-boolean`
  */
 export function test_gui_event(
   denops: Denops,
@@ -3647,6 +4259,8 @@ export function test_gui_event(
  * Can also be used as a `method`:
  *
  *     GetErrorText()->test_ignore_error()
+ *
+ * Return type: `Number`
  */
 export function test_ignore_error(denops: Denops, expr: unknown): Promise<void>;
 export function test_ignore_error(
@@ -3737,6 +4351,8 @@ export function test_ignore_error(
  * Can also be used as a `method`:
  *
  *     GetEvent()->test_mswin_event({args})
+ *
+ * Return type: `vim9-boolean`
  */
 export function test_mswin_event(
   denops: Denops,
@@ -3752,6 +4368,8 @@ export function test_mswin_event(
 
 /**
  * Return a `Blob` that is null. Only useful for testing.
+ *
+ * Return type: `Blob`
  */
 export function test_null_blob(denops: Denops): Promise<unknown>;
 export function test_null_blob(
@@ -3764,6 +4382,8 @@ export function test_null_blob(
 /**
  * Return a `Channel` that is null. Only useful for testing.
  * *only available when compiled with the +channel feature*
+ *
+ * Return type: `Channel`
  */
 export function test_null_channel(denops: Denops): Promise<unknown>;
 export function test_null_channel(
@@ -3775,6 +4395,8 @@ export function test_null_channel(
 
 /**
  * Return a `Dict` that is null. Only useful for testing.
+ *
+ * Return type: dict<any>
  */
 export function test_null_dict(
   denops: Denops,
@@ -3788,6 +4410,8 @@ export function test_null_dict(
 
 /**
  * Return a `Funcref` that is null. Only useful for testing.
+ *
+ * Return type: func(...): unknown
  */
 export function test_null_function(denops: Denops): Promise<unknown>;
 export function test_null_function(
@@ -3800,6 +4424,8 @@ export function test_null_function(
 /**
  * Return a `Job` that is null. Only useful for testing.
  * *only available when compiled with the +job feature*
+ *
+ * Return type: `job`
  */
 export function test_null_job(denops: Denops): Promise<unknown>;
 export function test_null_job(
@@ -3811,6 +4437,8 @@ export function test_null_job(
 
 /**
  * Return a `List` that is null. Only useful for testing.
+ *
+ * Return type: list<any>
  */
 export function test_null_list(denops: Denops): Promise<unknown[]>;
 export function test_null_list(
@@ -3822,6 +4450,8 @@ export function test_null_list(
 
 /**
  * Return a `Partial` that is null. Only useful for testing.
+ *
+ * Return type: func(...): unknown
  */
 export function test_null_partial(denops: Denops): Promise<unknown>;
 export function test_null_partial(
@@ -3833,6 +4463,8 @@ export function test_null_partial(
 
 /**
  * Return a `String` that is null. Only useful for testing.
+ *
+ * Return type: `String`
  */
 export function test_null_string(denops: Denops): Promise<string>;
 export function test_null_string(
@@ -3840,6 +4472,19 @@ export function test_null_string(
   ...args: unknown[]
 ): Promise<unknown> {
   return denops.call("test_null_string", ...args);
+}
+
+/**
+ * Return a `Tuple` that is null. Only useful for testing.
+ *
+ * Return type: `Tuple`
+ */
+export function test_null_tuple(denops: Denops): Promise<unknown>;
+export function test_null_tuple(
+  denops: Denops,
+  ...args: unknown[]
+): Promise<unknown> {
+  return denops.call("test_null_tuple", ...args);
 }
 
 /**
@@ -3856,6 +4501,8 @@ export function test_null_string(
  * Can also be used as a `method`:
  *
  *     GetOptionName()->test_option_not_set()
+ *
+ * Return type: `Number`
  */
 export function test_option_not_set(
   denops: Denops,
@@ -3927,6 +4574,8 @@ export function test_option_not_set(
  * Can also be used as a `method`:
  *
  *     GetOverrideVal()-> test_override('starting')
+ *
+ * Return type: `Number`
  */
 export function test_override(
   denops: Denops,
@@ -3948,6 +4597,8 @@ export function test_override(
  * Can also be used as a `method`:
  *
  *     GetVarname()->test_refcount()
+ *
+ * Return type: `Number`
  */
 export function test_refcount(denops: Denops, expr: unknown): Promise<number>;
 export function test_refcount(
@@ -3964,6 +4615,8 @@ export function test_refcount(
  *
  *     call test_setmouse(4, 20)
  *     call feedkeys("\<LeftMouse>", "xt")
+ *
+ * Return type: `Number`
  */
 export function test_setmouse(
   denops: Denops,
@@ -3989,6 +4642,8 @@ export function test_setmouse(
  * Can also be used as a `method`:
  *
  *     GetTime()->test_settime()
+ *
+ * Return type: `Number`
  */
 export function test_settime(denops: Denops, expr: unknown): Promise<void>;
 export function test_settime(
@@ -4001,6 +4656,8 @@ export function test_settime(
 /**
  * When **{seed}** is given this sets the seed value used by
  * `srand()`.  When omitted the test seed is removed.
+ *
+ * Return type: `Number`
  */
 export function test_srand_seed(denops: Denops, seed?: unknown): Promise<void>;
 export function test_srand_seed(
@@ -4012,6 +4669,8 @@ export function test_srand_seed(
 
 /**
  * Return a value with unknown type. Only useful for testing.
+ *
+ * Return type: unknown
  */
 export function test_unknown(denops: Denops): Promise<unknown>;
 export function test_unknown(
@@ -4023,6 +4682,8 @@ export function test_unknown(
 
 /**
  * Return a value with void type. Only useful for testing.
+ *
+ * Return type: void
  */
 export function test_void(denops: Denops): Promise<unknown>;
 export function test_void(
@@ -4051,10 +4712,10 @@ export function test_void(
  *    bufnr        buffer to add the property to; when omitted
  *                 the current buffer is used
  *    id           user defined ID for the property; must be a
- *                 number, should be positive; when using "text"
- *                 then "id" must not be present and will be set
- *                 automatically to a negative number; otherwise
- *                 zero is used
+ *                 number, should be positive `E1510`;
+ *                 when using "text" then "id" must not be
+ *                 present and will be set automatically to a
+ *                 negative number; otherwise zero is used
  *
  *    text         text to be displayed before **{col}**, or
  *                 above/below the line if **{col}** is zero; prepend
@@ -4147,6 +4808,8 @@ export function test_void(
  * Can also be used as a `method`:
  *
  *     GetLnum()->prop_add(col, props)
+ *
+ * Return type: `Number`
  */
 export function prop_add(
   denops: Denops,
@@ -4169,6 +4832,8 @@ export function prop_add(denops: Denops, ...args: unknown[]): Promise<unknown> {
  * Can also be used as a `method`:
  *
  *     GetLnum()->prop_clear()
+ *
+ * Return type: `Number`
  */
 export function prop_clear(
   denops: Denops,
@@ -4207,6 +4872,8 @@ export function prop_clear(
  * If a match is found then a Dict is returned with the entries
  * as with prop_list(), and additionally an "lnum" entry.
  * If no match is found then an empty Dict is returned.
+ *
+ * Return type: dict<any>
  */
 export function prop_find(
   denops: Denops,
@@ -4289,6 +4956,8 @@ export function prop_find(
  * Can also be used as a `method`:
  *
  *     GetLnum()->prop_list()
+ *
+ * Return type: list<dict<any>> or list<any>
  */
 export function prop_list(
   denops: Denops,
@@ -4331,6 +5000,8 @@ export function prop_list(
  * Can also be used as a `method`:
  *
  *     GetProps()->prop_remove()
+ *
+ * Return type: `Number`
  */
 export function prop_remove(
   denops: Denops,
@@ -4371,6 +5042,8 @@ export function prop_remove(
  * Can also be used as a `method`:
  *
  *     GetPropName()->prop_type_add(props)
+ *
+ * Return type: `Number`
  */
 export function prop_type_add(
   denops: Denops,
@@ -4392,6 +5065,8 @@ export function prop_type_add(
  * Can also be used as a `method`:
  *
  *     GetPropName()->prop_type_change(props)
+ *
+ * Return type: `Number`
  */
 export function prop_type_change(
   denops: Denops,
@@ -4419,6 +5094,8 @@ export function prop_type_change(
  * Can also be used as a `method`:
  *
  *     GetPropName()->prop_type_delete()
+ *
+ * Return type: `Number`
  */
 export function prop_type_delete(
   denops: Denops,
@@ -4445,6 +5122,8 @@ export function prop_type_delete(
  * Can also be used as a `method`:
  *
  *     GetPropName()->prop_type_get()
+ *
+ * Return type: dict<any>
  */
 export function prop_type_get(
   denops: Denops,
@@ -4463,6 +5142,8 @@ export function prop_type_get(
  *
  * **{props}** can contain a "bufnr" item.  When it is given, use
  * this buffer instead of the global property types.
+ *
+ * Return type: list<string> or list<any>
  */
 export function prop_type_list(
   denops: Denops,

--- a/function/vim/popup_create.ts
+++ b/function/vim/popup_create.ts
@@ -31,6 +31,8 @@ import type { Denops } from "../../mod.ts";
  * Can also be used as a `method`:
  *
  *     GetText()->popup_create({})
+ *
+ * Return type: `Number`
  */
 export function popup_create(
   denops: Denops,

--- a/function/vim/popup_setoptions.ts
+++ b/function/vim/popup_setoptions.ts
@@ -35,6 +35,8 @@ import type { Denops } from "../../mod.ts";
  * Can also be used as a `method`:
  *
  *     GetPopup()->popup_setoptions(options)
+ *
+ * Return type: `Number`
  */
 export function popup_setoptions(
   denops: Denops,

--- a/function/vim/prop_add_list.ts
+++ b/function/vim/prop_add_list.ts
@@ -46,7 +46,7 @@ export type PropAddListItem = [
  *     call prop_add_list(#{type: 'MyProp', id: 2},
  *                     \ [[1, 4, 1, 7],
  *                     \  [1, 15, 1, 20],
- *                     \  [2, 30, 3, 30]]
+ *                     \  [2, 30, 3, 30]])
  *
  * Can also be used as a `method`:
  *

--- a/function/window.ts
+++ b/function/window.ts
@@ -81,6 +81,8 @@ export interface WinInfo {
  *         botline         last complete displayed buffer line
  *         bufnr           number of buffer in the window
  *         height          window height (excluding winbar)
+ *         leftcol         first column displayed; only used when
+ *                         'wrap' is off
  *         loclist         1 if showing a location list
  *                         *only with the +quickfix feature*
  *         quickfix        1 if quickfix or location list window
@@ -107,6 +109,8 @@ export interface WinInfo {
  * Can also be used as a `method`:
  *
  *     GetWinnr()->getwininfo()
+ *
+ * Return type: list<dict<any>>
  */
 export function getwininfo(denops: Denops, winid?: number): Promise<WinInfo[]>;
 export function getwininfo(
@@ -139,6 +143,8 @@ export function getwininfo(
  * Can also be used as a `method`:
  *
  *     GetTimeout()->getwinpos()
+ *
+ * Return type: list<number>
  */
 export function getwinpos(
   denops: Denops,

--- a/option/_generated.ts
+++ b/option/_generated.ts
@@ -223,12 +223,12 @@ export const autowriteall: GlobalOption<boolean> = new BooleanOption(
  * Vim will guess the value.  In the GUI this should work correctly,
  * in other cases Vim might not be able to guess the right value.
  * If the GUI supports a dark theme, you can use the "d" flag in
- * 'guioptions', see 'go-d'.
+ * 'guioptions', see `'go-d'`.
  *
  * When the `t_RB` option is set, Vim will use it to request the background
  * color from the terminal.  If the returned RGB value is dark/light and
  * 'background' is not dark/light, 'background' will be set and the
- * screen is redrawn.  This may have side effects, make t_BG empty in
+ * screen is redrawn.  This may have side effects, make `t_RB` empty in
  * your .vimrc if you suspect this problem.  The response to `t_RB` can
  * be found in `v:termrbgresp`.
  *
@@ -294,8 +294,8 @@ export const background: GlobalOption<string> = new StringOption("background");
  * See `:fixdel` if your `<BS>` or `<Del>` key does not do what you want.
  * NOTE: This option is set to "" when 'compatible' is set.
  *
- * (default "", set to "indent,eol,start"
- *  in `defaults.vim`)
+ * (Vim default: "indent,eol,start",
+ *  Vi default:  "")
  */
 export const backspace: GlobalOption<string> = new StringOption("backspace");
 
@@ -360,7 +360,8 @@ export const backup: GlobalOption<boolean> = new BooleanOption("backup");
  * that opens a file, invokes Vim to edit that file, and then tests if
  * the open file was changed (through the file descriptor) will check the
  * backup file instead of the newly created file.  "crontab -e" is an
- * example.
+ * example, as are several `file-watcher` daemons like inotify.  In that
+ * case you probably want to switch this option.
  *
  * When a copy is made, the original file is truncated and then filled
  * with the new text.  This means that protection bits, owner and
@@ -619,7 +620,7 @@ export const breakindent: WindowLocalOption<boolean> = new BooleanOption(
  *                     applying 'breakindent', even if the resulting
  *                     text should normally be narrower. This prevents
  *                     text indented almost to the right window border
- *                     occupying lot of vertical space when broken.
+ *                     occupying lots of vertical space when broken.
  *                     (default: 20)
  *         shift:**{n}**   After applying 'breakindent', the wrapped line's
  *                     beginning will be shifted by the given number of
@@ -633,9 +634,9 @@ export const breakindent: WindowLocalOption<boolean> = new BooleanOption(
  *         list:**{n}**    Adds an additional indent for lines that match a
  *                     numbered or bulleted list (using the
  *                     'formatlistpat' setting).
- *         list:-1     Uses the length of a match with 'formatlistpat'
- *                     for indentation.
  *                     (default: 0)
+ *         list:-1     Uses the width of a match with 'formatlistpat' for
+ *                     indentation.
  *         column:**{n}**  Indent at column **{n}**. Will overrule the other
  *                     sub-options. Note: an additional indent may be
  *                     added for the 'showbreak' setting.
@@ -648,20 +649,6 @@ export const breakindent: WindowLocalOption<boolean> = new BooleanOption(
 export const breakindentopt: WindowLocalOption<string> = new StringOption(
   "breakindentopt",
 );
-
-/**
- * Which directory to use for the file browser:
- *    last         Use same directory as with last file browser, where a
- *                 file was opened or saved.
- *    buffer       Use the directory of the related buffer.
- *    current      Use the current directory.
- *    **{path}**       Use the specified directory
- *
- * (default: "last")
- *
- * *only for Motif, GTK, Mac and Win32 GUI*
- */
-export const browsedir: GlobalOption<string> = new StringOption("browsedir");
 
 /**
  * This option specifies what happens when a buffer is no longer
@@ -738,7 +725,7 @@ export const buflisted: BufferLocalOption<boolean> = new BooleanOption(
  * "nofile" and "nowrite" buffers are similar:
  * both:           The buffer is not to be written to disk, ":w" doesn't
  *                 work (":w filename" does work though).
- * both:           The buffer is never considered to be `'modified'`.
+ * both:           The buffer is never considered to be 'modified'.
  *                 There is no warning when the changes will be lost, for
  *                 example when you quit Vim.
  * both:           A swap file is only created when using too much memory
@@ -797,7 +784,7 @@ export const cdhome: GlobalOption<boolean> = new BooleanOption("cdhome");
  * searched for has a relative path, not an absolute part starting with
  * "/", "./" or "../", the 'cdpath' option is not used then.
  * The 'cdpath' option's value has the same form and semantics as
- * `'path'`.  Also see `file-searching`.
+ * 'path'.  Also see `file-searching`.
  * The default value is taken from $CDPATH, with a "," prepended to look
  * in the current directory first.
  * If the default value taken from $CDPATH is not what you want, include
@@ -819,10 +806,11 @@ export const cdpath: GlobalOption<string> = new StringOption("cdpath");
  * The default is CTRL-F when 'compatible' is off.
  * Only non-printable keys are allowed.
  * The key can be specified as a single character, but it is difficult to
- * type.  The preferred way is to use the `<>` notation.  Examples:
+ * type.  The preferred way is to use `key-notation` (e.g. `<Up>`, `<C-F>`) or
+ * a letter preceded with a caret (e.g. `^F` is CTRL-F).  Examples:
  *
- *     :exe "set cedit=\<C-Y>"
- *     :exe "set cedit=\<Esc>"
+ *     :set cedit=^Y
+ *     :set cedit=<Esc>
  *
  * `Nvi` also has this option, but it only uses the first character.
  * See `cmdwin`.
@@ -987,11 +975,13 @@ export const cinwords: BufferLocalOption<string> = new StringOption("cinwords");
  *                 register '*' for all yank, delete, change and put
  *                 operations which would normally go to the unnamed
  *                 register.  When "unnamed" is also included to the
- *                 option, yank operations (but not delete, change or
- *                 put) will additionally copy the text into register
- *                 '*'.
- *                 Only available with the `+X11` feature.
- *                 Availability can be checked with:
+ *                 option, yank operations (but not delete, change or put)
+ *                 will additionally copy the text into register '*'.  If
+ *                 Wayland is being used and the compositor does not
+ *                 support the primary-selection-unstable-v1 protocol,
+ *                 then the regular selection is used in its place.  Only
+ *                 available with the `+X11` or `+wayland_clipboard`
+ *                 feature.  Availability can be checked with:
  *
  *                     if has('unnamedplus')
  *
@@ -1025,21 +1015,25 @@ export const cinwords: BufferLocalOption<string> = new StringOption("cinwords");
  * exclude:**{pattern}**
  *                 Defines a pattern that is matched against the name of
  *                 the terminal 'term'.  If there is a match, no
- *                 connection will be made to the X server.  This is
- *                 useful in this situation:
+ *                 connection will be made to the X server or Wayland
+ *                 compositor.  This is useful in this situation:
  *                 - Running Vim in a console.
- *                 - $DISPLAY is set to start applications on another
- *                   display.
- *                 - You do not want to connect to the X server in the
- *                   console, but do want this in a terminal emulator.
- *                 To never connect to the X server use:
+ *                 - $DISPLAY/$WAYLAND_DISPLAY is set to start
+ *                   applications on another display.
+ *                 - You do not want to connect to the X server/Wayland
+ *                   compositor in the console, but do want this in a
+ *                   terminal emulator.
+ *                 To never connect to the X server/Wayland compositor
+ *                 use:
  *
  *                     exclude:.*
  *
- *                 This has the same effect as using the `-X` argument.
+ *                 This has the same effect as using the `-X` or `-Y`
+ *                 argument.
  *                 Note that when there is no connection to the X server
  *                 the window title won't be restored and the clipboard
- *                 cannot be accessed.
+ *                 cannot be accessed.  This is the same for Wayland,
+ *                 except there is no title restoring.
  *                 The value of 'magic' is ignored, **{pattern}** is
  *                 interpreted as if 'magic' was on.
  *                 The rest of the option value will be used for
@@ -1048,7 +1042,7 @@ export const cinwords: BufferLocalOption<string> = new StringOption("cinwords");
  * (default "autoselect,exclude:cons\|linux"
  *  for X-windows, "" otherwise)
  *
- * *only in GUI versions or when the `+xterm_clipboard` feature is included*
+ * *only in GUI versions or when the `+xterm_clipboard` or `+wayland_clipboard` features are included*
  */
 export const clipboard: GlobalOption<string> = new StringOption("clipboard");
 
@@ -1128,10 +1122,11 @@ export const comments: BufferLocalOption<string> = new StringOption("comments");
 
 /**
  * A template for a comment.  The "%s" in the value is replaced with the
- * comment text.  Currently only used to add markers for folding, see
- * `fold-marker`.  Also used by comment plugins `comment-install`.
+ * comment text, and should be padded with a space when possible.
+ * Currently used to add markers for folding, see `fold-marker`.  Also
+ * commonly used by commenting plugins (e.g. `comment-install`).
  *
- * (default "/*%s* /")
+ * (default "/* %s * /")
  *
  * *not available when compiled without the `+folding` feature*
  */
@@ -1164,6 +1159,25 @@ export const commentstring: BufferLocalOption<string> = new StringOption(
  *         `i_CTRL-X_CTRL-D`
  * ]       tag completion
  * t       same as "]"
+ * F**{func}** call the function **{func}**.  Multiple "F" flags may be specified.
+ *         Refer to `complete-functions` for details on how the function
+ *         is invoked and what it should return.  The value can be the
+ *         name of a function or a `Funcref`.  For `Funcref` values,
+ *         spaces must be escaped with a backslash ('\'), and commas with
+ *         double backslashes ('\\') (see `option-backslash`).
+ *         Unlike other sources, functions can provide completions starting
+ *         from a non-keyword character before the cursor, and their
+ *         start position for replacing text may differ from other sources.
+ *         If the Dict returned by the **{func}** includes {"refresh": "always"},
+ *         the function will be invoked again whenever the leading text
+ *         changes.
+ *         If generating matches is potentially slow, call
+ *         `complete_check()` periodically to keep Vim responsive. This
+ *         is especially important for `ins-autocompletion`.
+ * F       equivalent to using "F**{func}**", where the function is taken from
+ *         the 'completefunc' option.
+ * o       equivalent to using "F**{func}**", where the function is taken from
+ *         the 'omnifunc' option.
  *
  * Unloaded buffers are not loaded, thus their autocmds `:autocmd` are
  * not executed, this may lead to unexpected completions from some files
@@ -1181,6 +1195,13 @@ export const commentstring: BufferLocalOption<string> = new StringOption(
  * As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
  * based expansion (e.g., dictionary `i_CTRL-X_CTRL-K`, included patterns
  * `i_CTRL-X_CTRL-I`, tags `i_CTRL-X_CTRL-]` and normal expansions).
+ *
+ * An optional match limit can be specified for a completion source by
+ * appending a caret ("^") followed by a **{count}** to the source flag.
+ * For example: ".^9,w,u,t^5" limits matches from the current buffer
+ * to 9 and from tags to 5.  Other sources remain unlimited.
+ * Note: The match limit takes effect only during forward completion
+ * (CTRL-N) and is ignored during backward completion (CTRL-P).
  *
  * (default: ".,w,b,u,t,i")
  */
@@ -1205,8 +1226,39 @@ export const completefunc: BufferLocalOption<string> = new StringOption(
 );
 
 /**
+ * global
+ *         A comma-separated list of strings that controls the alignment and
+ *         display order of items in the popup menu during Insert mode
+ *         completion.  The supported values are "abbr", "kind", and "menu".
+ *         These values allow customizing how `complete-items` are shown in the
+ *         popup menu.  Note: must always contain those three values in any
+ *         order.
+ *
+ * (default: "abbr,kind,menu")
+ */
+export const completeitemalign: GlobalOption<string> = new StringOption(
+  "completeitemalign",
+);
+
+/**
  * A comma-separated list of options for Insert mode completion
  * `ins-completion`.  The supported values are:
+ *
+ *    fuzzy    Enable `fuzzy-matching` for completion candidates. This
+ *             allows for more flexible and intuitive matching, where
+ *             characters can be skipped and matches can be found even
+ *             if the exact sequence is not typed.  Note: This option
+ *             does not affect the collection of candidate list, it only
+ *             controls how completion candidates are reduced from the
+ *             list of alternatives.  If you want to use `fuzzy-matching`
+ *             to gather more alternatives for your candidate list,
+ *             see 'completefuzzycollect'.
+ *
+ *    longest  Only insert the longest common text of the matches.  If
+ *             the menu is displayed you can use CTRL-L to add more
+ *             characters.  Whether case is ignored depends on the kind
+ *             of completion.  For buffer text the 'ignorecase' option is
+ *             used.
  *
  *    menu     Use a popup menu to show the possible completions.  The
  *             menu is only shown when there is more than one match and
@@ -1216,20 +1268,28 @@ export const completefunc: BufferLocalOption<string> = new StringOption(
  *             Useful when there is additional information about the
  *             match, e.g., what file it comes from.
  *
- *    longest  Only insert the longest common text of the matches.  If
- *             the menu is displayed you can use CTRL-L to add more
- *             characters.  Whether case is ignored depends on the kind
- *             of completion.  For buffer text the 'ignorecase' option is
- *             used.
+ *    nearest  Matches are listed based on their proximity to the cursor
+ *             position, unlike the default behavior, which only
+ *             considers proximity for matches appearing below the
+ *             cursor.  This applies only to matches from the current
+ *             buffer.  No effect if "fuzzy" is present.
  *
- *    preview  Show extra information about the currently selected
- *             completion in the preview window.  Only works in
- *             combination with "menu" or "menuone".
+ *    noinsert Do not insert any text for a match until the user selects
+ *             a match from the menu.  Only works in combination with
+ *             "menu" or "menuone".  No effect if "longest" is present.
+ *
+ *    noselect Same as "noinsert", except that no menu item is
+ *             pre-selected.  If both "noinsert" and "noselect" are
+ *             present, "noselect" has precedence.
+ *
+ *    nosort   Disable sorting of completion candidates based on fuzzy
+ *             scores when "fuzzy" is enabled.  Candidates will appear
+ *             in their original order.
  *
  *    popup    Show extra information about the currently selected
  *             completion in a popup window.  Only works in combination
  *             with "menu" or "menuone".  Overrides "preview".
- *             See `'completepopup'` for specifying properties.
+ *             See 'completepopup' for specifying properties.
  *             *only works when compiled with the `+textprop` feature*
  *
  *    popuphidden
@@ -1239,17 +1299,25 @@ export const completefunc: BufferLocalOption<string> = new StringOption(
  *             See the example at `complete-popuphidden`.
  *             *only works when compiled with the `+textprop` feature*
  *
- *    noinsert Do not insert any text for a match until the user selects
- *             a match from the menu. Only works in combination with
- *             "menu" or "menuone". No effect if "longest" is present.
+ *    preinsert
+ *             Preinsert the portion of the first candidate word that is
+ *             not part of the current completion leader and using the
+ *             `hl-ComplMatchIns` highlight group.  In order for it to
+ *             work, "fuzzy" must not be set and "menuone" must be set.
  *
- *    noselect Do not select a match in the menu, force the user to
- *             select one from the menu. Only works in combination with
- *             "menu" or "menuone".
+ *    preview  Show extra information about the currently selected
+ *             completion in the preview window.  Only works in
+ *             combination with "menu" or "menuone".
+ *
+ * Only "fuzzy", "popup", "popuphidden" and "preview" have an effect when
+ * 'autocomplete' is enabled.
+ *
+ * This option does not apply to `cmdline-completion`. See 'wildoptions'
+ * for that.
  *
  * (default: "menu,preview")
  */
-export const completeopt: GlobalOption<string> = new StringOption(
+export const completeopt: GlobalOrBufferLocalOption<string> = new StringOption(
   "completeopt",
 );
 
@@ -1344,7 +1412,7 @@ export const confirm: GlobalOption<boolean> = new BooleanOption("confirm");
 /**
  * Copy the structure of the existing lines indent when autoindenting a
  * new line.  Normally the new indent is reconstructed by a series of
- * tabs followed by spaces as required (unless `'expandtab'` is enabled,
+ * tabs followed by spaces as required (unless 'expandtab' is enabled,
  * in which case only spaces are used).  Enabling this option makes the
  * new line copy whatever characters were used for indenting on the
  * existing line.  'expandtab' has no effect on these characters, a Tab
@@ -1497,7 +1565,7 @@ export const copyindent: BufferLocalOption<boolean> = new BooleanOption(
  *
  *         m       When included, a showmatch will always wait half a
  *                 second.  When not included, a showmatch will wait half
- *                 a second or until a character is typed.  `'showmatch'`
+ *                 a second or until a character is typed.  'showmatch'
  *
  *         M       When excluded, "%" matching will take backslashes into
  *                 account.  Thus in "( \( )" and "\( ( \)" the outer
@@ -1587,6 +1655,9 @@ export const copyindent: BufferLocalOption<boolean> = new BooleanOption(
  *         Z       When using "w!" while the 'readonly' option is set,
  *                 don't reset 'readonly'.
  *
+ *         z       Special casing the "cw" and "d" command (see `cw` and
+ *                 `d-special`).
+ *
  *         !       When redoing a filter command, use the last used
  *                 external command, whatever it was.  Otherwise the last
  *                 used -filter- command is used.
@@ -1645,6 +1716,13 @@ export const copyindent: BufferLocalOption<boolean> = new BooleanOption(
  *                 the cursor would skip over it and jump to the
  *                 following occurrence.
  *
+ *         `~`       When included, don't resolve symbolic links when
+ *                 changing directory with `:cd`, `:lcd`, or `:tcd`.
+ *                 This preserves the symbolic link path in buffer names
+ *                 and when displaying the current directory.  When
+ *                 excluded (default), symbolic links are resolved to
+ *                 their target paths.
+ *
  * POSIX flags.  These are not included in the Vi default value, except
  * when $VIM_POSIX was set on startup. `posix`
  *
@@ -1677,8 +1755,9 @@ export const copyindent: BufferLocalOption<boolean> = new BooleanOption(
  *                 variables overrule the terminal size values obtained
  *                 with system specific functions.
  *
- * (Vim default: "aABceFs",
- *  Vi default:  all flags)
+ * (Vim default: "aABceFsz",
+ *  Vi default:  all flags, except `"#{|&/\.~"`
+ *  `$VIM_POSIX`:  all flags)
  */
 export const cpoptions: GlobalOption<string> = new StringOption("cpoptions");
 
@@ -1876,11 +1955,24 @@ export const diffexpr: GlobalOption<string> = new StringOption("diffexpr");
  * Option settings for diff mode.  It can consist of the following items.
  * All are optional.  Items must be separated by a comma.
  *
- *         filler          Show filler lines, to keep the text
- *                         synchronized with a window that has inserted
- *                         lines at the same position.  Mostly useful
- *                         when windows are side-by-side and 'scrollbind'
- *                         is set.
+ *         algorithm:**{text}** Use the specified diff algorithm with the
+ *                         internal diff engine. Currently supported
+ *                         algorithms are:
+ *                         myers      the default algorithm
+ *                         minimal    spend extra time to generate the
+ *                                    smallest possible diff
+ *                         patience   patience diff algorithm
+ *                         histogram  histogram diff algorithm
+ *
+ *         anchor          Anchor specific lines in each buffer to be
+ *                         aligned with each other if 'diffanchors' is
+ *                         set.  See `diff-anchors`.
+ *
+ *         closeoff        When a window is closed where 'diff' is set
+ *                         and there is only one window remaining in the
+ *                         same tab page with 'diff' set, execute
+ *                         `:diffoff` in that window.  This undoes a
+ *                         `:diffsplit` command.
  *
  *         context:**{n}**     Use a context of **{n}** lines between a change
  *                         and a fold that contains unchanged lines.
@@ -1890,6 +1982,23 @@ export const diffexpr: GlobalOption<string> = new StringOption("diffexpr");
  *                         for a deleted line. Set it to a very large
  *                         value (999999) to disable folding completely.
  *                         See `fold-diff`.
+ *
+ *         filler          Show filler lines, to keep the text
+ *                         synchronized with a window that has inserted
+ *                         lines at the same position.  Mostly useful
+ *                         when windows are side-by-side and 'scrollbind'
+ *                         is set.
+ *
+ *         foldcolumn:**{n}**  Set the 'foldcolumn' option to **{n}** when
+ *                         starting diff mode.  Without this 2 is used.
+ *
+ *         followwrap      Follow the 'wrap' option and leave as it is.
+ *
+ *         horizontal      Start diff mode with horizontal splits (unless
+ *                         explicitly specified otherwise).
+ *
+ *         hiddenoff       Do not use diff mode for a buffer when it
+ *                         becomes hidden.
  *
  *         iblank          Ignore changes where lines are all blank.  Adds
  *                         the "-B" flag to the "diff" command if
@@ -1903,6 +2012,35 @@ export const diffexpr: GlobalOption<string> = new StringOption("diffexpr");
  *         icase           Ignore changes in case of text.  "a" and "A"
  *                         are considered the same.  Adds the "-i" flag
  *                         to the "diff" command if 'diffexpr' is empty.
+ *
+ *         indent-heuristic
+ *                         Use the indent heuristic for the internal
+ *                         diff library.
+ *
+ *         inline:**{text}**   Highlight inline differences within a change.
+ *                         See `view-diffs`.  Supported values are:
+ *
+ *                         none    Do not perform inline highlighting.
+ *                         simple  Highlight from first different
+ *                                 character to the last one in each
+ *                                 line.  This is the default if no
+ *                                 `inline:` value is set.
+ *                         char    Use internal diff to perform a
+ *                                 character-wise diff and highlight the
+ *                                 difference.
+ *                         word    Use internal diff to perform a
+ *                                 `word`-wise diff and highlight the
+ *                                 difference.  Non-alphanumeric
+ *                                 multi-byte characters such as emoji
+ *                                 and CJK characters are considered
+ *                                 individual words.
+ *
+ *         internal        Use the internal diff library.  This is
+ *                         ignored when 'diffexpr' is set.
+ *                         When running out of memory when writing a
+ *                         buffer this item will be ignored for diffs
+ *                         involving that buffer.  Set the 'verbose'
+ *                         option to see when this happens.
  *
  *         iwhite          Ignore changes in amount of white space.  Adds
  *                         the "-b" flag to the "diff" command if
@@ -1923,45 +2061,19 @@ export const diffexpr: GlobalOption<string> = new StringOption("diffexpr");
  *                         of the "diff" command for what this does
  *                         exactly.
  *
- *         horizontal      Start diff mode with horizontal splits (unless
- *                         explicitly specified otherwise).
+ *         linematch:**{n}**   Align and mark changes between the most
+ *                         similar lines between the buffers. When the
+ *                         total number of lines in the diff hunk exceeds
+ *                         **{n}**, the lines will not be aligned because for
+ *                         very large diff hunks there will be a
+ *                         noticeable lag. A reasonable setting is
+ *                         "linematch:60", as this will enable alignment
+ *                         for a 2 buffer diff hunk of 30 lines each,
+ *                         or a 3 buffer diff hunk of 20 lines each.
+ *                         Implicitly sets "filler" when this is set.
  *
  *         vertical        Start diff mode with vertical splits (unless
  *                         explicitly specified otherwise).
- *
- *         closeoff        When a window is closed where 'diff' is set
- *                         and there is only one window remaining in the
- *                         same tab page with 'diff' set, execute
- *                         `:diffoff` in that window.  This undoes a
- *                         `:diffsplit` command.
- *
- *         hiddenoff       Do not use diff mode for a buffer when it
- *                         becomes hidden.
- *
- *         foldcolumn:**{n}**  Set the 'foldcolumn' option to **{n}** when
- *                         starting diff mode.  Without this 2 is used.
- *
- *         followwrap      Follow the 'wrap' option and leave as it is.
- *
- *         internal        Use the internal diff library.  This is
- *                         ignored when 'diffexpr' is set.
- *                         When running out of memory when writing a
- *                         buffer this item will be ignored for diffs
- *                         involving that buffer.  Set the 'verbose'
- *                         option to see when this happens.
- *
- *         indent-heuristic
- *                         Use the indent heuristic for the internal
- *                         diff library.
- *
- *         algorithm:**{text}** Use the specified diff algorithm with the
- *                         internal diff engine. Currently supported
- *                         algorithms are:
- *                         myers      the default algorithm
- *                         minimal    spend extra time to generate the
- *                                    smallest possible diff
- *                         patience   patience diff algorithm
- *                         histogram  histogram diff algorithm
  *
  * Examples:
  *
@@ -1970,7 +2082,8 @@ export const diffexpr: GlobalOption<string> = new StringOption("diffexpr");
  *     :set diffopt=internal,filler,foldcolumn:3
  *     :set diffopt-=internal  " do NOT use the internal diff parser
  *
- * (default "internal,filler,closeoff")
+ * (default
+ *  "internal,filler,closeoff,inline:simple")
  *
  * *not available when compiled without the `+diff` feature*
  */
@@ -2282,10 +2395,93 @@ export const errorformat: GlobalOrBufferLocalOption<string> = new StringOption(
  *
  *     :set ei=WinEnter,WinLeave
  *
+ * To ignore all but some events, a "-" prefix can be used:
+ *
+ *     :set ei=all,-WinLeave
+ *
  * (default "")
  */
 export const eventignore: GlobalOption<string> = new StringOption(
   "eventignore",
+);
+
+/**
+ * window-local
+ *         Similar to 'eventignore' but applies to a particular window and its
+ *         buffers, for which window and buffer related autocommands can be
+ *         ignored indefinitely without affecting the global 'eventignore'.
+ *
+ *         Note: The following events are considered to happen outside of a
+ *         window context and thus cannot be ignored by 'eventignorewin':
+ *
+ *                 `CmdlineChanged`,
+ *                 `CmdlineEnter`,
+ *                 `CmdlineLeave`,
+ *                 `CmdlineLeavePre`,
+ *                 `CmdUndefined`,
+ *                 `CmdwinEnter`,
+ *                 `CmdwinLeave`,
+ *                 `ColorScheme`,
+ *                 `ColorSchemePre`,
+ *                 `CompleteChanged`,
+ *                 `CompleteDone`,
+ *                 `CompleteDonePre`,
+ *                 `DiffUpdated`,
+ *                 `DirChanged`,
+ *                 `DirChangedPre`,
+ *                 `EncodingChanged`,
+ *                 `ExitPre`,
+ *                 `FocusGained`,
+ *                 `FocusLost`,
+ *                 `FuncUndefined`,
+ *                 `GUIEnter`,
+ *                 `GUIFailed`,
+ *                 `KeyInputPre`,
+ *                 `MenuPopup`,
+ *                 `ModeChanged`,
+ *                 `OptionSet`,
+ *                 `QuickFixCmdPost`,
+ *                 `QuickFixCmdPre`,
+ *                 `QuitPre`,
+ *                 `RemoteReply`,
+ *                 `SafeState`,
+ *                 `SafeStateAgain`,
+ *                 `SessionLoadPost`,
+ *                 `SessionWritePost`,
+ *                 `ShellCmdPost`,
+ *                 `SigUSR1`,
+ *                 `SourceCmd`,
+ *                 `SourcePost`,
+ *                 `SourcePre`,
+ *                 `SpellFileMissing`,
+ *                 `StdinReadPost`,
+ *                 `StdinReadPre`,
+ *                 `SwapExists`,
+ *                 `Syntax`,
+ *                 `TabClosed`,
+ *                 `TabClosedPre`,
+ *                 `TabEnter`,
+ *                 `TabLeave`,
+ *                 `TabNew`,
+ *                 `TermChanged`,
+ *                 `TerminalOpen`,
+ *                 `TerminalWinOpen`,
+ *                 `TermResponse`,
+ *                 `TermResponseAll`,
+ *                 `User`,
+ *                 `VimEnter`,
+ *                 `VimLeave`,
+ *                 `VimLeavePre`,
+ *                 `VimResized`,
+ *                 `VimResume`,
+ *                 `VimSuspend`,
+ *                 `WinNew`,
+ *                 `WinNewPre`
+ *
+ * (default "")
+ */
+export const eventignorewin: GlobalOption<string> = new StringOption(
+  "eventignorewin",
 );
 
 /**
@@ -2464,7 +2660,7 @@ export const fileencodings: GlobalOption<string> = new StringOption(
  * 'textmode' is set, otherwise 'textmode' is reset.
  *
  * (MS-Windows default: "dos",
- *  Unix, macOS default: "unix")
+ *  Unix default: "unix")
  */
 export const fileformat: BufferLocalOption<string> = new StringOption(
   "fileformat",
@@ -2524,7 +2720,7 @@ export const fileformat: BufferLocalOption<string> = new StringOption(
  *
  * (default:
  *  Vim+Vi MS-Windows: "dos,unix",
- *  Vim    Unix, macOS: "unix,dos",
+ *  Vim    Unix: "unix,dos",
  *  Vi     Cygwin: "unix,dos",
  *  Vi     others: "")
  */
@@ -2557,22 +2753,23 @@ export const fileignorecase: GlobalOption<boolean> = new BooleanOption(
  *         /* vim: set filetype=idl : * /
  * `FileType` `filetypes`
  * When a dot appears in the value then this separates two filetype
- * names.  Example:
+ * names, it should therefore not be used for a filetype.  Example:
  *         /* vim: set filetype=c.doxygen : * /
  * This will use the "c" filetype first, then the "doxygen" filetype.
  * This works both for filetype plugins and for syntax files.  More than
  * one dot may appear.
  * This option is not copied to another buffer, independent of the 's' or
  * 'S' flag in 'cpoptions'.
- * Only normal file name characters can be used, `"/\*?[|<>"` are illegal.
+ * Only alphanumeric characters, '-' and '_' can be used (and a '.' is
+ * allowed as delimiter when combining different filetypes).
  *
  * (default: "")
  */
 export const filetype: BufferLocalOption<string> = new StringOption("filetype");
 
 /**
- * Characters to fill the statuslines, vertical separators and special
- * lines in the window.
+ * Characters to fill the statuslines, vertical separators, special
+ * lines in the window and truncated text in the `ins-completion-menu`.
  * It is a comma-separated list of items.  Each item has a name, a colon
  * and the value of that item: `E1511`
  *
@@ -2587,16 +2784,19 @@ export const filetype: BufferLocalOption<string> = new StringOption("filetype");
  *   diff          '-'             deleted lines of the 'diff' option
  *   eob           `'~'`             empty lines below the end of a buffer
  *   lastline      '@'             'display' contains lastline/truncate
+ *   trunc         '>'             truncated text in the
+ *                                 `ins-completion-menu`.
+ *   truncrl       `'<'`             same as "trunc" in 'rightleft' mode
+ *   tpl_vert      '|'             vertical separators of 'tabpanel'
  *
  * Any one that is omitted will fall back to the default.
  *
  * Example:
  *
- *     :set fillchars=stl:\ ,stlnc:\ ,vert:\|,fold:-,diff:-
+ *     :set fillchars=stl:\ ,stlnc:\ ,vert:\|,fold:-,diff:-,tpl_vert:\|
  *
- * For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
- * single-byte and multibyte characters are supported.  But double-width
- * characters are not supported. `E1512`
+ * All items support single-byte and multibyte characters.  But
+ * double-width characters are not supported. `E1512`
  *
  * The highlighting used for these items:
  *   item name     highlight group
@@ -2604,14 +2804,74 @@ export const filetype: BufferLocalOption<string> = new StringOption("filetype");
  *   stlnc         StatusLineNC            `hl-StatusLineNC`
  *   vert          VertSplit               `hl-VertSplit`
  *   fold          Folded                  `hl-Folded`
+ *   foldopen      FoldColumn              `hl-FoldColumn`
+ *   foldclose     FoldColumn              `hl-FoldColumn`
+ *   foldsep       FoldColumn              `hl-FoldColumn`
  *   diff          DiffDelete              `hl-DiffDelete`
  *   eob           EndOfBuffer             `hl-EndOfBuffer`
  *   lastline      NonText                 `hl-NonText`
+ *   trunc         one of the many Popup menu highlighting groups like
+ *                 `hl-PmenuSel`
+ *   truncrl       same as "trunc"
  *
- * (default `"vert:|,fold:-,eob:~"`)
+ * (default `"vert:|,fold:-,eob:~,lastline:@"`)
  */
 export const fillchars: GlobalOrWindowLocalOption<string> = new StringOption(
   "fillchars",
+);
+
+/**
+ * Function that is called to obtain the filename(s) for the `:find`
+ * command.  When this option is empty, the internal `file-searching`
+ * mechanism is used.
+ *
+ * The value can be the name of a function, a `lambda` or a `Funcref`.
+ * See `option-value-function` for more information.
+ *
+ * The function is called with two arguments.  The first argument is a
+ * `String` and is the `:find` command argument.  The second argument is
+ * a `Boolean` and is set to `v:true` when the function is called to get
+ * a List of command-line completion matches for the `:find` command.
+ * The function should return a List of strings.
+ *
+ * The function is called only once per `:find` command invocation.
+ * The function can process all the directories specified in 'path'.
+ *
+ * If a match is found, the function should return a `List` containing
+ * one or more file names.  If a match is not found, the function
+ * should return an empty List.
+ *
+ * If any errors are encountered during the function invocation, an
+ * empty List is used as the return value.
+ *
+ * It is not allowed to change text or jump to another window while
+ * executing the 'findfunc' `textlock`.
+ *
+ * This option cannot be set from a `modeline` or in the `sandbox`, for
+ * security reasons.
+ *
+ * Examples:
+ *
+ *     " Use glob()
+ *     func FindFuncGlob(cmdarg, cmdcomplete)
+ *         let pat = a:cmdcomplete ? $'{a:cmdarg}*' : a:cmdarg
+ *         return glob(pat, v:false, v:true)
+ *     endfunc
+ *     set findfunc=FindFuncGlob
+ *
+ *     " Use the 'git ls-files' output
+ *     func FindGitFiles(cmdarg, cmdcomplete)
+ *         let fnames = systemlist('git ls-files')
+ *         return fnames->filter('v:val =~? a:cmdarg')
+ *     endfunc
+ *     set findfunc=FindGitFiles
+ *
+ * (default empty)
+ *
+ * *not available when compiled without the `+eval` feature*
+ */
+export const findfunc: GlobalOrBufferLocalOption<string> = new StringOption(
+  "findfunc",
 );
 
 /**
@@ -3012,7 +3272,9 @@ export const gdefault: GlobalOption<boolean> = new BooleanOption("gdefault");
  *
  * (default "%f:%l:%m,%f:%l%m,%f  %l%m")
  */
-export const grepformat: GlobalOption<string> = new StringOption("grepformat");
+export const grepformat: GlobalOrBufferLocalOption<string> = new StringOption(
+  "grepformat",
+);
 
 /**
  * Program to use for the `:grep` command.  This option may contain '%'
@@ -3157,179 +3419,6 @@ export const guifontwide: GlobalOption<string> = new StringOption(
 );
 
 /**
- * This option only has an effect in the GUI version of Vim.  It is a
- * sequence of letters which describes what components and options of the
- * GUI should be used.
- * To avoid problems with flags that are added in the future, use the
- * "+=" and "-=" feature of ":set" `add-option-flags`.
- *
- * Valid characters are as follows:
- *
- *   '!'   External commands are executed in a terminal window.  Without
- *         this flag the MS-Windows GUI will open a console window to
- *         execute the command.  The Unix GUI will simulate a dumb
- *         terminal to list the command output.
- *         The terminal window will be positioned at the bottom, and grow
- *         upwards as needed.
- *
- *   'a'   Autoselect:  If present, then whenever VISUAL mode is started,
- *         or the Visual area extended, Vim tries to become the owner of
- *         the windowing system's global selection.  This means that the
- *         Visually highlighted text is available for pasting into other
- *         applications as well as into Vim itself.  When the Visual mode
- *         ends, possibly due to an operation on the text, or when an
- *         application wants to paste the selection, the highlighted text
- *         is automatically yanked into the "* selection register.
- *         Thus the selection is still available for pasting into other
- *         applications after the VISUAL mode has ended.
- *             If not present, then Vim won't become the owner of the
- *         windowing system's global selection unless explicitly told to
- *         by a yank or delete operation for the "* register.
- *         The same applies to the modeless selection.
- *
- *   'P'   Like autoselect but using the "+ register instead of the "*
- *         register.
- *
- *   'A'   Autoselect for the modeless selection.  Like 'a', but only
- *         applies to the modeless selection.
- *
- *             'guioptions'   autoselect Visual  autoselect modeless
- *                  ""              -                       -
- *                  "a"            yes                     yes
- *                  "A"             -                      yes
- *                  "aA"           yes                     yes
- *
- *         When using a terminal see the 'clipboard' option.
- *
- *   'c'   Use console dialogs instead of popup dialogs for simple
- *         choices.
- *
- *   'd'   Use dark theme variant if available. Currently only works for
- *         GTK+ GUI.
- *
- *   'e'   Add tab pages when indicated with 'showtabline'.
- *         'guitablabel' can be used to change the text in the labels.
- *         When 'e' is missing a non-GUI tab pages line may be used.
- *         The GUI tabs are only supported on some systems, currently
- *         GTK, Motif, Mac OS/X, Haiku, and MS-Windows.
- *
- *   'f'   Foreground: Don't use fork() to detach the GUI from the shell
- *         where it was started.  Use this for programs that wait for the
- *         editor to finish (e.g., an e-mail program).  Alternatively you
- *         can use "gvim -f" or ":gui -f" to start the GUI in the
- *         foreground.  `gui-fork`
- *         Note: Set this option in the vimrc file.  The forking may have
- *         happened already when the `gvimrc` file is read.
- *
- *   'i'   Use a Vim icon.  For GTK with KDE it is used in the left-upper
- *         corner of the window.  It's black&white on non-GTK, because of
- *         limitations of X11.  For a color icon, see `X11-icon`.
- *
- *   'm'   Menu bar is present.
- *
- *   'M'   The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
- *         that this flag must be added in the .vimrc file, before
- *         switching on syntax or filetype recognition (when the `gvimrc`
- *         file is sourced the system menu has already been loaded; the
- *         `:syntax on` and `:filetype on` commands load the menu too).
- *
- *   'g'   Grey menu items: Make menu items that are not active grey.  If
- *         'g' is not included inactive menu items are not shown at all.
- *
- *   't'   Include tearoff menu items.  Currently only works for Win32,
- *         GTK+, and Motif 1.2 GUI.
- *
- *   'T'   Include Toolbar.  Currently only in Win32, GTK+, Motif and
- *         Photon GUIs.
- *
- *   'r'   Right-hand scrollbar is always present.
- *
- *   'R'   Right-hand scrollbar is present when there is a vertically
- *         split window.
- *
- *   'l'   Left-hand scrollbar is always present.
- *
- *   'L'   Left-hand scrollbar is present when there is a vertically
- *         split window.
- *
- *   'b'   Bottom (horizontal) scrollbar is present.  Its size depends on
- *         the longest visible line, or on the cursor line if the 'h'
- *         flag is included. `gui-horiz-scroll`
- *
- *   'h'   Limit horizontal scrollbar size to the length of the cursor
- *         line.  Reduces computations. `gui-horiz-scroll`
- *
- * And yes, you may even have scrollbars on the left AND the right if
- * you really want to :-).  See `gui-scrollbars` for more information.
- *
- *   'v'   Use a vertical button layout for dialogs.  When not included,
- *         a horizontal layout is preferred, but when it doesn't fit a
- *         vertical layout is used anyway.  Not supported in GTK 3.
- *
- *   'p'   Use Pointer callbacks for X11 GUI.  This is required for some
- *         window managers.  If the cursor is not blinking or hollow at
- *         the right moment, try adding this flag.  This must be done
- *         before starting the GUI.  Set it in your `gvimrc`.  Adding or
- *         removing it after the GUI has started has no effect.
- *
- *   'F'   Add a footer.  Only for Motif.  See `gui-footer`.
- *
- *   'k'   Keep the GUI window size when adding/removing a scrollbar, or
- *         toolbar, tabline, etc.  Instead, the behavior is similar to
- *         when the window is maximized and will adjust 'lines' and
- *         'columns' to fit to the window.  Without the 'k' flag Vim will
- *         try to keep 'lines' and 'columns' the same when adding and
- *         removing GUI components.
- *
- * (default "egmrLtT"   (MS-Windows,
- *  "t" is removed in `defaults.vim`),
- *  "aegimrLtT" (GTK and Motif),
- *  )
- *
- * *only available when compiled with GUI enabled*
- */
-export const guioptions: GlobalOption<string> = new StringOption("guioptions");
-
-/**
- * When non-empty describes the text to use in a label of the GUI tab
- * pages line.  When empty and when the result is empty Vim will use a
- * default label.  See `setting-guitablabel` for more info.
- *
- * The format of this option is like that of 'statusline'.
- * 'guitabtooltip' is used for the tooltip, see below.
- * The expression will be evaluated in the `sandbox` when set from a
- * modeline, see `sandbox-option`.
- * This option cannot be set in a modeline when 'modelineexpr' is off.
- *
- * Only used when the GUI tab pages line is displayed.  'e' must be
- * present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
- * used.
- *
- * (default empty)
- *
- * *only available when compiled with GUI enabled*
- */
-export const guitablabel: GlobalOption<string> = new StringOption(
-  "guitablabel",
-);
-
-/**
- * When non-empty describes the text to use in a tooltip for the GUI tab
- * pages line.  When empty Vim will use a default tooltip.
- * This option is otherwise just like 'guitablabel' above.
- * You can include a line break.  Simplest method is to use `:let`:
- *
- *     :let &guitabtooltip = "line one\nline two"
- *
- * (default empty)
- *
- * *only available when compiled with GUI enabled*
- */
-export const guitabtooltip: GlobalOption<string> = new StringOption(
-  "guitabtooltip",
-);
-
-/**
  * Name of the main help file.  All distributed help files should be
  * placed together in one directory.  Additionally, all "doc" directories
  * in 'runtimepath' will be used.
@@ -3402,13 +3491,13 @@ export const hidden: GlobalOption<boolean> = new BooleanOption("hidden");
 /**
  * A history of ":" commands, and a history of previous search patterns
  * is remembered.  This option decides how many entries may be stored in
- * each of these histories (see `cmdline-editing`).
+ * each of these histories (see `cmdline-editing` and 'messagesopt' for
+ * the number of messages to remember).
  * The maximum value is 10000.
  * NOTE: This option is set to the Vi default value when 'compatible' is
  * set and to the Vim default value when 'compatible' is reset.
  *
- * (Vim default: 50, Vi default: 0,
- *  set to 200 in `defaults.vim`)
+ * (Vim default: 200, Vi default: 0)
  */
 export const history: GlobalOption<number> = new NumberOption("history");
 
@@ -3477,7 +3566,8 @@ export const iconstring: GlobalOption<string> = new StringOption("iconstring");
 
 /**
  * Ignore case in search patterns, `cmdline-completion`, when
- * searching in the tags file, and non-|Vim9| `expr-==`.
+ * searching in the tags file, non-|Vim9| `expr-==` and for Insert-mode
+ * completion `ins-completion`.
  * Also see 'smartcase' and 'tagcase'.
  * Can be overruled by using "\c" or "\C" in the pattern, see
  * `/ignorecase`.
@@ -3487,27 +3577,6 @@ export const iconstring: GlobalOption<string> = new StringOption("iconstring");
 export const ignorecase: GlobalOption<boolean> = new BooleanOption(
   "ignorecase",
 );
-
-/**
- * When set the Input Method is always on when starting to edit a command
- * line, unless entering a search pattern (see 'imsearch' for that).
- * Setting this option is useful when your input method allows entering
- * English characters directly, e.g., when it's used to type accented
- * characters with dead keys.
- *
- * (default off)
- */
-export const imcmdline: GlobalOption<boolean> = new BooleanOption("imcmdline");
-
-/**
- * When set the Input Method is never used.  This is useful to disable
- * the IM when it doesn't work properly.
- * Currently this option is on by default for SGI/IRIX machines.  This
- * may change in later releases.
- *
- * (default off, on for some systems (SGI))
- */
-export const imdisable: GlobalOption<boolean> = new BooleanOption("imdisable");
 
 /**
  * Specifies whether :lmap or an Input Method (IM) is to be used in
@@ -3592,7 +3661,7 @@ export const include: GlobalOrBufferLocalOption<string> = new StringOption(
  *
  * Also used for the `gf` command if an unmodified file name can't be
  * found.  Allows doing "gf" on the name after an 'include' statement.
- * Also used for `<cfile>`.
+ * Note: Not used for `<cfile>`.
  *
  * If the expression starts with s: or `<SID>`, then it is replaced with
  * the script ID (`local-function`). Example:
@@ -3683,7 +3752,7 @@ export const incsearch: GlobalOption<boolean> = new BooleanOption("incsearch");
  * in Insert mode as specified with the 'indentkeys' option.
  * When this option is not empty, it overrules the 'cindent' and
  * 'smartindent' indenting.  When 'lisp' is set, this option is
- * is only used when 'lispoptions' contains "expr:1".
+ * only used when 'lispoptions' contains "expr:1".
  * When 'paste' is set this option is not used for indenting.
  * The expression is evaluated with `v:lnum` set to the line number for
  * which the indent is to be computed.  The cursor is also in this line
@@ -3886,7 +3955,7 @@ export const iskeyword: BufferLocalOption<string> = new StringOption(
  * Unprintable and zero-width Unicode characters are displayed as `<xxxx>`.
  * There is no option to specify these characters.
  *
- * (default for Win32 and macOS:
+ * (default for Win32 and VMS:
  *  `"@,~-255"`; otherwise: "@,161-255")
  */
 export const isprint: GlobalOption<string> = new StringOption("isprint");
@@ -3922,7 +3991,7 @@ export const jumpoptions: GlobalOption<string> = new StringOption(
  * Setting this option to a valid keymap name has the side effect of
  * setting 'iminsert' to one, so that the keymap becomes effective.
  * 'imsearch' is also set to one, unless it was -1
- * Only normal file name characters can be used, `"/\*?[|<>"` are illegal.
+ * Only alphanumeric characters, '.', '-' and '_' can be used.
  *
  * (default "")
  *
@@ -3996,7 +4065,7 @@ export const keywordprg: GlobalOrBufferLocalOption<string> = new StringOption(
  * part can be in one of two forms:
  * 1.  A list of pairs.  Each pair is a "from" character immediately
  *     followed by the "to" character.  Examples: "aA", "aAbBcC".
- * 2.  A list of "from" characters, a semi-colon and a list of "to"
+ * 2.  A list of "from" characters, a semicolon and a list of "to"
  *     characters.  Example: "abc;ABC"
  * Example: "aA,fgh;FGH,cCdDeE"
  * Special characters need to be preceded with a backslash.  These are
@@ -4087,7 +4156,7 @@ export const laststatus: GlobalOption<number> = new NumberOption("laststatus");
  * update use `:redraw`.
  * This may occasionally cause display errors.  It is only meant to be set
  * temporarily when performing an operation where redrawing may cause
- * flickering or cause a slow down.
+ * flickering or cause a slowdown.
  *
  * (default off)
  */
@@ -4167,8 +4236,7 @@ export const lisp: BufferLocalOption<boolean> = new BooleanOption("lisp");
 
 /**
  * Comma-separated list of items that influence the Lisp indenting when
- * enabled with the `'lisp'` option.  Currently only one item is
- * supported:
+ * enabled with the 'lisp' option.  Currently only one item is supported:
  *         expr:1  use 'indentexpr' for Lisp indenting when it is set
  *         expr:0  do not use 'indentexpr' for Lisp indenting (default)
  * Note that when using 'indentexpr' the `=` operator indents all the
@@ -4182,7 +4250,7 @@ export const lispoptions: BufferLocalOption<string> = new StringOption(
 
 /**
  * Comma-separated list of words that influence the Lisp indenting when
- * enabled with the `'lisp'` option.
+ * enabled with the 'lisp' option.
  *
  * (default is very long)
  */
@@ -4508,6 +4576,32 @@ export const maxmempattern: GlobalOption<number> = new NumberOption(
 export const menuitems: GlobalOption<number> = new NumberOption("menuitems");
 
 /**
+ * Option settings for outputting messages.  It can consist of the
+ * following items.  Items must be separated by a comma.
+ *
+ * hit-enter       Use a `hit-enter` prompt when the message is longer than
+ *                 'cmdheight' size.
+ *
+ * wait:**{n}**        Instead of using a `hit-enter` prompt, simply wait for
+ *                 **{n}** milliseconds so that the user has a chance to read
+ *                 the message.  The maximum value of **{n}** is 10000.  Use
+ *                 0 to disable the wait (but then the user may miss an
+ *                 important message).
+ *                 This item is ignored when "hit-enter" is present, but
+ *                 required when "hit-enter" is not present.
+ *
+ * history:**{n}**     Determines how many entries are remembered in the
+ *                 `:messages` history.  The maximum value is 10000.
+ *                 Setting it to zero clears the message history.
+ *                 This item must always be present.
+ *
+ * (default "hit-enter,history:500")
+ */
+export const messagesopt: GlobalOption<string> = new StringOption(
+  "messagesopt",
+);
+
+/**
  * Parameters for `:mkspell`.  This tunes when to start compressing the
  * word tree.  Compression can be slow when there are many words, but
  * it's needed to avoid running out of memory.  The amount of memory used
@@ -4668,7 +4762,7 @@ export const more: GlobalOption<boolean> = new BooleanOption("more");
  * When the mouse is not enabled, the GUI will still use the mouse for
  * modeless selection.  This doesn't move the text cursor.
  *
- * See `mouse-using`.  Also see `'clipboard'`.
+ * See `mouse-using`.  Also see 'clipboard'.
  *
  * Note: When enabling the mouse in a terminal, copy/paste will use the
  * "* register if there is access to an X-server.  The xterm handling of
@@ -4745,93 +4839,6 @@ export const mousehide: GlobalOption<boolean> = new BooleanOption("mousehide");
 export const mousemodel: GlobalOption<string> = new StringOption("mousemodel");
 
 /**
- * When on, mouse move events are delivered to the input queue and are
- * available for mapping. The default, off, avoids the mouse movement
- * overhead except when needed. See `gui-mouse-mapping`.
- * Warning: Setting this option can make pending mappings to be aborted
- * when the mouse is moved.
- * Currently only works in the GUI, may be made to work in a terminal
- * later.
- *
- * (default off)
- *
- * *only works in the GUI*
- */
-export const mousemoveevent: GlobalOption<boolean> = new BooleanOption(
-  "mousemoveevent",
-);
-
-/**
- * This option tells Vim what the mouse pointer should look like in
- * different modes.  The option is a comma-separated list of parts, much
- * like used for 'guicursor'.  Each part consist of a mode/location-list
- * and an argument-list:
- *         mode-list:shape,mode-list:shape,..
- * The mode-list is a dash separated list of these modes/locations:
- *                 In a normal window:
- *         n       Normal mode
- *         v       Visual mode
- *         ve      Visual mode with 'selection' "exclusive" (same as 'v',
- *                 if not specified)
- *         o       Operator-pending mode
- *         i       Insert mode
- *         r       Replace mode
- *
- *                 Others:
- *         c       appending to the command-line
- *         ci      inserting in the command-line
- *         cr      replacing in the command-line
- *         m       at the 'Hit ENTER' or 'More' prompts
- *         ml      idem, but cursor in the last line
- *         e       any mode, pointer below last window
- *         s       any mode, pointer on a status line
- *         sd      any mode, while dragging a status line
- *         vs      any mode, pointer on a vertical separator line
- *         vd      any mode, while dragging a vertical separator line
- *         a       everywhere
- *
- * The shape is one of the following:
- * avail   name            looks like
- * w x     arrow           Normal mouse pointer
- * w x     blank           no pointer at all (use with care!)
- * w x     beam            I-beam
- * w x     updown          up-down sizing arrows
- * w x     leftright       left-right sizing arrows
- * w x     busy            The system's usual busy pointer
- * w x     no              The system's usual 'no input' pointer
- *   x     udsizing        indicates up-down resizing
- *   x     lrsizing        indicates left-right resizing
- *   x     crosshair       like a big thin +
- *   x     hand1           black hand
- *   x     hand2           white hand
- *   x     pencil          what you write with
- *   x     question        big ?
- *   x     rightup-arrow   arrow pointing right-up
- * w x     up-arrow        arrow pointing up
- *   x     `<number>`        any X11 pointer number (see X11/cursorfont.h)
- *
- * The "avail" column contains a 'w' if the shape is available for Win32,
- * x for X11.
- * Any modes not specified or shapes not available use the normal mouse
- * pointer.
- *
- * Example:
- *
- *     :set mouseshape=s:udsizing,m:no
- *
- * will make the mouse turn to a sizing arrow over the status lines and
- * indicate no input when the hit-enter prompt is displayed (since
- * clicking the mouse has no effect in this state.)
- *
- * (default "i-r:beam,s:updown,sd:udsizing,
- *  vs:leftright,vd:lrsizing,m:no,
- *  ml:up-arrow,v:rightup-arrow")
- *
- * *only available when compiled with the `+mouseshape` feature*
- */
-export const mouseshape: GlobalOption<string> = new StringOption("mouseshape");
-
-/**
  * Only for GUI, Win32 and Unix with xterm.  Defines the maximum
  * time in msec between two mouse clicks for the second click to be
  * recognized as a multi click.
@@ -4864,6 +4871,20 @@ export const mousetime: GlobalOption<number> = new NumberOption("mousetime");
  *             (without "unsigned" it would become "9-2019").
  *             Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
  *             (2^64 - 1) has no effect, overflow is prevented.
+ * blank   If included, treat numbers as signed or unsigned based on
+ *         preceding whitespace.  If a number with a leading dash has its
+ *         dash immediately preceded by a non-whitespace character (i.e.,
+ *         not a tab or a " "), the negative sign won't be considered as
+ *         part of the number.  For example:
+ *             Using CTRL-A on "14" in "Carbon-14" results in "Carbon-15"
+ *             (without "blank" it would become "Carbon-13").
+ *             Using CTRL-X on "8" in "Carbon -8" results in "Carbon -9"
+ *             (because -8 is preceded by whitespace.  If "unsigned" was
+ *             set, it would result in "Carbon -7").
+ *         If this format is included, overflow is prevented as if
+ *         "unsigned" were set.  If both this format and "unsigned" are
+ *         included, "unsigned" will take precedence.
+ *
  * Numbers which simply begin with a digit in the range 1-9 are always
  * considered decimal.  This also happens for numbers that are not
  * recognized as octal or hex.
@@ -4941,20 +4962,6 @@ export const numberwidth: WindowLocalOption<number> = new NumberOption(
  * *not available when compiled without the `+eval` feature*
  */
 export const omnifunc: BufferLocalOption<string> = new StringOption("omnifunc");
-
-/**
- * *only for MS-Windows*
- *         Enable reading and writing from devices.  This may get Vim stuck on a
- *         device that can be opened but doesn't actually do the I/O.  Therefore
- *         it is off by default.
- *         Note that on MS-Windows editing "aux.h", "lpt1.txt" and the like also
- *         result in editing a device.
- *
- * (default off)
- */
-export const opendevice: GlobalOption<boolean> = new BooleanOption(
-  "opendevice",
-);
 
 /**
  * This option specifies a function to be called by the `g@` operator.
@@ -5084,7 +5091,7 @@ export const patchmode: GlobalOption<string> = new StringOption("patchmode");
  *
  * To use an environment variable, you probably need to replace the
  * separator.  Here is an example to append $INCL, in which directory
- * names are separated with a semi-colon:
+ * names are separated with a semicolon:
  *
  *     :let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
  *
@@ -5099,7 +5106,7 @@ export const path: GlobalOrBufferLocalOption<string> = new StringOption("path");
 /**
  * When changing the indent of the current line, preserve as much of the
  * indent structure as possible.  Normally the indent is replaced by a
- * series of tabs followed by spaces as required (unless `'expandtab'` is
+ * series of tabs followed by spaces as required (unless 'expandtab' is
  * enabled, in which case only spaces are used).  Enabling this option
  * means the indent will preserve as many existing characters as possible
  * for indenting, and only add additional tabs or spaces as required.
@@ -5425,7 +5432,7 @@ export const rulerformat: GlobalOption<string> = new StringOption(
  *   import/       files that are found by `:import`
  *   indent/       indent scripts `indent-expression`
  *   keymap/       key mapping files `mbyte-keymap`
- *   lang/         menu translations `:menutrans`
+ *   lang/         message translations `:menutrans` and `multi-lang`
  *   menu.vim      GUI menus `menu.vim`
  *   pack/         packages `:packadd`
  *   plugin/       plugin scripts `write-plugin`
@@ -5495,9 +5502,6 @@ export const rulerformat: GlobalOption<string> = new StringOption(
  *  $VIMRUNTIME,
  *  $VIM/vimfiles/after,
  *  $HOME/vimfiles/after"
- *  macOS: "$VIM:vimfiles,
- *  $VIMRUNTIME,
- *  $VIM:vimfiles:after"
  *  Haiku: "$BE_USER_SETTINGS/vim,
  *  $VIM/vimfiles,
  *  $VIMRUNTIME,
@@ -5531,7 +5535,7 @@ export const scroll: WindowLocalOption<number> = new NumberOption("scroll");
  * current window also scrolls other scrollbind windows (windows that
  * also have this option set).  This option is useful for viewing the
  * differences between two versions of a file, see 'diff'.
- * See `'scrollopt'` for options that determine how this option should be
+ * See 'scrollopt' for options that determine how this option should be
  * interpreted.
  * This option is mostly reset when splitting a window to edit another
  * file.  This means that ":split | edit file" results in two windows
@@ -5634,9 +5638,16 @@ export const sections: GlobalOption<string> = new StringOption("sections");
  * selection.
  * When "old" is used and 'virtualedit' allows the cursor to move past
  * the end of line the line break still isn't included.
- * Note that when "exclusive" is used and selecting from the end
- * backwards, you cannot include the last character of a line, when
- * starting in Normal mode and 'virtualedit' empty.
+ * When "exclusive" is used, cursor position in visual mode will be
+ * adjusted for inclusive motions `inclusive-motion-selection-exclusive`.
+ *
+ * Note:
+ * - When "exclusive" is used and selecting from the end backwards, you
+ *   cannot include the last character of a line, when starting in Normal
+ *   mode and 'virtualedit' empty.
+ * - when "exclusive" is used with a single character visual selection,
+ *   Vim will behave as if the 'selection' is inclusive (in other words,
+ *   you cannot visually select an empty region).
  *
  * The 'selection' option is set by the `:behave` command.
  *
@@ -5809,6 +5820,9 @@ export const shellcmdflag: GlobalOption<string> = new StringOption(
  * Don't forget to precede the space with a backslash: ":set sp=\ ".
  * In the future pipes may be used for filtering and this option will
  * become obsolete (at least for Unix).
+ * Note: When using a pipe like "| tee", you'll lose the exit code of the
+ * shell command.  This might be configurable by your shell, look for
+ * the pipefail option (for bash and zsh, use ":set -o pipefail").
  * This option cannot be set from a `modeline` or in the `sandbox`, for
  * security reasons.
  *
@@ -5969,10 +5983,10 @@ export const shiftround: GlobalOption<boolean> = new BooleanOption(
 );
 
 /**
- * Number of spaces to use for each step of (auto)indent.  Used for
- * `'cindent'`, `>>`, `<<`, etc.
- * When zero the 'tabstop' value will be used.  Use the `shiftwidth()`
- * function to get the effective shiftwidth value.
+ * Number of columns that make up one level of (auto)indentation.  Used
+ * by 'cindent', `<<`, `>>`, etc.
+ * If set to 0, Vim uses the current 'tabstop' value.  Use `shiftwidth()`
+ * to obtain the effective value in scripts.
  *
  * (default 8)
  */
@@ -5982,7 +5996,7 @@ export const shiftwidth: BufferLocalOption<number> = new NumberOption(
 
 /**
  * This option helps to avoid all the `hit-enter` prompts caused by file
- * messages, for example  with CTRL-G, and to avoid some other messages.
+ * messages, for example with CTRL-G, and to avoid some other messages.
  * It is a list of flags:
  *  flag   meaning when present
  *   f     use "(3 of 5)" instead of "(file 3 of 5)"
@@ -6005,8 +6019,8 @@ export const shiftwidth: BufferLocalOption<number> = new NumberOption(
  *         message;  also for quickfix message (e.g., ":cn")
  *   s     don't give "search hit BOTTOM, continuing at TOP" or
  *         "search hit TOP, continuing at BOTTOM" messages; when using
- *         the search count do not show "W" after the count message (see
- *         S below)
+ *         the search count do not show "W" before the count message
+ *         (see `shm-S` below)
  *   t     truncate file message at the start if it is too long
  *         to fit on the command-line, `"<"` will appear in the left most
  *         column; ignored in Ex mode
@@ -6028,7 +6042,12 @@ export const shiftwidth: BufferLocalOption<number> = new NumberOption(
  *         `:silent` was used for the command; note that this also
  *         affects messages from autocommands and 'autoread' reloading
  *   S     do not show search count message when searching, e.g.
- *         "[1/5]"
+ *         "[1/5]". When the "S" flag is not present (e.g. search count
+ *         is shown), the "search hit BOTTOM, continuing at TOP" and
+ *         "search hit TOP, continuing at BOTTOM" messages are only
+ *         indicated by a "W" (Mnemonic: Wrapped) letter before the
+ *         search count statistics.  The maximum limit can be set with
+ *         the 'maxsearchcount' option.
  *
  * This gives you the opportunity to avoid that a change between buffers
  * requires you to hit `<Enter>`, but still gives as useful a message as
@@ -6094,8 +6113,7 @@ export const showbreak: GlobalOrWindowLocalOption<string> = new StringOption(
  * NOTE: This option is set to the Vi default value when 'compatible' is
  * set and to the Vim default value when 'compatible' is reset.
  *
- * (Vim default: on, off for Unix,
- *  Vi default: off, set in `defaults.vim`)
+ * (Vim default: on, Vi default: off)
  */
 export const showcmd: GlobalOption<boolean> = new BooleanOption("showcmd");
 
@@ -6200,7 +6218,7 @@ export const sidescroll: GlobalOption<number> = new NumberOption("sidescroll");
 /**
  * The minimal number of screen columns to keep to the left and to the
  * right of the cursor if 'nowrap' is set.  Setting this option to a
- * value greater than 0 while having `'sidescroll'` also at a non-zero
+ * value greater than 0 while having 'sidescroll' also at a non-zero
  * value makes some context visible in the line you are scrolling in
  * horizontally (except at beginning of the line).  Setting this option
  * to a large value (like 999) has the effect of keeping the cursor
@@ -6214,9 +6232,9 @@ export const sidescroll: GlobalOption<number> = new NumberOption("sidescroll");
  *
  * NOTE: This option is set to 0 when 'compatible' is set.
  *
- * Example: Try this together with 'sidescroll' and 'listchars' as
- *          in the following example to never allow the cursor to move
- *          onto the "extends" character:
+ * Example: Try this together with 'sidescroll' and 'listchars' as in the
+ *          following example to never allow the cursor to move onto the
+ *          "extends" character:
  *
  *              :set nowrap sidescroll=1 listchars=extends:>,precedes:<
  *              :set sidescrolloff=1
@@ -6246,9 +6264,11 @@ export const signcolumn: WindowLocalOption<string> = new StringOption(
  * Override the 'ignorecase' option if the search pattern contains upper
  * case characters.  Only used when the search pattern is typed and
  * 'ignorecase' option is on.  Used for the commands "/", "?", "n", "N",
- * ":g" and ":s".  Not used for "*", "#", "gd", tag search, etc.  After
- * "*" and "#" you can make 'smartcase' used by doing a "/" command,
- * recalling the search pattern from history and hitting `<Enter>`.
+ * ":g" and ":s" and when filtering matches for the completion menu
+ * `compl-states`.
+ * Not used for "*", "#", "gd", tag search, etc.  After "*" and "#" you
+ * can make 'smartcase' used by doing a "/" command, recalling the search
+ * pattern from history and hitting `<Enter>`.
  * NOTE: This option is reset when 'compatible' is set.
  *
  * (default off)
@@ -6286,19 +6306,16 @@ export const smartindent: BufferLocalOption<boolean> = new BooleanOption(
 );
 
 /**
- * When on, a `<Tab>` in front of a line inserts blanks according to
- * 'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
- * `<BS>` will delete a 'shiftwidth' worth of space at the start of the
- * line.
- * When off, a `<Tab>` always inserts blanks according to 'tabstop' or
- * 'softtabstop'.  'shiftwidth' is only used for shifting text left or
- * right `shift-left-right`.
- * What gets inserted (a `<Tab>` or spaces) depends on the 'expandtab'
- * option.  Also see `ins-expandtab`.  When 'expandtab' is not set, the
- * number of spaces is minimized by using `<Tab>`s.
- * This option is reset when 'paste' is set and restored when 'paste' is
- * reset.
- * NOTE: This option is reset when 'compatible' is set.
+ * When enabled, the `<Tab>` key will indent by 'shiftwidth' if the cursor
+ * is in leading whitespace.  The `<BS>` key has the opposite effect.
+ * In leading whitespace, this has the same effect as setting
+ * 'softtabstop' to the value of 'shiftwidth'.
+ * This option is reset when 'compatible' is set; it is temporarily
+ * disabled when 'paste' is enabled, and restored when 'paste' is turned
+ * off.
+ * NOTE: in most cases, using 'softtabstop' is a better option.  Have a
+ * look at section `30.5` of the user guide for detailed
+ * explanations on how Vim works with tabs and spaces.
  *
  * (default off)
  */
@@ -6320,25 +6337,28 @@ export const smoothscroll: WindowLocalOption<boolean> = new BooleanOption(
 );
 
 /**
- * Number of spaces that a `<Tab>` counts for while performing editing
- * operations, like inserting a `<Tab>` or using `<BS>`.  It "feels" like
- * `<Tab>`s are being inserted, while in fact a mix of spaces and `<Tab>`s is
- * used.  This is useful to keep the 'ts' setting at its standard value
- * of 8, while being able to edit like it is set to 'sts'.  However,
- * commands like "x" still work on the actual characters.
- * When 'sts' is zero, this feature is off.
- * When 'sts' is negative, the value of 'shiftwidth' is used.
- * 'softtabstop' is set to 0 when the 'paste' option is set and restored
- * when 'paste' is reset.
- * See also `ins-expandtab`.  When 'expandtab' is not set, the number of
- * spaces is minimized by using `<Tab>`s.
- * The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
- * set.
- * NOTE: This option is set to 0 when 'compatible' is set.
+ * Create soft tab stops, separated by 'softtabstop' number of columns.
+ * In Insert mode, pressing the `<Tab>` key will move the cursor to the
+ * next soft tab stop, instead of inserting a literal tab.  `<BS>` behaves
+ * similarly in reverse.  Vim inserts a minimal mix of tab and space
+ * characters to produce the visual effect.
+ *
+ * This setting does not affect the display of existing tab characters.
+ *
+ * A value of 0 disables this behaviour.  A negative value makes Vim use
+ * 'shiftwidth'.  If you plan to use 'sts' and 'shiftwidth' with
+ * different values, you might consider setting 'smarttab'.
+ *
+ * 'softtabstop' is temporarily set to 0 when 'paste' is on and reset
+ * when it is turned off.  It is also reset when 'compatible' is set.
+ *
+ * The 'L' flag in 'cpoptions' alters tab behavior when 'list' is
+ * enabled.  See also `ins-expandtab` ans user manual section `30.5` for
+ * in-depth explanations.
  *
  * If Vim is compiled with the `+vartabs` feature then the value of
- * 'softtabstop' will be ignored if `'varsofttabstop'` is set to
- * anything other than an empty string.
+ * 'softtabstop' will be ignored if 'varsofttabstop' is set to anything
+ * other than an empty string.
  *
  * (default 0)
  */
@@ -6498,7 +6518,7 @@ export const spelloptions: BufferLocalOption<string> = new StringOption(
  *                 minus two.
  *
  * timeout:**{millisec}**   Limit the time searching for suggestions to
- *                 **{millisec}** milli seconds.  Applies to the following
+ *                 **{millisec}** milliseconds.  Applies to the following
  *                 methods.  When omitted the limit is 5000. When
  *                 negative there is no limit.  *only works when built
  *                 with the `+reltime` feature*
@@ -6592,7 +6612,8 @@ export const splitright: GlobalOption<boolean> = new BooleanOption(
  * non-blank of the line.  When off the cursor is kept in the same column
  * (if possible).  This applies to the commands:
  * - CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
- * - "d", `"<<"` and ">>" with a linewise operator
+ * - "d", `"<<"`, "==" and ">>" with a linewise operator
+ *   (`operator-resulting-pos`)
  * - "%" with a count
  * - buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
  * - Ex commands that only has a line number, e.g., ":25" or ":+".
@@ -6780,7 +6801,7 @@ export const startofline: GlobalOption<boolean> = new BooleanOption(
  * Examples:
  * Emulate standard status line with 'ruler' set
  *
- *     :set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
+ *     :set statusline=%<%f\ %h%w%m%r%=%-14.(%l,%c%V%)\ %P
  *
  * Similar, but add ASCII value of char under the cursor (like "ga")
  *
@@ -6852,12 +6873,12 @@ export const suffixesadd: BufferLocalOption<string> = new StringOption(
  * Careful: All text will be in memory:
  *         - Don't use this for big files.
  *         - Recovery will be impossible!
- * A swapfile will only be present when `'updatecount'` is non-zero and
+ * A swapfile will only be present when 'updatecount' is non-zero and
  * 'swapfile' is set.
  * When 'swapfile' is reset, the swap file for the current buffer is
  * immediately deleted.  When 'swapfile' is set, and 'updatecount' is
  * non-zero, a swap file is immediately created.
- * Also see `swap-file` and `'swapsync'`.
+ * Also see `swap-file` and 'swapsync'.
  * If you want to open a new buffer without creating a swap file for it,
  * use the `:noswapfile` modifier.
  * See 'directory' for where the swap file is created.
@@ -6947,13 +6968,28 @@ export const synmaxcol: BufferLocalOption<number> = new NumberOption(
  * Syntax autocommand event is triggered with the value as argument.
  * This option is not copied to another buffer, independent of the 's' or
  * 'S' flag in 'cpoptions'.
- * Only normal file name characters can be used, `"/\*?[|<>"` are illegal.
+ * Only alphanumeric characters, '.', '-' and '_' can be used.
  *
  * (default empty)
  *
  * *not available when compiled without the `+syntax` feature*
  */
 export const syntax: BufferLocalOption<string> = new StringOption("syntax");
+
+/**
+ * This option controls the behavior when closing tab pages (e.g., using
+ * `:tabclose`).  When empty Vim goes to the next (right) tab page.
+ *
+ * Possible values (comma-separated list):
+ *    left         If included, go to the previous tab page instead of
+ *                 the next one.
+ *    uselast      If included, go to the previously used tab page if
+ *                 possible.  This option takes precedence over the
+ *                 others.
+ *
+ * (default "")
+ */
+export const tabclose: GlobalOption<string> = new StringOption("tabclose");
 
 /**
  * When non-empty, this option determines the content of the tab pages
@@ -6990,46 +7026,13 @@ export const tabline: GlobalOption<string> = new StringOption("tabline");
 export const tabpagemax: GlobalOption<number> = new NumberOption("tabpagemax");
 
 /**
- * Number of spaces that a `<Tab>` in the file counts for.  Also see
- * the `:retab` command, and the 'softtabstop' option.
- *
- * Note: Setting 'tabstop' to any other value than 8 can make your file
- * appear wrong in many places, e.g., when printing it.
- * The value must be more than 0 and less than 10000.
- *
- * There are five main ways to use tabs in Vim:
- * 1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
- *    (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
- *    will use a mix of tabs and spaces, but typing `<Tab>` and `<BS>` will
- *    behave like a tab appears every 4 (or 3) characters.
- *    This is the recommended way, the file will look the same with other
- *    tools and when listing it in a terminal.
- * 2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
- *    'expandtab'.  This way you will always insert spaces.  The
- *    formatting will never be messed up when 'tabstop' is changed (leave
- *    it at 8 just in case).  The file will be a bit larger.
- *    You do need to check if no Tabs exist in the file.  You can get rid
- *    of them by first setting 'expandtab' and using `%retab!`, making
- *    sure the value of 'tabstop' is set correctly.
- * 3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
- *    'expandtab'.  This way you will always insert spaces.  The
- *    formatting will never be messed up when 'tabstop' is changed.
- *    You do need to check if no Tabs exist in the file, just like in the
- *    item just above.
- * 4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
- *    `modeline` to set these values when editing the file again.  Only
- *    works when using Vim to edit the file, other tools assume a tabstop
- *    is worth 8 spaces.
- * 5. Always set 'tabstop' and 'shiftwidth' to the same value, and
- *    'noexpandtab'.  This should then work (for initial indents only)
- *    for any tabstop setting that people use.  It might be nice to have
- *    tabs after the first non-blank inserted as spaces if you do this
- *    though.  Otherwise aligned comments will be wrong when 'tabstop' is
- *    changed.
- *
- * If Vim is compiled with the `+vartabs` feature then the value of
- * 'tabstop' will be ignored if `'vartabstop'` is set to anything other
- * than an empty string.
+ * Defines the column multiple used to display the Horizontal Tab
+ * character (ASCII 9); a Horizontal Tab always advances to the next tab
+ * stop.
+ * The value must be at least 1 and at most 9999.
+ * If Vim was compiled with `+vartabs` and 'vartabstop' is set, this
+ * option is ignored.
+ * Leave it at 8 unless you have a strong reason (see usr `30.5`).
  *
  * (default 8)
  */
@@ -7111,7 +7114,8 @@ export const tagcase: GlobalOrBufferLocalOption<string> = new StringOption(
 );
 
 /**
- * This option specifies a function to be used to perform tag searches.
+ * This option specifies a function to be used to perform tag searches
+ * (including `taglist()`).
  * The function gets the tag pattern and should return a List of matching
  * tags.  See `tag-function` for an explanation of how to write the
  * function and an example.  The value can be the name of a function, a
@@ -7229,7 +7233,8 @@ export const termbidi: GlobalOption<boolean> = new BooleanOption("termbidi");
  *
  * NOTE: This option is reset when 'compatible' is set.
  *
- * (default off)
+ * (default off unless Vim detects that it runs
+ *  in a capable terminal)
  *
  * *not available when compiled without the `+termguicolors` feature*
  */
@@ -7388,7 +7393,7 @@ export const ttimeoutlen: GlobalOption<number> = new NumberOption(
  * When Vim was compiled with HAVE_X11 defined, the original title will
  * be restored if possible.  The output of ":version" will include "+X11"
  * when HAVE_X11 was defined, otherwise it will be "-X11".  This also
- * works for the icon name `'icon'`.
+ * works for the icon name 'icon'.
  * But: When Vim was started with the `-X` argument, restoring the title
  * will not work (except in the GUI).
  * If the title cannot be restored, it is set to the value of 'titleold'.
@@ -7442,7 +7447,9 @@ export const titleold: GlobalOption<string> = new StringOption("titleold");
  * be restored if possible, see `X11`.
  *
  * When this option contains printf-style '%' items, they will be
- * expanded according to the rules used for 'statusline'.
+ * expanded according to the rules used for 'statusline'.  If it contains
+ * an invalid '%' format, the value is used as-is and no error or warning
+ * will be given when the value is set.
  * This option cannot be set in a modeline when 'modelineexpr' is off.
  *
  * Example:
@@ -7471,7 +7478,7 @@ export const titlestring: GlobalOption<string> = new StringOption(
 
 /**
  * List of directory names for undo files, separated with commas.
- * See `'backupdir'` for details of the format.
+ * See 'backupdir' for details of the format.
  * "." means using the directory of the file.  The undo file name for
  * "file.txt" is `".file.txt.un~"`.
  * For other directories the file name is the full path of the edited
@@ -7562,13 +7569,13 @@ export const undoreload: GlobalOption<number> = new NumberOption("undoreload");
  * recovery `crash-recovery`).  'updatecount' is set to zero by starting
  * Vim with the "-n" option, see `startup`.  When editing in readonly
  * mode this option will be initialized to 10000.
- * The swapfile can be disabled per buffer with `'swapfile'`.
+ * The swapfile can be disabled per buffer with 'swapfile'.
  * When 'updatecount' is set from zero to non-zero, swap files are
  * created for all buffers that have 'swapfile' set.  When 'updatecount'
  * is set to zero, existing swap files are not deleted.
- * Also see `'swapsync'`.
- * This option has no meaning in buffers where `'buftype'` is "nofile"
- * or "nowrite".
+ * Also see 'swapsync'.
+ * This option has no meaning in buffers where 'buftype' is "nofile" or
+ * "nowrite".
  *
  * (default: 200)
  */
@@ -7586,11 +7593,9 @@ export const updatecount: GlobalOption<number> = new NumberOption(
 export const updatetime: GlobalOption<number> = new NumberOption("updatetime");
 
 /**
- * A list of the number of spaces that a `<Tab>` counts for while editing,
- * such as inserting a `<Tab>` or using `<BS>`.  It "feels" like variable-
- * width `<Tab>`s are being inserted, while in fact a mixture of spaces
- * and `<Tab>`s is used.  Tab widths are separated with commas, with the
- * final value applying to all subsequent tabs.
+ * Defines variable-width soft tab stops.  The value is a comma-separated
+ * list of widths in columns.  Each width defines the number of columns
+ * before the next soft tab stop.  The last value repeats indefinitely.
  *
  * For example, when editing assembly language files where statements
  * start in the 9th column and comments in the 41st, it may be useful
@@ -7598,11 +7603,12 @@ export const updatetime: GlobalOption<number> = new NumberOption("updatetime");
  *
  *     :set varsofttabstop=8,32,8
  *
- * This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
- * for every column thereafter.
+ * This sets soft tab stops at column 8, then at column 40 (8 + 32), and
+ * every 8 columns thereafter.
  *
- * Note that the value of `'softtabstop'` will be ignored while
- * 'varsofttabstop' is set.
+ * Note: this setting overrides 'softtabstop'.
+ * See section `30.5` of the user manual for detailed explanations on how
+ * Vim works with tabs and spaces.
  *
  * (default "")
  *
@@ -7613,17 +7619,22 @@ export const varsofttabstop: BufferLocalOption<string> = new StringOption(
 );
 
 /**
- * A list of the number of spaces that a `<Tab>` in the file counts for,
- * separated by commas.  Each value corresponds to one tab, with the
- * final value applying to all subsequent tabs. For example:
+ * Defines variable-width tab stops. The value is a comma-separated list
+ * of widths in columns.  Each width defines the number of columns
+ * before the next tab stop; the last value repeats indefinitely.
  *
- *     :set vartabstop=4,20,10,8
+ * For example:
  *
- * This will make the first tab 4 spaces wide, the second 20 spaces,
- * the third 10 spaces, and all following tabs 8 spaces.
+ *     :set vartabstop=4,8
  *
- * Note that the value of `'tabstop'` will be ignored while 'vartabstop'
- * is set.
+ * This places the first tab stop 4 columns from the start of the line
+ * and each subsequent tab stop 8 columns apart.
+ *
+ * Note: this setting overrides 'tabstop'.
+ * On UNIX, it is recommended to keep the default tabstop value of 8.
+ * Consider setting 'varsofttabstop' instead.
+ * See section `30.5` of the user manual for detailed explanations on how
+ * Vim works with tabs and spaces.
  *
  * (default "")
  *
@@ -7687,7 +7698,6 @@ export const verbosefile: GlobalOption<string> = new StringOption(
  *  for Win32: "$HOME/vimfiles/view",
  *  for Unix: "$HOME/.vim/view" or
  *  "$XDG_CONFIG_HOME/vim/view"
- *  for macOS: "$VIM/vimfiles/view",
  *  for VMS: "sys$login:vimfiles/view")
  *
  * *not available when compiled without the `+mksession` feature*
@@ -7845,10 +7855,19 @@ export const whichwrap: GlobalOption<string> = new StringOption("whichwrap");
  * Some keys will not work, such as CTRL-C, `<CR>` and Enter.
  * `<Esc>` can be used, but hitting it twice in a row will still exit
  * command-line as a failsafe measure.
- * Although 'wc' is a number option, you can set it to a special key:
+ * Although 'wc' is a number option, it can be specified as a number, a
+ * single character, a `key-notation` (e.g. `<Up>`, `<C-F>`) or a letter
+ * preceded with a caret (e.g. `^F` is CTRL-F):
  *
+ *     :set wc=27
+ *     :set wc=X
+ *     :set wc=^I
  *     :set wc=<Tab>
  *
+ * 'wildchar' also enables completion in search pattern contexts such as
+ * `/`, `?`, `:s`, `:g`, `:v`, and `:vim`.  To insert a literal `<Tab>`
+ * instead of triggering completion, type `<C-V><Tab>` or "\t".
+ * See also 'wildoptions' and `wildtrigger()`.
  * NOTE: This option is set to the Vi default value when 'compatible' is
  * set and to the Vim default value when 'compatible' is reset.
  *
@@ -7961,63 +7980,84 @@ export const wildignorecase: GlobalOption<boolean> = new BooleanOption(
  * The "WildMenu" highlighting is used for displaying the current match
  * `hl-WildMenu`.
  *
- * (default off, set in `defaults.vim`)
+ * (default on)
  */
 export const wildmenu: GlobalOption<boolean> = new BooleanOption("wildmenu");
 
 /**
- * Completion mode that is used for the character specified with
- * 'wildchar'.  It is a comma-separated list of up to four parts.  Each
- * part specifies what to do for each consecutive use of 'wildchar'.  The
- * first part specifies the behavior for the first use of 'wildchar',
- * The second part for the second use, etc.
+ * Completion mode used for the character specified with 'wildchar'.
+ * This option is a comma-separated list of up to four parts,
+ * corresponding to the first, second, third, and fourth presses of
+ * 'wildchar'.  Each part is a colon-separated list of completion
+ * behaviors, which are applied simultaneously during that phase.
  *
- * Each part consists of a colon separated list consisting of the
- * following possible values:
- * ""              Complete only the first match.
- * "full"          Complete the next full match.  After the last match,
- *                 the original string is used and then the first match
- *                 again.  Will also start 'wildmenu' if it is enabled.
- * "longest"       Complete till longest common string.  If this doesn't
- *                 result in a longer string, use the next part.
- * "list"          When more than one match, list all matches.
- * "lastused"      When completing buffer names and more than one buffer
- *                 matches, sort buffers by time last used (other than
- *                 the current buffer).
- * When there is only a single match, it is fully completed in all cases.
+ * The possible behavior values are:
+ * ""              Only complete (insert) the first match.  No further
+ *                 matches are cycled or listed.
+ * "full"          Complete the next full match.  Cycles through all
+ *                 matches, returning to the original input after the
+ *                 last match.  If 'wildmenu' is enabled, it will be
+ *                 shown.
+ * "longest"       Complete to the longest common substring.  If this
+ *                 doesn't extend the input, the next 'wildmode' part is
+ *                 used.
+ * "list"          If multiple matches are found, list all of them.
+ * "lastused"      When completing buffer names, sort them by most
+ *                 recently used (excluding the current buffer).  Only
+ *                 applies to buffer name completion.
+ * "noselect"      If 'wildmenu' is enabled, show the menu but do not
+ *                 preselect the first item.
+ * If only one match exists, it is completed fully, unless "noselect" is
+ * specified.
  *
- * Examples of useful colon-separated values:
- * "longest:full"  Like "longest", but also start 'wildmenu' if it is
- *                 enabled.  Will not complete to the next full match.
- * "list:full"     When more than one match, list all matches and
- *                 complete first match.
- * "list:longest"  When more than one match, list all matches and
- *                 complete till longest common string.
- * "list:lastused" When more than one buffer matches, list all matches
- *                 and sort buffers by time last used (other than the
- *                 current buffer).
+ * Some useful combinations of colon-separated values:
+ * "longest:full"          Start with the longest common string and show
+ *                         'wildmenu' (if enabled).  Does not cycle
+ *                         through full matches.
+ * "list:full"             List all matches and complete first match.
+ * "list:longest"          List all matches and complete till the longest
+ *                         common prefix.
+ * "list:lastused"         List all matches.  When completing buffers,
+ *                         sort them by most recently used (excluding the
+ *                         current buffer).
+ * "noselect:lastused"     Do not preselect the first item in 'wildmenu'
+ *                         if it is active.  When completing buffers,
+ *                         sort them by most recently used (excluding the
+ *                         current buffer).
  *
  * Examples:
  *
  *     :set wildmode=full
  *
- * Complete first full match, next match, etc.  (the default)
+ * Complete full match on every press (default behavior)
  *
  *     :set wildmode=longest,full
  *
- * Complete longest common string, then each full match
+ * First press: longest common substring
+ * Second press: cycle through full matches
  *
  *     :set wildmode=list:full
  *
- * List all matches and complete each full match
+ * First press: list all matches and complete the first one
  *
  *     :set wildmode=list,full
  *
- * List all matches without completing, then each full match
+ * First press: list matches only
+ * Second press: complete full matches
  *
  *     :set wildmode=longest,list
  *
- * Complete longest common string, then list alternatives.
+ * First press: longest common substring
+ * Second press: list all matches
+ *
+ *     :set wildmode=noselect:full
+ *
+ * First press: show 'wildmenu' without completing or selecting
+ * Second press: cycle full matches
+ *
+ *     :set wildmode=noselect:lastused,full
+ *
+ * Same as above, but buffer matches are sorted by time last used
  * More info here: `cmdline-completion`.
  *
  * (Vim default: "full")
@@ -8026,7 +8066,22 @@ export const wildmode: GlobalOption<string> = new StringOption("wildmode");
 
 /**
  * A list of words that change how `cmdline-completion` is done.
+ *
  * The following values are supported:
+ *   exacttext     When this flag is present, search pattern completion
+ *                 (e.g., in `/`, `?`, `:s`, `:g`, `:v`, and `:vim`)
+ *                 shows exact buffer text as menu items, without
+ *                 preserving regex artifacts like position
+ *                 anchors (e.g., `/\<`).  This provides more intuitive
+ *                 menu items that match the actual buffer text.
+ *                 However, searches may be less accurate since the
+ *                 pattern is not preserved exactly.
+ *                 By default, Vim preserves the typed pattern (with
+ *                 anchors) and appends the matched word.  This preserves
+ *                 search correctness, especially when using regular
+ *                 expressions or with 'smartcase' enabled.  However, the
+ *                 case of the appended matched word may not exactly
+ *                 match the case of the word in the buffer.
  *   fuzzy         Use `fuzzy-matching` to find completion matches. When
  *                 this value is specified, wildcard expansion will not
  *                 be used for completion.  The matches will be sorted by
@@ -8042,6 +8097,9 @@ export const wildmode: GlobalOption<string> = new StringOption("wildmode");
  *                 is displayed per line.  Often used tag kinds are:
  *                         d       #define
  *                         f       function
+ *
+ * This option does not apply to `ins-completion`. See 'completeopt' for
+ * that.
  *
  * (default "")
  */

--- a/option/nvim/_generated.ts
+++ b/option/nvim/_generated.ts
@@ -124,6 +124,9 @@ export const redrawdebug: GlobalOption<string> = new StringOption(
  * Minimum is 1, maximum is 100000.
  * Only in `terminal` buffers.
  *
+ * Note: Lines that are not visible and kept in scrollback are not
+ * reflown when the terminal buffer is resized horizontally.
+ *
  * (default 10000)
  */
 export const scrollback: BufferLocalOption<number> = new NumberOption(
@@ -262,7 +265,6 @@ export const shada: GlobalOption<string> = new StringOption("shada");
 export const shadafile: GlobalOption<string> = new StringOption("shadafile");
 
 /**
- * EXPERIMENTAL
  * When non-empty, this option determines the content of the area to the
  * side of a window, normally containing the fold, sign and number columns.
  * The format of this option is like that of 'statusline'.
@@ -270,8 +272,7 @@ export const shadafile: GlobalOption<string> = new StringOption("shadafile");
  * Some of the items from the 'statusline' format are different for
  * 'statuscolumn':
  *
- * %l      line number of currently drawn line
- * %r      relative line number of currently drawn line
+ * %l      line number column for currently drawn line
  * %s      sign column for currently drawn line
  * %C      fold column for currently drawn line
  *
@@ -299,11 +300,8 @@ export const shadafile: GlobalOption<string> = new StringOption("shadafile");
  *
  * Examples:
  *
- *     " Relative number with bar separator and click handlers:
- *     set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
- *
- *     " Right aligned relative cursor line number:
- *     let &stc='%=%{v:relnum?v:relnum:v:lnum} '
+ *     " Line number with bar separator and click handlers:
+ *     set statuscolumn=%@SignCb@%s%=%T%@NumCb@%l│%T
  *
  *     " Line numbers in hexadecimal for non wrapped part of lines:
  *     let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
@@ -394,6 +392,21 @@ export const winbar: GlobalOrWindowLocalOption<string> = new StringOption(
  * (default 0)
  */
 export const winblend: WindowLocalOption<number> = new NumberOption("winblend");
+
+/**
+ * Defines the default border style of floating windows. The default value
+ * is empty, which is equivalent to "none". Valid values include:
+ * - "bold": Bold line box.
+ * - "double": Double-line box.
+ * - "none": No border.
+ * - "rounded": Like "single", but with rounded corners ("╭" etc.).
+ * - "shadow": Drop shadow effect, by blending with the background.
+ * - "single": Single-line box.
+ * - "solid": Adds padding by a single whitespace cell.
+ *
+ * (default "")
+ */
+export const winborder: GlobalOption<string> = new StringOption("winborder");
 
 /**
  * Window-local highlights.  Comma-delimited list of highlight

--- a/option/vim/_generated.ts
+++ b/option/vim/_generated.ts
@@ -46,6 +46,29 @@ export const altkeymap: GlobalOption<boolean> = new BooleanOption("altkeymap");
 export const antialias: GlobalOption<boolean> = new BooleanOption("antialias");
 
 /**
+ * When on, Vim shows a completion menu as you type, similar to using
+ * `i_CTRL-N`, but triggered automatically.  See `ins-autocompletion`.
+ *
+ * (default off)
+ *
+ * *only available on platforms with timing support*
+ */
+export const autocomplete: GlobalOption<boolean> = new BooleanOption(
+  "autocomplete",
+);
+
+/**
+ * Delay in milliseconds before the autocomplete menu appears after
+ * typing. If you prefer it not to open too quickly, set this value
+ * slightly above your typing speed. See `ins-autocompletion`.
+ *
+ * (default 0)
+ */
+export const autocompletedelay: GlobalOption<number> = new NumberOption(
+  "autocompletedelay",
+);
+
+/**
  * When on, Vim will change the current working directory whenever you
  * change the directory of the shell running in a terminal window. You
  * need proper setting-up, so whenever the shell's pwd changes an OSC 7
@@ -201,6 +224,63 @@ export const balloonexpr: GlobalOrBufferLocalOption<string> = new StringOption(
 export const bioskey: GlobalOption<boolean> = new BooleanOption("bioskey");
 
 /**
+ * Which directory to use for the file browser:
+ *    last         Use same directory as with last file browser, where a
+ *                 file was opened or saved.
+ *    buffer       Use the directory of the related buffer.
+ *    current      Use the current directory.
+ *    **{path}**       Use the specified directory
+ *
+ * (default: "last")
+ *
+ * *only for Motif, GTK, Mac and Win32 GUI*
+ */
+export const browsedir: GlobalOption<string> = new StringOption("browsedir");
+
+/**
+ * Number of quickfix lists that should be remembered for the quickfix
+ * stack.  Must be between 1 and 100.  If the option is set to a value
+ * that is lower than the amount of entries in the quickfix list stack,
+ * entries will be removed starting from the oldest one.  If the current
+ * quickfix list was removed, then the quickfix list at top of the stack
+ * (the most recently created) will be used in its place.  For additional
+ * info, see `quickfix-stack`.
+ *
+ * (default: 10)
+ *
+ * *only available when compiled with the `+quickfix` feature*
+ */
+export const chistory: GlobalOption<number> = new NumberOption("chistory");
+
+/**
+ * Specifies which method of accessing the system clipboard is used,
+ * depending on which method works first or is available.  Supported
+ * methods are:
+ *         wayland         Wayland selections
+ *         x11             X11 selections
+ *
+ * Note: This option is ignored when either the GUI is running or if Vim
+ * is run on a system without Wayland or X11 support, such as Windows or
+ * macOS.  The GUI or system way of accessing the clipboard is always
+ * used instead.
+ *
+ * The option value is a list of comma separated items.  The list is
+ * parsed left to right in order, and the first method that Vim
+ * determines is available or is working is used as the actual method for
+ * accessing the clipboard.
+ *
+ * The current method that is being used can be found in the `v:clipmethod`
+ * variable.
+ *
+ * (default for Unix: "wayland,x11",
+ *  for VMS: "x11",
+ *  otherwise: "")
+ *
+ * *only when the `+xterm_clipboard` or `+wayland_clipboard` features are included*
+ */
+export const clipmethod: GlobalOption<string> = new StringOption("clipmethod");
+
+/**
  * This option has the effect of making Vim either more Vi-compatible, or
  * make Vim behave in a more useful way.
  *
@@ -304,7 +384,7 @@ export const bioskey: GlobalOption<boolean> = new BooleanOption("bioskey");
  * 'smartcase'     + off           no automatic ignore case switch
  * 'smartindent'   + off           no smart indentation
  * 'smarttab'      + off           no smart tab size
- * 'softtabstop'   + 0             tabs are always 'tabstop' positions
+ * 'softtabstop'   + 0             no soft tab stops
  * 'startofline'   + on            goto startofline with some commands
  * 'tagcase'       & "followic"    'ignorecase' when searching tags file
  * 'tagrelative'   & off           tag file names are not relative
@@ -326,6 +406,32 @@ export const bioskey: GlobalOption<boolean> = new BooleanOption("bioskey");
  */
 export const compatible: GlobalOption<boolean> = new BooleanOption(
   "compatible",
+);
+
+/**
+ * A comma-separated list of strings to enable fuzzy collection for
+ * specific `ins-completion` modes, affecting how matches are gathered
+ * during completion.  For specified modes, fuzzy matching is used to
+ * find completion candidates instead of the standard prefix-based
+ * matching.  This option can contain the following values:
+ *
+ * keyword         keywords in the current file    `i_CTRL-X_CTRL-N`
+ *                 keywords with flags ".", "w",   `i_CTRL-N` `i_CTRL-P`
+ *                 "b", "u", "U" and "k**{dict}**" in 'complete'
+ *                 keywords in 'dictionary'        `i_CTRL-X_CTRL-K`
+ *
+ * files           file names                      `i_CTRL-X_CTRL-F`
+ *
+ * whole_line      whole lines                     `i_CTRL-X_CTRL-L`
+ *
+ * When using the 'completeopt' "longest" option value, fuzzy collection
+ * can identify the longest common string among the best fuzzy matches
+ * and insert it automatically.
+ *
+ * (default: empty)
+ */
+export const completefuzzycollect: GlobalOption<string> = new StringOption(
+  "completefuzzycollect",
 );
 
 /**
@@ -373,7 +479,7 @@ export const conskey: GlobalOption<boolean> = new BooleanOption("conskey");
  *                 the pieces of text.
  *
  *    xchacha20    XChaCha20 Cipher with Poly1305 Message Authentication
- *                 Code.  Medium strong till strong encryption.
+ *                 Code.  Medium strong to strong encryption.
  *                 Encryption is provided by the libsodium library, it
  *                 requires Vim to be built with `+sodium`.
  *                 It adds a seed and a message authentication code (MAC)
@@ -507,6 +613,33 @@ export const cscopeverbose: GlobalOption<boolean> = new BooleanOption(
 );
 
 /**
+ * List of **{address}** in each buffer, separated by commas, that are
+ * considered anchors when used for diffing.  It's valid to specify "$+1"
+ * for 1 past the last line.  "%" cannot be used for this option.  There
+ * can be at most 20 anchors set for each buffer.
+ *
+ * Each anchor line splits the buffer (the split happens above the
+ * anchor), with each part being diff'ed separately before the final
+ * result is joined.  When more than one **{address}** are provided, the
+ * anchors will be sorted interally by line number.  If using buffer
+ * local options, each buffer should have the same number of anchors
+ * (extra anchors will be ignored).  This option is only used when
+ * 'diffopt' has "anchor" set.  See `diff-anchors` for more details and
+ * examples.
+ *
+ * If some of the **{address}** do not resolve to a line in each buffer (e.g.
+ * a pattern search that does not match anything), none of the anchors
+ * will be used.
+ *
+ * Diff anchors can only be used when there are no hidden diff buffers.
+ *
+ * (default "")
+ */
+export const diffanchors: GlobalOrBufferLocalOption<string> = new StringOption(
+  "diffanchors",
+);
+
+/**
  * Makes the 'g' and 'c' flags of the ":substitute" command to be
  * toggled each time the flag is given.  See `complex-change`.  See
  * also 'gdefault' option.
@@ -597,6 +730,140 @@ export const guiligatures: GlobalOption<string> = new StringOption(
 );
 
 /**
+ * This option only has an effect in the GUI version of Vim.  It is a
+ * sequence of letters which describes what components and options of the
+ * GUI should be used.
+ * To avoid problems with flags that are added in the future, use the
+ * "+=" and "-=" feature of ":set" `add-option-flags`.
+ *
+ * Valid characters are as follows:
+ *
+ *   '!'   External commands are executed in a terminal window.  Without
+ *         this flag the MS-Windows GUI will open a console window to
+ *         execute the command.  The Unix GUI will simulate a dumb
+ *         terminal to list the command output.
+ *         The terminal window will be positioned at the bottom, and grow
+ *         upwards as needed.
+ *
+ *   'a'   Autoselect:  If present, then whenever VISUAL mode is started,
+ *         or the Visual area extended, Vim tries to become the owner of
+ *         the windowing system's global selection.  This means that the
+ *         Visually highlighted text is available for pasting into other
+ *         applications as well as into Vim itself.  When the Visual mode
+ *         ends, possibly due to an operation on the text, or when an
+ *         application wants to paste the selection, the highlighted text
+ *         is automatically yanked into the "* selection register.
+ *         Thus the selection is still available for pasting into other
+ *         applications after the VISUAL mode has ended.
+ *             If not present, then Vim won't become the owner of the
+ *         windowing system's global selection unless explicitly told to
+ *         by a yank or delete operation for the "* register.
+ *         The same applies to the modeless selection.
+ *
+ *   'P'   Like autoselect but using the "+ register instead of the "*
+ *         register.
+ *
+ *   'A'   Autoselect for the modeless selection.  Like 'a', but only
+ *         applies to the modeless selection.
+ *
+ *             'guioptions'   autoselect Visual  autoselect modeless
+ *                  ""              -                       -
+ *                  "a"            yes                     yes
+ *                  "A"             -                      yes
+ *                  "aA"           yes                     yes
+ *
+ *         When using a terminal see the 'clipboard' option.
+ *
+ *   'c'   Use console dialogs instead of popup dialogs for simple
+ *         choices.
+ *
+ *   'd'   Use dark theme variant if available. Currently only works for
+ *         GTK+ GUI.
+ *
+ *   'e'   Add tab pages when indicated with 'showtabline'.
+ *         'guitablabel' can be used to change the text in the labels.
+ *         When 'e' is missing a non-GUI tab pages line may be used.
+ *         The GUI tabs are only supported on some systems, currently
+ *         GTK, Motif, Mac OS/X, Haiku, and MS-Windows.
+ *
+ *   'f'   Foreground: Don't use fork() to detach the GUI from the shell
+ *         where it was started.  Use this for programs that wait for the
+ *         editor to finish (e.g., an e-mail program).  Alternatively you
+ *         can use "gvim -f" or ":gui -f" to start the GUI in the
+ *         foreground.  `gui-fork`
+ *         Note: Set this option in the vimrc file.  The forking may have
+ *         happened already when the `gvimrc` file is read.
+ *
+ *   'i'   Use a Vim icon.  For GTK with KDE it is used in the left-upper
+ *         corner of the window.  It's black&white on non-GTK, because of
+ *         limitations of X11.  For a color icon, see `X11-icon`.
+ *
+ *   'm'   Menu bar is present.
+ *
+ *   'M'   The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
+ *         that this flag must be added in the .vimrc file, before
+ *         switching on syntax or filetype recognition (when the `gvimrc`
+ *         file is sourced the system menu has already been loaded; the
+ *         `:syntax on` and `:filetype on` commands load the menu too).
+ *
+ *   'g'   Grey menu items: Make menu items that are not active grey.  If
+ *         'g' is not included inactive menu items are not shown at all.
+ *
+ *   't'   Include tearoff menu items.  Currently only works for Win32,
+ *         GTK+, and Motif 1.2 GUI.
+ *
+ *   'T'   Include Toolbar.  Currently only in Win32, GTK+, Motif and
+ *         Photon GUIs.
+ *
+ *   'r'   Right-hand scrollbar is always present.
+ *
+ *   'R'   Right-hand scrollbar is present when there is a vertically
+ *         split window.
+ *
+ *   'l'   Left-hand scrollbar is always present.
+ *
+ *   'L'   Left-hand scrollbar is present when there is a vertically
+ *         split window.
+ *
+ *   'b'   Bottom (horizontal) scrollbar is present.  Its size depends on
+ *         the longest visible line, or on the cursor line if the 'h'
+ *         flag is included. `gui-horiz-scroll`
+ *
+ *   'h'   Limit horizontal scrollbar size to the length of the cursor
+ *         line.  Reduces computations. `gui-horiz-scroll`
+ *
+ * And yes, you may even have scrollbars on the left AND the right if
+ * you really want to :-).  See `gui-scrollbars` for more information.
+ *
+ *   'v'   Use a vertical button layout for dialogs.  When not included,
+ *         a horizontal layout is preferred, but when it doesn't fit a
+ *         vertical layout is used anyway.  Not supported in GTK 3.
+ *
+ *   'p'   Use Pointer callbacks for X11 GUI.  This is required for some
+ *         window managers.  If the cursor is not blinking or hollow at
+ *         the right moment, try adding this flag.  This must be done
+ *         before starting the GUI.  Set it in your `gvimrc`.  Adding or
+ *         removing it after the GUI has started has no effect.
+ *
+ *   'F'   Add a footer.  Only for Motif.  See `gui-footer`.
+ *
+ *   'k'   Keep the GUI window size when adding/removing a scrollbar, or
+ *         toolbar, tabline, etc.  Instead, the behavior is similar to
+ *         when the window is maximized and will adjust 'lines' and
+ *         'columns' to fit to the window.  Without the 'k' flag Vim will
+ *         try to keep 'lines' and 'columns' the same when adding and
+ *         removing GUI components.
+ *
+ * (default "egmrLtT"   (MS-Windows,
+ *  "t" is removed in `defaults.vim`),
+ *  "aegimrLtT" (GTK and Motif),
+ *  )
+ *
+ * *only available when compiled with GUI enabled*
+ */
+export const guioptions: GlobalOption<string> = new StringOption("guioptions");
+
+/**
  * Only in the GUI: If on, an attempt is made to open a pseudo-tty for
  * I/O to/from shell commands.  See `gui-pty`.
  *
@@ -605,6 +872,45 @@ export const guiligatures: GlobalOption<string> = new StringOption(
  * *only available when compiled with GUI enabled*
  */
 export const guipty: GlobalOption<boolean> = new BooleanOption("guipty");
+
+/**
+ * When non-empty describes the text to use in a label of the GUI tab
+ * pages line.  When empty and when the result is empty Vim will use a
+ * default label.  See `setting-guitablabel` for more info.
+ *
+ * The format of this option is like that of 'statusline'.
+ * 'guitabtooltip' is used for the tooltip, see below.
+ * The expression will be evaluated in the `sandbox` when set from a
+ * modeline, see `sandbox-option`.
+ * This option cannot be set in a modeline when 'modelineexpr' is off.
+ *
+ * Only used when the GUI tab pages line is displayed.  'e' must be
+ * present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
+ * used.
+ *
+ * (default empty)
+ *
+ * *only available when compiled with GUI enabled*
+ */
+export const guitablabel: GlobalOption<string> = new StringOption(
+  "guitablabel",
+);
+
+/**
+ * When non-empty describes the text to use in a tooltip for the GUI tab
+ * pages line.  When empty Vim will use a default tooltip.
+ * This option is otherwise just like 'guitablabel' above.
+ * You can include a line break.  Simplest method is to use `:let`:
+ *
+ *     :let &guitabtooltip = "line one\nline two"
+ *
+ * (default empty)
+ *
+ * *only available when compiled with GUI enabled*
+ */
+export const guitabtooltip: GlobalOption<string> = new StringOption(
+  "guitabtooltip",
+);
 
 /**
  * This option can be used to set highlighting mode for various
@@ -618,13 +924,13 @@ export const guipty: GlobalOption<boolean> = new BooleanOption("guipty");
  * `hl-Directory`   d  directories in CTRL-D listing and other special
  *                     things in listings
  * `hl-ErrorMsg`    e  error messages
- *                  h  (obsolete, ignored)
  * `hl-IncSearch`   i  'incsearch' highlighting
  * `hl-CurSearch`   y  current instance of last search pattern
  * `hl-Search`      l  last search pattern highlighting (see 'hlsearch')
  * `hl-MoreMsg`     m  `more-prompt`
  * `hl-ModeMsg`     M  Mode (e.g., "-- INSERT --")
  * `hl-MsgArea`     g  `Command-line` and message area
+ * `hl-ComplMatchIns` h  matched text of currently inserted completion
  * `hl-LineNr`      n  line number for ":number" and ":#" commands, and
  *                     when 'number' or 'relativenumber' option is set.
  * `hl-LineNrAbove`   a  line number above the cursor for when the
@@ -639,9 +945,9 @@ export const guipty: GlobalOption<boolean> = new BooleanOption("guipty");
  * `hl-Title`       t  Titles for output from ":set all", ":autocmd" etc.
  * `hl-VertSplit`   c  column used to separate vertically split windows
  * `hl-Visual`      v  Visual mode
- * `hl-VisualNOS`   V  Visual mode when Vim does is "Not Owning the
- *                     Selection" Only X11 Gui's `gui-x11` and
- *                     `xterm-clipboard`.
+ * `hl-VisualNOS`   V  Visual mode when Vim is "Not Owning the
+ *                     Selection" Only X11 Gui's `gui-x11`,
+ *                     `xterm-clipboard` and `wayland-selections`
  * `hl-WarningMsg`  w  warning messages
  * `hl-WildMenu`    W  wildcard matches displayed for 'wildmenu'
  * `hl-Folded`      f  line used for closed folds
@@ -649,7 +955,8 @@ export const guipty: GlobalOption<boolean> = new BooleanOption("guipty");
  * `hl-DiffAdd`     A  added line in diff mode
  * `hl-DiffChange`  C  changed line in diff mode
  * `hl-DiffDelete`  D  deleted line in diff mode
- * `hl-DiffText`    T  inserted text in diff mode
+ * `hl-DiffText`    T  changed text in diff mode
+ * `hl-DiffTextAdd`   E  inserted text in diff mode
  * `hl-SignColumn`  >  column used for `signs`
  * `hl-Conceal`     -  the placeholders used for concealed characters
  *                     (see 'conceallevel')
@@ -665,6 +972,8 @@ export const guipty: GlobalOption<boolean> = new BooleanOption("guipty");
  * `hl-PmenuExtraSel` }  popup menu "extra" selected line
  * `hl-PmenuSbar`   x  popup menu scrollbar
  * `hl-PmenuThumb`  X  popup menu scrollbar thumb
+ * `hl-PmenuMatch`  k  popup menu matched text
+ * `hl-PmenuMatchSel` <  popup menu matched text in selected line
  *
  * The display modes are:
  *         r       reverse         (termcap entry "mr" and "me")
@@ -699,16 +1008,17 @@ export const guipty: GlobalOption<boolean> = new BooleanOption("guipty");
  *  v:Visual,V:VisualNOS,w:WarningMsg,
  *  W:WildMenu,f:Folded,F:FoldColumn,
  *  A:DiffAdd,C:DiffChange,D:DiffDelete,
- *  T:DiffText,>:SignColumn,-:Conceal,
- *  B:SpellBad,P:SpellCap,R:SpellRare,
- *  L:SpellLocal,+:Pmenu,=:PmenuSel,
+ *  T:DiffText,E:DiffTextAdd,>:SignColumn,
+ *  -:Conceal,B:SpellBad,P:SpellCap,
+ *  R:SpellRare, L:SpellLocal,+:Pmenu,
+ *  =:PmenuSel, k:PmenuMatch,<:PmenuMatchSel,
  *  [:PmenuKind,]:PmenuKindSel,
  *  {:PmenuExtra,}:PmenuExtraSel,
  *  x:PmenuSbar,X:PmenuThumb,*:TabLine,
  *  #:TabLineSel,_:TabLineFill,!:CursorColumn,
  *  .:CursorLine,o:ColorColumn,q:QuickFixLine,
  *  z:StatusLineTerm,Z:StatusLineTermNC,
- *  g:MsgArea"`)
+ *  g:MsgArea,h:ComplMatchIns"`)
  */
 export const highlight: GlobalOption<string> = new StringOption("highlight");
 
@@ -801,6 +1111,27 @@ export const imactivatekey: GlobalOption<string> = new StringOption(
 );
 
 /**
+ * When set the Input Method is always on when starting to edit a command
+ * line, unless entering a search pattern (see 'imsearch' for that).
+ * Setting this option is useful when your input method allows entering
+ * English characters directly, e.g., when it's used to type accented
+ * characters with dead keys.
+ *
+ * (default off)
+ */
+export const imcmdline: GlobalOption<boolean> = new BooleanOption("imcmdline");
+
+/**
+ * When set the Input Method is never used.  This is useful to disable
+ * the IM when it doesn't work properly.
+ * Currently this option is on by default for SGI/IRIX machines.  This
+ * may change in later releases.
+ *
+ * (default off, on for some systems (SGI))
+ */
+export const imdisable: GlobalOption<boolean> = new BooleanOption("imdisable");
+
+/**
  * This option specifies a function that is called to obtain the status
  * of Input Method.  It must return a positive number when IME is active.
  * The value can be the name of a function, a `lambda` or a `Funcref`.
@@ -844,6 +1175,25 @@ export const imstatusfunc: GlobalOption<string> = new StringOption(
  * *only available when compiled with `+xim` and `+GUI_GTK`*
  */
 export const imstyle: GlobalOption<number> = new NumberOption("imstyle");
+
+/**
+ * Defines characters and patterns for completion in insert mode.  Used
+ * by the `complete_match()` function to determine the starting position
+ * for completion.  This is a comma-separated list of triggers.  Each
+ * trigger can be:
+ * - A single character like "." or "/"
+ * - A sequence of characters like "->", "/*", or "/**"
+ *
+ * Note: Use "\\," to add a literal comma as trigger character, see
+ * `option-backslash`.
+ *
+ * Examples:
+ *
+ *     set isexpand=.,->,/*,\\,
+ *
+ * (default: "")
+ */
+export const isexpand: BufferLocalOption<string> = new StringOption("isexpand");
 
 /**
  * Makes Vim work in a way that Insert mode is the default mode.  Useful
@@ -911,11 +1261,12 @@ export const key: BufferLocalOption<string> = new StringOption("key");
  * protocol name to be used.  To illustrate this, the default value would
  * be set with:
  *
- *     set keyprotocol=kitty:kitty,foot:kitty,wezterm:kitty,xterm:mok2
+ *     set keyprotocol=kitty:kitty,foot:kitty,ghostty:kitty,wezterm:kitty
+ *     set keyprotocol+=xterm:mok2
  *
- * This means that when 'term' contains "kitty, "foot" or "wezterm"
- * somewhere then the "kitty" protocol is used.  When 'term' contains
- * "xterm" somewhere, then the "mok2" protocol is used.
+ * This means that when 'term' contains "kitty, "foot", "ghostty" or
+ * "wezterm" somewhere, then the "kitty" protocol is used.  When 'term'
+ * contains "xterm" somewhere, then the "mok2" protocol is used.
  *
  * The first match is used, thus if you want to have "kitty" use the
  * kitty protocol, but "badkitty" not, then you should match "badkitty"
@@ -970,6 +1321,20 @@ export const langnoremap: GlobalOption<boolean> = new BooleanOption(
 );
 
 /**
+ * Like 'chistory', but for the location list stack associated with a
+ * window.  If the option is changed in either the location list window
+ * itself or the window that is associated with the location list stack,
+ * the new value will also be applied to the other one.  This means this
+ * value will always be the same for a given location list window and its
+ * corresponding window.  See `quickfix-stack` for additional info.
+ *
+ * (default: 10)
+ *
+ * *only available when compiled with the `+quickfix` feature*
+ */
+export const lhistory: WindowLocalOption<number> = new NumberOption("lhistory");
+
+/**
  * Specifies the name of the Lua shared library. The default is
  * DYNAMIC_LUA_DLL, which was specified at compile time.
  * Environment variables are expanded `:set_env`.
@@ -998,6 +1363,7 @@ export const macatsui: GlobalOption<boolean> = new BooleanOption("macatsui");
  * Maximum value is 6.
  * Even when this option is set to 2 you can still edit text with more
  * combining characters, you just can't see them.  Use `g8` or `ga`.
+ * When set to 0, you will not be able to see any combining characters.
  * See `mbyte-combining`.
  *
  * (default 2)
@@ -1036,6 +1402,106 @@ export const maxmem: GlobalOption<number> = new NumberOption("maxmem");
  *  available)
  */
 export const maxmemtot: GlobalOption<number> = new NumberOption("maxmemtot");
+
+/**
+ * Maximum number of matches shown for the search count status `shm-S`
+ * When the number of matches exceeds this value, Vim shows ">" instead
+ * of the exact count to keep searching fast.
+ * Note: larger values may impact performance.
+ * The value must be between 1 and 9999.
+ *
+ * (default 99)
+ */
+export const maxsearchcount: GlobalOption<number> = new NumberOption(
+  "maxsearchcount",
+);
+
+/**
+ * When on, mouse move events are delivered to the input queue and are
+ * available for mapping. The default, off, avoids the mouse movement
+ * overhead except when needed. See `gui-mouse-mapping`.
+ * Warning: Setting this option can make pending mappings to be aborted
+ * when the mouse is moved.
+ * Currently only works in the GUI, may be made to work in a terminal
+ * later.
+ *
+ * (default off)
+ *
+ * *only works in the GUI*
+ */
+export const mousemoveevent: GlobalOption<boolean> = new BooleanOption(
+  "mousemoveevent",
+);
+
+/**
+ * This option tells Vim what the mouse pointer should look like in
+ * different modes.  The option is a comma-separated list of parts, much
+ * like used for 'guicursor'.  Each part consists of a mode/location-list
+ * and an argument-list:
+ *         mode-list:shape,mode-list:shape,..
+ * The mode-list is a dash separated list of these modes/locations:
+ *                 In a normal window:
+ *         n       Normal mode
+ *         v       Visual mode
+ *         ve      Visual mode with 'selection' "exclusive" (same as 'v',
+ *                 if not specified)
+ *         o       Operator-pending mode
+ *         i       Insert mode
+ *         r       Replace mode
+ *
+ *                 Others:
+ *         c       appending to the command-line
+ *         ci      inserting in the command-line
+ *         cr      replacing in the command-line
+ *         m       at the 'Hit ENTER' or 'More' prompts
+ *         ml      idem, but cursor in the last line
+ *         e       any mode, pointer below last window
+ *         s       any mode, pointer on a status line
+ *         sd      any mode, while dragging a status line
+ *         vs      any mode, pointer on a vertical separator line
+ *         vd      any mode, while dragging a vertical separator line
+ *         a       everywhere
+ *
+ * The shape is one of the following:
+ * avail   name            looks like
+ * w x g   arrow           Normal mouse pointer
+ * w x     blank           no pointer at all (use with care!)
+ * w x g   beam            I-beam
+ * w x g   updown          up-down sizing arrows
+ * w x g   leftright       left-right sizing arrows
+ * w x g   busy            The system's usual busy pointer
+ * w x g   no              The system's usual 'no input' pointer
+ *   x g   udsizing        indicates up-down resizing
+ *   x g   lrsizing        indicates left-right resizing
+ *   x g   crosshair       like a big thin +
+ *   x g   hand1           black hand
+ *   x g   hand2           white hand
+ *   x     pencil          what you write with
+ *   x g   question        big ?
+ *   x     rightup-arrow   arrow pointing right-up
+ * w x     up-arrow        arrow pointing up
+ *   x     `<number>`        any X11 pointer number (see X11/cursorfont.h)
+ *
+ * The "avail" column contains a 'w' if the shape is available for Win32,
+ * x for X11 (including GTK+ 2), g for GTK+ 3.
+ * Any modes not specified or shapes not available use the normal mouse
+ * pointer.
+ *
+ * Example:
+ *
+ *     :set mouseshape=s:udsizing,m:no
+ *
+ * will make the mouse turn to a sizing arrow over the status lines and
+ * indicate no input when the hit-enter prompt is displayed (since
+ * clicking the mouse has no effect in this state.)
+ *
+ * (default "i-r:beam,s:updown,sd:udsizing,
+ *  vs:leftright,vd:lrsizing,m:no,
+ *  ml:up-arrow,v:rightup-arrow")
+ *
+ * *only available when compiled with the `+mouseshape` feature*
+ */
+export const mouseshape: GlobalOption<string> = new StringOption("mouseshape");
 
 /**
  * The number of milliseconds between polls for MzScheme threads.
@@ -1080,6 +1546,20 @@ export const mzschemedll: GlobalOption<string> = new StringOption(
  */
 export const mzschemegcdll: GlobalOption<string> = new StringOption(
   "mzschemegcdll",
+);
+
+/**
+ * *only for MS-Windows*
+ *         Enable reading and writing from devices.  This may get Vim stuck on a
+ *         device that can be opened but doesn't actually do the I/O.  Therefore
+ *         it is off by default.
+ *         Note that on MS-Windows editing "aux.h", "lpt1.txt" and the like also
+ *         result in editing a device.
+ *
+ * (default off)
+ */
+export const opendevice: GlobalOption<boolean> = new BooleanOption(
+  "opendevice",
 );
 
 /**
@@ -1299,6 +1779,21 @@ export const printoptions: GlobalOption<string> = new StringOption(
  * (default on)
  */
 export const prompt: GlobalOption<boolean> = new BooleanOption("prompt");
+
+/**
+ * Determines the maximum width to use for the popup menu for completion.
+ * When zero, there is no maximum width limit, otherwise the popup menu
+ * will never be wider than this value.  Truncated text will be indicated
+ * by "trunc" value of 'fillchars' option.
+ *
+ * This option takes precedence over 'pumwidth'.
+ * `ins-completion-menu`.
+ *
+ * (default 0)
+ */
+export const pummaxwidth: GlobalOption<number> = new NumberOption(
+  "pummaxwidth",
+);
 
 /**
  * Specifies the name of the Python 2.x shared library. The default is
@@ -1567,6 +2062,22 @@ export const shortname: BufferLocalOption<boolean> = new BooleanOption(
 );
 
 /**
+ * The value of this option specifies when the `tabpanel` with tab page
+ * labels will be displayed:
+ *         0: never
+ *         1: only if there are at least two tab pages
+ *         2: always
+ * See `tab-page` for more information about tab page labels.
+ *
+ * (default 0)
+ *
+ * *not available when compiled without the `+tabpanel` feature*
+ */
+export const showtabpanel: GlobalOption<number> = new NumberOption(
+  "showtabpanel",
+);
+
+/**
  * When this option is not empty a swap file is synced to disk after
  * writing to it.  This takes some time, especially on busy unix systems.
  * When this option is empty parts of the swap file may be in memory and
@@ -1581,6 +2092,74 @@ export const shortname: BufferLocalOption<boolean> = new BooleanOption(
  * (default "fsync")
  */
 export const swapsync: GlobalOption<string> = new StringOption("swapsync");
+
+/**
+ * When non-empty, this option determines the content of the `tabpanel`.
+ * The option consists of printf style '%' items interspersed with
+ * normal text, similar to the 'statusline' or 'tabline'.
+ *
+ * When changing something that is used in 'tabpanel' that does not
+ * trigger it to be updated, use `:redrawtabpanel`.
+ * This option cannot be set in a modeline when 'modelineexpr' is off.
+ *
+ * You can use `g:actual_curtabpage` within a function assigned to
+ * tabpanel. `g:actual_curtabpage` represents current tab's label number.
+ * The option value can contain line breaks:
+ *
+ *     set tabpanel=%!TabPanel()
+ *     function! TabPanel() abort
+ *       return printf("(%2d)\n  %%f", g:actual_curtabpage)
+ *     endfunction
+ *
+ * The result is:
+ *
+ *     +-----------+---------------------------------
+ *     |(1)        |
+ *     |  ~/aaa.txt|
+ *     |(2)        |
+ *     |  ~/.vimrc |
+ *     |           |
+ *     |           |
+ *     |           |
+ *
+ * (default empty)
+ */
+export const tabpanel: GlobalOption<string> = new StringOption("tabpanel");
+
+/**
+ * Optional settings for the `tabpanel`,  It can consist of the following
+ * items.  Items must be separated by a comma.
+ *
+ *         align:**{text}**    Specifies the position of the tabpanel.
+ *                         Currently supported positions are:
+ *
+ *                         left    left-side
+ *                         right   right-side
+ *
+ *                         (default "left")
+ *
+ *         columns:**{n}**     Number of columns of the tabpanel.
+ *                         If this value is 0 or less than 'columns', the
+ *                         tab panel will not be displayed.
+ *                         (default 20)
+ *
+ *         vert            Use a vertical separator for tabpanel.
+ *                         The vertical separator character is taken from
+ *                         "tpl_vert" in 'fillchars'.
+ *                         (default off)
+ *
+ * Examples:
+ *
+ *     :set tabpanelopt=columns:16,align:right
+ *     :set tabpanelopt=
+ *     :set tabpanelopt=vert,align:right
+ *     :set tabpanelopt=columns:16
+ *
+ * (default "")
+ */
+export const tabpanelopt: GlobalOption<string> = new StringOption(
+  "tabpanelopt",
+);
 
 /**
  * Specifies the name of the Tcl shared library. The default is
@@ -1651,9 +2230,12 @@ export const termencoding: GlobalOption<string> = new StringOption(
 /**
  * The key that starts a CTRL-W command in a terminal window.  Other keys
  * are sent to the job running in the window.
- * The `<>` notation can be used, e.g.:
+ * The key can be specified as a single character, a `key-notation` (e.g.
+ * `<Up>`, `<C-F>`) or a letter preceded with a caret (e.g. `^F` is CTRL-F):
  *
- *     :set termwinkey=<C-L>
+ *     :set twk=X
+ *     :set twk=^I
+ *     :set twk=<C-L>
  *
  * The string must be one key stroke but can be multiple bytes.
  * When not set CTRL-W is used, so that CTRL-W : gets you to the command
@@ -2132,6 +2714,50 @@ export const wincolor: WindowLocalOption<string> = new StringOption("wincolor");
  * *only available when compiled with the `terminal` feature on MS-Windows*
  */
 export const winptydll: GlobalOption<string> = new StringOption("winptydll");
+
+/**
+ * Specifies the Wayland seat to use for Wayland functionality,
+ * specifically the clipboard.  If the seat does not exist, then the
+ * option will still be set to the new value, with the Wayland clipboard
+ * being unavailable as a result.  If an empty value is passed then Vim
+ * will attempt to use the first seat found available.  Updating this
+ * option will also update `v:clipmethod`.
+ *
+ * (default "")
+ *
+ * *only when the `+wayland` feature is included*
+ */
+export const wlseat: GlobalOption<string> = new StringOption("wlseat");
+
+/**
+ * When enabled, then allow Vim to steal focus by creating a temporary
+ * surface, in order to access the clipboard.  For more information see
+ * `wayland-focus-steal`.
+ *
+ * (default off)
+ *
+ * *only when the `+wayland_clipboard` feature is included*
+ */
+export const wlsteal: GlobalOption<boolean> = new BooleanOption("wlsteal");
+
+/**
+ * The timeout in milliseconds before Vim gives up on waiting for the
+ * Wayland compositor.  While Vim waits on the compositor, it is
+ * unresponsive to input and does not update the screen.  Therefore
+ * setting this to a lower value may make Vim feel more responsive in
+ * some cases.  On the other hand, it may also mean you receive errors
+ * when the compositor takes more time to respond than usual.
+ *
+ * Additionally, this option is also used as the maximum timeout when
+ * waiting for a surface to gain focus, see `wayland-focus-steal`.
+ *
+ * (default 500)
+ *
+ * *only when the `+wayland` feature is included*
+ */
+export const wltimeoutlen: GlobalOption<number> = new NumberOption(
+  "wltimeoutlen",
+);
 
 /**
  * When detecting xterm patchlevel 141 or higher with the termresponse


### PR DESCRIPTION
## Summary
- Update supported Deno version from 1.x to 2.x in CI configuration
- Update supported versions to Vim 9.1.1646 and Neovim 0.11.3  
- Fix code generation for Neovim 0.11+ documentation changes
- Regenerate function definitions with updated type information

## Test plan
- [x] CI tests pass with new supported versions
- [x] Code generation works with Neovim 0.11+
- [x] Function definitions are properly regenerated

🤖 Generated with [Claude Code](https://claude.ai/code)