### PR TITLE
:memo: Synchronize comments with implementation

### DIFF
--- a/buffer/decoration.ts
+++ b/buffer/decoration.ts
@@ -64,7 +64,7 @@ export interface Decoration {
  * }
  * ```
  *
- * It uses `prop_add_list` in Vim and `nvim_buf_add_highlight` in Neovim to
+ * It uses `prop_add_list` in Vim and `nvim_buf_set_extmark` in Neovim to
  * decorate the buffer.
  */
 export function decorate(
@@ -122,7 +122,7 @@ export function decorate(
  * }
  * ```
  *
- * It uses `prop_add` in Vim and `nvim_buf_add_highlight` in Neovim to decorate the
+ * It uses `prop_remove` in Vim and `nvim_buf_clear_namespace` in Neovim to decorate the
  * buffer.
  */
 export function undecorate(


### PR DESCRIPTION
After commit 504bc8e, `nvim_buf_set_extmark` has been used for decoration as the successor to `nvim_buf_add_highlight`, but some comments were not updated accordingly.

This Pull Request synchronizes the comments with the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated inline docs to align with the current Neovim buffer decoration API, clarifying how decorations are applied and removed.
  * Improves accuracy and reduces confusion when reading editor-related documentation.
  * No functional changes; existing behavior and workflows remain the same.
  * No action required from users; this is a documentation-only refresh for clarity and future maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->